### PR TITLE
chore: Modify AI translations

### DIFF
--- a/deepin-devicemanager/translations/deepin-devicemanager.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager.ts
@@ -4,26 +4,41 @@
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>More</translation>
     </message>
@@ -49,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>More</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Collapse</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>More</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Collapse</translation>
     </message>
@@ -92,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Device Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation type="unfinished">Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Memory Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
@@ -190,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -208,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Driver Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logical Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
@@ -296,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
@@ -364,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -372,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Core ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Core(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualization</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Flags</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensions</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation type="unfinished">L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Max Speed</translation>
     </message>
@@ -490,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Graphics Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Memory Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maximum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Minimum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Current Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Display Output</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
@@ -618,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
@@ -691,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Maximum Current</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
@@ -764,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>CPU quantity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Motherboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Sound Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Storage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Other PCI Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Keyboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Printer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Other Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Device</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -905,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Total Width</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Configured Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Maximum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Minimum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Configured Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Data Width</translation>
     </message>
@@ -979,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Display Input</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Interface Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Support Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Current Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Display Ratio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Primary Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
@@ -1430,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Media Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation type="unfinished">Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation type="unfinished">Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmware Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Rotation Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
@@ -1512,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Select a driver for update</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>No drivers found in this folder</translation>
     </message>
@@ -1526,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Loading Audio Device Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Loading BIOS Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Loading CD-ROM Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Loading Operating System Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Loading CPU Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Loading Other Devices Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Loading Power Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Loading Printer Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Loading Mouse Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Loading Network Adapter Info...</translation>
     </message>
@@ -1579,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
@@ -1594,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
@@ -1607,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file&apos;s name</comment>
         <translation>Device Info</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Device Manager</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
@@ -1696,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>More</translation>
     </message>
@@ -1704,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation type="unfinished">Current Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation type="unfinished">Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation type="unfinished">Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1745,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Updating</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Warning</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>The device will be unavailable after the driver uninstallation</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Uninstall</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Uninstalling</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Update successful</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Uninstallation successful</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Update failed</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Uninstallation failed</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>The selected folder does not exist, please select again</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Broken package</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Unmatched package architecture</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>The selected file does not exist, please select again</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>It is not a driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Unable to install - no digital signature</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Unknown error</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>The driver module was not found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Invalid module format</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>The driver module has dependencies</translation>
     </message>
@@ -1883,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation type="unfinished">Device Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation type="unfinished">Version Available</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation type="unfinished">Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation type="unfinished">Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation type="unfinished">New Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation type="unfinished">Current Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation type="unfinished">Missing drivers (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation type="unfinished">Outdated drivers (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation type="unfinished">Up-to-date drivers (%1)</translation>
     </message>
@@ -1941,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1975,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation type="unfinished">Current Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation type="unfinished">Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2013,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2046,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Failed to enable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Failed to disable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Failed to disable it: unable to get the device SN</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Update Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Uninstall Drivers</translation>
     </message>
@@ -2074,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
@@ -2113,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Enable</translation>
     </message>
@@ -2133,33 +2133,33 @@
         <translation>Allow it to wake the computer</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Failed to disable it: unable to get the device SN</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Failed to disable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Failed to enable the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Update Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Uninstall Drivers</translation>
     </message>
@@ -2167,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>SubVendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>SubDevice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Driver Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Driver Activation Cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Config Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>latency</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Handlers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>BIOS Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Base Board Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>System Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Chassis Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Physical Memory Array</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Release Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Runtime Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Characteristics</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Product Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Asset Tag</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Features</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Location In Chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Chassis Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Contained Object Handles</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Wake-up Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>SKU Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Lock</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Boot-up State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Power Supply State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Thermal State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Security Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Height</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Number Of Power Cords</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Contained Elements</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Location</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Error Correction Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maximum Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Error Information Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Number Of Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Release date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Board name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Language Description Format</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Installable Languages</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Currently Installed Language</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Packet type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Link policy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Link mode</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Service Classes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Device Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Device</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Serial ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>product</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Powered</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Discoverable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Pairable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Discovering</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Driver Modules</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Device File</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Device Files</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Device Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Application</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>logical name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU implementer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU variant</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU part</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>One</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Ten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Twelve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Fourteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Sixteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Eighteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Twenty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Twenty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Twenty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Twenty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Twenty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Thirty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Thirty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Thirty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Thirty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Thirty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Forty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Forty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Forty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Forty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Forty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Fifty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Fifty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Fifty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Fifty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Fifty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sixty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sixty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sixty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sixty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sixty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Seventy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Seventy-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Seventy-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Seventy-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Seventy-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Eighty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Eighty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Eighty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Eighty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Eighty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Ninety</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Ninety-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Ninety-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Ninety-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Ninety-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>One hundred</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>One hundred and Two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>One hundred and four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>One hundred and Six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>One hundred and Eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>One hundred and Ten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>One hundred and Twelve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>One hundred and Fourteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>One hundred and Sixteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>One hundred and Eighteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>One hundred and Twenty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>One hundred and Twenty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>One hundred and Twenty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>One hundred and Twenty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>One hundred and Twenty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>One hundred and Ninety-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Two hundred and fifty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL client APIs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL version</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Unknown</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Hardware Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>No CPU found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Motherboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>No motherboard found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>No memory found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Storage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>No disk found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>No GPU found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>No monitor found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>No network adapter found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Sound Adapter</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>No audio device found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>No Bluetooth device found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Other PCI Devices</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>No other PCI devices found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Power</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>No battery found</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Sound Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>No audio device found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>No Bluetooth device found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Other PCI Devices</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>No other PCI devices found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Power</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>No battery found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Keyboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>No keyboard found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Mouse</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>No mouse found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Printer</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>No printer found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Camera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>No camera found</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>No CD-ROM found</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>No mouse found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>No printer found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>No camera found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>No CD-ROM found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Other Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>No other devices found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Array Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Form Factor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Set</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Bank Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Type Detail</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Part Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rank</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Memory Technology</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Memory Operating Mode Capability</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmware Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Module Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Module Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Memory Subsystem Controller Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Memory Subsystem Controller Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Non-Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Cache Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logical Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
@@ -3694,313 +3694,313 @@
         <translation>sides</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>bus info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>logicalsectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometry (Logical)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Device Manager</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Device Manager is a handy tool for viewing hardware information and managing the devices.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>New drivers available! Install or update them now.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Include subfolders</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Search for drivers in this path</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 driver updates available</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Time checked: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Downloading drivers for %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Download speed: %1 Downloaded %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Installing drivers for %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 drivers installed, %2 drivers failed</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 drivers installed</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Failed to install drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Network error. Reconnecting...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Download speed: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Your drivers are up to date</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>reboot</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Please %1 for the installed drivers to take effect</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>submit feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Please try again or %1 to us</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Install All</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Scan Again</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Scanning hardware device drivers, please wait...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Scanning %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Scan failed</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Network unavailable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Please check your network connection</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Please scan again or %1 to us</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>You are installing a driver, which will be interrupted if you exit.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Are you sure you want to exit?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Exit</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4116,22 +4116,22 @@
         <translation>Failed to get driver files</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Install</translation>
     </message>
@@ -4144,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Update drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Uninstall drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Allow it to wake the computer</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Enable</translation>
     </message>
@@ -4184,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
@@ -4212,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Select a local folder please</translation>
     </message>
@@ -4220,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Loading...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ady.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ady.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ady">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Пірат</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Хәят</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Больше</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Сигналлаштыру</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Қайта инсталляция</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Больше</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Сәйкес</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Қысқарту</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Қолданылмайтын</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Құрылым аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Тараз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Чип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Мүмкіндіктер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Путь</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Ревизия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Ядро режимы драйверы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Мемория адресі</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Қолданылмайтын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Қысқарту</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Тараз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Тараз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Чипсет</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Алиас</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>تәкъдимчی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Скорость</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Максималь Қუьر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Драйвер Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Мөмкүнлік</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Бус Инфо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Логик Нәмә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC Адрэс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Мәғәнәсіз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Ия</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Нәмә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Тәкъдимчی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Бус Инфо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Мөмкүнлік</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Максималь Қუьр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Скорость</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Мәғәнәсіз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Ия</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Нәмә</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Нәмә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Тәкъдимчی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Ядро ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Тред</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجوميپس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>آرکیتектورа</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Сіمه CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Процессор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Ядро(а)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Віртуалізація</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Флаги</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>Кеш L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>Кеш L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>Кеш L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>Кеш L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Шаг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Скорость</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Максимальная скорость</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Адә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Инженер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>График әмәләт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Физик ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Әмәләт адресы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO порт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Бус информациясы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Максимальная разрешенность</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Минимальная разрешенность</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Текущая разрешенность</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Тасвир</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>الإخراج الرقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>إخراج الشاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>التيار القصير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>خاققى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>نەشىرلىك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>كىيىن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>قىلما</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>كۆرۈنүш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>CPU сانы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Атасى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>ئادەم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>ئېكراん چېكىرۈچىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>سۆن چېكىرۈچىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Сاқلاش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Башقا PCI چېكىرۈچىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Батарея</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>تېكىنىكى چېكىرۈچىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>مۇس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>كىرەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>مۇنىتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>پىرنتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>كەمەرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Башقا چېكىرۈچىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>چېكىرۈچى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ОС</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ئىسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>سەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>كۆرۈнүش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>نەچىن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>تېزلىك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ئەڭ ھەر چەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ئەڭ ھەر چەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>سېرىال نومىرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>تەڭلىشىملىق ۋولتاچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>ئەڭ ھەر چەن ۋولتاچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>ئەڭ كىچىك ۋولتاچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>تەڭلىشىملىق سۈرەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>مەلۇمات ھەر چەن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ئادەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>سەرھەتچى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>نەچىنىكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>كۆرسىتىش كىرۇشى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ئىنتېرفېس نەچىنىكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>كۆرسىتىش چەنلىكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>ھازىر چەنلىكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>كۆرسىتىش نىسپەتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>'ئەڭ ھەر چەن' كۆرسىتىش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ھەجىم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>سېرىال نومىرا</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ئادەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>سەرھەتچى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>نەچىنىكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>نەشىر ھەجىمى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>بۇس مەلۇماتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>ھەقىقىيلىق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>درايۋېر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>درايۋېر نەشىر ھەجىمى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>ئەڭ ھەر چەن ھەزىمەتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>تەكلىف ھەزىمەتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>پورت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>مультيكست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>لينك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>لايتنس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>إن إي بي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>فويرموير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>دوبلكس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>برودكاست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>أوتونوميسيون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>آدرس memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>آي آر كيو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>آدرس mac</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>نام لوجيکال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>مصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>معلومات بوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>نسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>إدخال/إخراج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>ذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>آي آر كيو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>لايتنس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>مُبرمج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>مصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>نسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>معلومات بوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>خواص</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>مُسَطِّر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>القدرة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>السعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>المقعد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>السعة المُصمَّمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>الجهد المُصمَّد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>نسخة SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>رقم تسلسل SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاريخ تصنيع SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>كيمياء SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>درجة الحرارة</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>مُشارَك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>نوع واجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Изял</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Изготовитель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Тип носителя</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Размер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Возможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Версия прошивки</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Скорость</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Номер серийный</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Версия интерфейса</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Скорость вращения</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Недоступно</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Выберите драйвер для обновления</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>В этом каталоге не найдены драйверы</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Загрузка информации об аудиоустройстве...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Загрузка информации о BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Загрузка информации о CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Загрузка информации об операционной системе...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Загрузка информации о процессоре...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Загрузка информации о других устройствах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Загрузка информации о питании...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Загрузка информации о принтере...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Загрузка информации о мыши...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Загрузка информации о сетевом адаптере...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Изял</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Недоступно</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Изял</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Недоступно</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>مәғлүмәт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Кыскалаштырулар</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Ябы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Ярдәм</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Күчерергә</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Экспорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Яңылау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Аппаратура менеджеры</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Аппарат</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Драйверлар</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Күренеш</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Экран үзгәреүче</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>Процессор</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Теләтә үзгәреүче</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Аккумулятор</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Яхшырак</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Драйвер платформа версиясы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Сақланырга мөмкин булган драйверлар</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Сақланган драйверлар</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Төҙәү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Бергә</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Күчерергә</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Уйлап чыгыш</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Драйверны алып ташлап ҡалғаннан һуң ҡәтғи ҡына ҡулланылмаҫҡа ҡуйыла</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Алып ташлау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Алып ташлау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Төҙәү уңында</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Алып ташлау уңында</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>به‌تاрак چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Next</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Update</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Previous</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Driver Install</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Driver Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Driver Restore</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>چاپ چاک چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>چاپ چاک چاپ چاک چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Backup Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Restorable Drivers</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Overview</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Driver Install</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Driver Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Driver Restore</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>تәкъдим ҡәтғи итеп булмады</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>тәкъдим ҡәтғи итеп булмады</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>тәкъдим ҡәтғи итеп булмады: тәкъдим SN-ы алыу мөмкинлексез</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Драйверҙарҙы тапшырыу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Драйверҙарҙы алып ташлау</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Таҡырып</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Импортлау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Күчереу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Күренеш</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Таҡырып</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Импортлау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Күчереу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Ҡәтғи итеу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Драйверҙарҙы тапшырыу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Драйверҙарҙы алып ташлау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Компьютерҙы ҡылыуға рәсмән ҡылыу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Ҡәтғи итеу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>тәкъдим ҡәтғи итеп булмады: тәкъдим SN-ы алыу мөмкинлексез</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>тәкъдим ҡәтғи итеп булмады</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>тәкъдим ҡәтғи итеп булмады</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Драйверҙарҙы тапшырыу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Драйверҙарҙы алып ташлау</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Алтын ҡына</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Алтын ҡына</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Драйвер һәмәғәт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Драйвер ҡәтғи итеү командалары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Конфигурация һәмәғәт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>Кеше</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Физика</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Бус</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Информация BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Информация о базовой плате</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Информация о системе</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Информация о корпусе</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Физический массив памяти</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Дата выпуска</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Адрес</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Размер во время выполнения</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Размер ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Характеристики</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Редакция BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Редакция программного обеспечения</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Название продукта</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Номер серийный</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Метка активов</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Функции</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Расположение в корпусе</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Ручка корпуса</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Содержащие объекты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Тип пробуждения</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Номер SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>خانә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Тығыу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Башланғыч һәм ҡынау үзәге</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Энергия ҡуя торған үзәк</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Температур үзәге</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Хәтерләү һәм һыҙыҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ОЕМ мәғлүмәте</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Баҫым</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Энергия ҡуя торған ышаҡтар саны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Яһаған элементтар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Яҡын урын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Хата төҙәтеү төрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Максимал ҡабатлау</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Хата мәғлүмәте үзәге</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Урындағы ҡәтәгәт саны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Берәү һаны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Плата исеме</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS версияһы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Тел һәм таснифлау форматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Ҡуя торған телдар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Хәҙерге ҡуя торған тел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD адресы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Пакет төрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Сығыш ҡағиҙәһе</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Сығыш ҡынауы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Клас</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Хәрәкәт ҡынауы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>کлас چیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>версия HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>версия LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>زیر ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>چیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>product</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>توضيحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>بەکارهێنی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>توانای چەک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>توانای جوڵە کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>چەک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>ماودىلەر چەک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>فایل چیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>فایلەتە چیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>نومرە چیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>کاروان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ستاتوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>نومرە لۆژیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>چاکی کۆمپیوټەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>کۆمپیوټەر چەک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>کۆمپیوټەر واریان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>کۆمپیوټەر بەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>کۆمپیوټەر رەویسیۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>یەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>شەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Сәв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Дәв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Десят</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Двенадцат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Четырнадцат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Шестнадцат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Восемнадцат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Двадцат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Двадцать двой</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Двадцать четвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Двадцать шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Двадцать восем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Тридцат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Тридцать двой</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Тридцать четвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Тридцать шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Тридцать восем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Сорок</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Сорок двой</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Сорок четвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Сорок шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Сорок восем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Пятьдесят</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Пятьдесят двой</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Пятьдесят четвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Пятьдесят шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Пятьдесят восем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Шестьдесят</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Шестьдесят двой</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Шестьдесят четвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ئەتىيىتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ئەتىيىتى چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>ئەتىيىتى ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>ئەتىيىتى ھەن چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>ئەتىيىتى ھەن چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>ئەتىيىتى ھەن چۆت چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>ئەتىيىتى ھەن چۆت ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ئەتىيىتى چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ئەتىيىتى چۆت چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ئەتىيىتى چۆت ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ئەتىيىتى چۆت ھەن چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ئەتىيىتى چۆت ھەن چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>ئەتىيىتى چۆت ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>ئەتىيىتى چۆت ھەن چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>ئەتىيىتى چۆت ھەن چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>ئەتىيىتى چۆت ھەن چۆت چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>ئەتىيىتى چۆت ھەن چۆت ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>بىر ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>بىر ھەن ۋە چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>بىر ھەن ۋە چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>بىر ھەن ۋە چۆت چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>بىر ھەن ۋە چۆت ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چۆت چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چۆت ھەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چۆت چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چۆت چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>بىر ھەن ۋە چۆت ھەن چۆت چۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>ئەرە بىر ھەندىزى ۋە ھەندىزى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>ئەرە بىر ھەندىزى ۋە ھەندىزى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>ئەرە بىر ھەندىزى ۋە ھەندىزى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>ئەرە بىر ھەندىزى ۋە ھەندىزى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR ئەھۋالى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU ئىشلەتكۈچىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU نەچە ئەھۋالى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL نەچە ئەھۋالى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL ئىشلەتكۈچى API</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL نەچە ئەھۋالى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL نەچە ئەھۋالى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>نىقىشلىمىغان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>ئەھۋاللىق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ھەرىكەتلىك ھەندىزى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU يوق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>مۇتېربوарدى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>مۇتېربواردى يوق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>ئىنىمىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>ئىنىمىسى يوق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>سەتىر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>سەتىر يوق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ئىشلەتىشچى ھەققىدە ئەھۋالنى باقىرىشنى باقىرمايدى!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>كۆرۈپ چېكىنىڭنى ھەققىدە ھەققىدە ئەھۋالنى باقىرمايدى</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ئىشلەتىشچى ھەققىدە ئەھۋالنى باقىرمايدى!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>كۆرۈش ھەققىدە ئەھۋاللىق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU يوق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>مۇنىتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>مۇنىتور يوق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Adapter گەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Adapter گەن بارلا یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Adapter һыҙыҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Аудио ҡураулы барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Bluetooth ҡураулы барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Башҡа PCI ҡураулылары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Башҡа PCI ҡураулылары барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Электричество</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Батарея барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Ҡлавиатура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Ҡлавиатура барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Мыш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Мыш барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Печать</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Печать барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Камера барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Башҡа ҡураулылар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Башҡа ҡураулылар барла یوҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Массив ҡулланыуы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Формат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Төп</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Банк ҡуйыуы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Төр үҙәнәре</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Хәтәр һаны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Ранк</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Эмал һыҙыҡы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>تəyinат әйләнә һыҙыҡ үзгәреше үзәге</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Фирмваре версиясе</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Модуль өйләнгәнче ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Модуль продукт ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Тəyinат әйләнә һыҙыҡ контроллер өйләнгәнче ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Тəyinат әйләнә һыҙыҡ контроллер продукт ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Яңылыҡсы булмаған үлкән</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Яңылыҡсы үлкән</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Кэш үлкән</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Логик үлкән</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>инч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Тәртип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>рәйеслек</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>аккумулятор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>төп-путь</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>энергия ҡуылышы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>төҙәтеү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>тәртипкә үткән</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>статистика бар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ҡайта ҡынау</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>һалыҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>һыҙыҡ һалыҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>энергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>энергия-пуст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>энергия-толкын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>энергия-толкын өзәге</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>энергия-таскын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>вольт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>процент</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تەکنولوجيا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>иконка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>онлаين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>батареядә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ҡапаҡ ҡырылған</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ҡапаҡ ҡырылған</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>күпчелек әмәл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>нөсәт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>жоба ҡырылған</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>жоба ҡырылған</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>жоба һыйҙыҡлығы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>маркәр үҙгәреш вакыты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>саны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ориентация</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>төҫтән үткәрелгән</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer is accepting jobs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer is shared</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer is temporary</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer make and model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>printer state change time</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>printer state reasons</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>printer type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer uri supported</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>төбәктәре</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logicalsectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>هوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>هندسة (منطقية)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير الأجهزة هو أداة مفيدة لعرض معلومات الأجهزة وإدارتها.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>تم إصدار مسارات جديدة! قم بتثبيتها أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>شامل المجلدات الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ابحث عن مسارات الأجهزة في هذا المسار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 تحديثات مسارات الأجهزة متاحة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'وقت التحقق: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل مسارات الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تثبيت مسارات الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'تم تثبيت %1 مسارات أجهزة، %2 مسارات أجهزة فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'تم تثبيت %1 مسارات أجهزة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تثبيت مسارات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعة التنزيل: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>مسارات الأجهزة لديك محدثة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع مسارات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>إجمالي %1 مسارات أجهزة، منها %2 تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 مسارات أجهزة يمكن نسخها، يُنصح بالقيام بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 مسارات أجهزة يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ مسار الجهاز %1، إجمالي %2 مسارات أجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'نسخ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'تم نسخ %1 مسارات أجهزة، %2 مسارات أجهزة فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ مسارات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'تم نسخ %1 مسارات أجهزة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 مسارات أجهزة يمكن استعادةها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار مسار جهاز للاستعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver is restoring...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Restoring: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>reboot</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Please %1 for the installed drivers to take effect</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>View backup path</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Backup All</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>submit feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Please try again or %1 to us</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Install All</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Scan Again</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Scanning hardware device drivers, please wait...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Scanning %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Scan failed</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Network unavailable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Please check your network connection</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Please scan again or %1 to us</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>You are installing a driver, which will be interrupted if you exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Are you sure you want to exit?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Exit</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>You are backing up drivers, which will be interrupted if you exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>You are restoring drivers, which will be interrupted if you exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Imaging device</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Display adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Sound card</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Wireless network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Installation successful</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>تәкъдим өстән үтмәгән</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Яүнәләү</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Тәкъдим өстән үтәү</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Тәкъдим өстән үтмәгән</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Яңыланмавы</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Мәгънә</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Сақлау үстән үтмәгән</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Сақлау үстән үтәү</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Сақлау үстән үтмәгән</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Сақлау үстән үткән</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Тышлану</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Мәғлүм булмавы һәт</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Теләвәз һәт</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Бәрән</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Драйвер файлларын алу үстән үтмәгән</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Яңылау</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Сақлау</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Тышлану</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Тәкъдим өстән үтәү</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Иярәт</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Яңылау</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Экспорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Драйверларын яңылау</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Драйверларын укыту</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Компьютерны үзенән үткәрә</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Иярәт</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Яңылау</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Экспорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Күчерә</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Иярәт</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>نәмән</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Пәйдаланыларын үзгәртә ҡуйып ҡалырға</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Яуап бирә...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_af.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_af.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="af">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Meer</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>EC_NOTIFY_NETWORK</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>EC_REINSTALL</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Meer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Vouier</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaar</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Apparaatnaam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Fabrikant</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Funksies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Geheugenadres</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Fabrikant</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Fabrikant</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Vervaardiger</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maksimum Druk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Stuurprogrammeer Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Stuurprogrammeer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Funksies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Bus Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logiese Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Vervaardiger</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Bus Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Funksies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Stuurprogrammeer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maksimum Druk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Vervaardiger</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Kern ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Threads</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arkitektuur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>CPU Familie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Processor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Kern(e)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualisering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Vlagte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Uitbreidings</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Stap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Spoed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Max Spoed</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Grafiese Geheug</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Fisiese ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Geheugadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Bus Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maksimum Resolusie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minimum Resolusie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Huidige Resolusie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Stuurprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Beskrywing</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Digitale Uitgang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Skermuitgang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Funksies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Bus Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maksimum Krag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Stuurprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Funksies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interfacing</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Bus Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maksimum Stroom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Stuurprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Vaardighede</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Onvoldoende</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Oorsig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Aantal CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Moederbord</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Gedrag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Skermadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Luidsadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Opslag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Ander PCI-ontwerpe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Netwerkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Muis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Toetsbord</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Ander toestelle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Toestel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Totale breedte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Opsporing</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Gestelde spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Maksimum spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Minimum spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Gestelde spoed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Data-breedte</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Soort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Beeldinvoer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Interfacetyg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Ondersteunde resolusie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Huidige resolusie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Beeldverhouding</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Primêre monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Soort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Bus-inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Moontlikhede</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Stuurprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Stuurprogram-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Maksimum tempo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Onderhandelde tempo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Poort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Skak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latensie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Outoegesprek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Gedragingsadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC-adres</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logiese Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Vennoot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Bus-informasie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>In/Out</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Gedraging</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latensie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Stuurprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Funksies</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Vennoot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Bus-informasie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Moeglikhede</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Stuurprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maksimumkrag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Onvrywillig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Staand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kapasiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Slot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Ontwerp Kapasiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Ontwerp Spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS Vervaardigingsdatum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS Chemie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Temperatuur</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Verkoper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Gedeel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Staand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Interfacetypering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Vervaardiger</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Media-typering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Funksies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Stelselprogrammeversie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Beskrywing</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Interfac</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Rotasiekoers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Kies ’n stuurder vir ’n update</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Geen stuurders gevind in hierdie folder</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Laden van Audio Apparaat Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Laden van BIOS Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Laden van CD-ROM Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Laden van Bedryfsstelsel Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Laden van CPU Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Laden van Ander Apparaat Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Laden van Druk Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Laden van Drukker Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Laden van Muis Inligting...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Laden van Netwerkadapter Inligting...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaarheid</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Toestel Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Toon snelkoppings</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Sluit</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Hulp</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Sisteem</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Druk af</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Vernieu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Toestelbeheer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hardeware</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Stuurprogramme</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Oversigt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Skermadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Netwerkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Batterie</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Meer</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Stuurplatform-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Kopiesbare Stuurprogramme</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Gekopiesde Stuurprogramme</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Bevorder</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Kanselleer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Volgende</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Waarskuwing</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Die toestel sal onvoldoende beskikbaar wees na die oninstalleer van die stuurprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Deinstalleer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Deinstalleer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Besoek suksesvol</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Deinstalleer suksesvol</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Akselering het misluk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Deinstallasie het misluk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Volgende</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Die gekose folder bestaan nie, kies asseblief weer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Akselering</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Vorige</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Beskadigde pakket</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Onverenigbare pakket-arkitektuur</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Die gekose lêer bestaan nie, kies asseblief weer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Dit is nie 'n stuurprogramma'</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Nie in staat om te installeer - geen digitale handtekening</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Onbekende fout</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Die stuurprogrammamodule is nie gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Ongeldige moduleformaat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Die stuurprogrammamodule het afhanklikhede</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Stuurprogramma installeer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Stuurprogramma backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Stuurprogramma herstel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Binnekom</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Jy het geen stuurprogrammas om te herstel, backup asseblief eers</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Ga na Backup Stuurprogramma</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Backup-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Herstelbare stuurprogrammas</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Vernieu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Druk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Oorsig</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Stuurprogramma installeer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Stuurprogramma backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Stuurprogramma herstel</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Apparaat kan nie geaktiveer word nie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Apparaat kan nie deaktiveer word nie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Apparaat kan nie deaktiveer word nie: moeilik om die apparaat SN te kry</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Werkerswerk versien</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Deinstalleer Werkerswerk</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Vernieu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Druk af</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Oorsig</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Vernieu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Druk af</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Aktiveer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Werkerswerk versien</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Deinstalleer Werkerswerk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Stel dit toe om die rekenaar te wakker maak</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Apparaat kan nie deaktiveer word nie: moeilik om die apparaat SN te kry</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Apparaat kan nie deaktiveer word nie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Apparaat kan nie geaktiveer word nie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Werkerswerk versien</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Deinstalleer Werkerswerk</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>SubVendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>SubDevice</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Werkerswerk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Werkerswerk Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Werkerswerk Aktivasiesteg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Konfigurasie Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Phys</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>BIOS Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Basisbord Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Sistem Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Chassis Inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fisiese Geheuearray</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Vrygemaak Datum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Addres</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Aktiewe Grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM Grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Kenmerke</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>BIOS Revisie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Stelselprogramma Revisie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Produk Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Seriële Nommer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Aktief Tag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Eigenskappe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Ligging In Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Chassis Hand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Bevattende Objekthandles</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Wake-up Tipe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU Nommer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Gesin</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Sper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Stoottoestand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Draadstoestand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Termiese Toestand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Veiligheidsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM-informasie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Hoogte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Aantal Draad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Bevatte Elemente</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Lokasie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Foutkorreksie-tyd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maksimum Kapasiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Foutinformatie Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Aantal Apparate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMGROOTTE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Vrygestelde Datum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Plaatnaam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Taalbeskrywing Formaat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Installeerbare Tale</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Huidigely Installeerde Taal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Pakkettype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Skakelpolitiek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Skakelmode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Dienstklasse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Toestelklas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subversie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Toestel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Seriële ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produkt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>beskrywing</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Aangedryf</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Ontdekbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Paarbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Ontdekking</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Stuurprogrammodules</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Toestelbestand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Toestelbestand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Toestelnommer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Toepassing</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logiese naam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU-implementer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU-arkitektuur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU-variant</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU-deel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU-revisie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Een</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Ag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Neg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Tien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Twelve</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Veertien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Sestien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Negentien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Twintig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Twintig twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Twintig vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Twintig ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Twintig ag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Dertig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Dertig twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Dertig vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Dertig ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Dertig ag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Veertig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Veertig twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Veertig vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Veertig vyf</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Veertig ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Veertig ag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Vyftig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Vyftig twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Vyftig vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Vyftig ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Vyftig ag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Sestig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Sestig-vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Sesendrie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Sesendag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Seweënd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Seweënd twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Seweënd vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Seweënd ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Seweënd agt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Aksend</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Aksend twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Aksend vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Aksend ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Aksend agt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Nogend</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Nogend twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Nogend vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Nogend ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Nogend agt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Een honderd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Een honderd en Twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Een honderd en Vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Een honderd en Ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Een honderd en Acht</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Een honderd en Tien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Een honderd en Twaalf</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Een honderd en Veertien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Een honderd en Zestien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Een honderd en Achttien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Een honderd en Twintig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Een honderd en Twintig twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Een honderd en Twintig vier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Een honderd en twintig-six</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Een honderd en twintig-acht</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Een honderd en negentig-twee</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Twee honderd en vijftig-six</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR kapasiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU versierder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU tipe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL kliënt APIs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Onbekend</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Hardewareklas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Geen CPU gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Moederbord</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Geen moederbord gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Gedheugen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Geen gedheugen gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Opslag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Geen skerm gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Stuurder herstel misluk!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Probeer asseblief weer of gee ons feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Stuurder back-up misluk!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Toonadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Geen GPU gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Geen monitor gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Netwerkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Geen netwerkadapter gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Klinkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Geen audioapparaat gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Geen Bluetoothapparaat gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Ander PCI-Apparaat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Geen ander PCI-Apparaat gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Krag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Geen batterie gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Toetsbord</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Geen toetsbord gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Muis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Geen muis gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Geen printer gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Geen kamera gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Geen CD-ROM gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Ander Apparaat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Geen ander apparaat gevind</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Reeks Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Vormfactor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Stel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bank Lokator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Tipe Detail</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Deelnommer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Geheue Technologie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Geheuebedrywingsmodusvermoë</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Stelwerk-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Modul-afrikaans ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Modul-produktyd ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Geheuebedrywingsstelselbeheerderafrikaans ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Geheuebedrywingsstelselbeheerderproduktyd ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Niet-volatief grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Volatief grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Cache grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logiese grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>duim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>netwerk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>akkumulator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-pad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>kragvoorsiening</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>gewysig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>het geskiedenis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>het statistieke</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>laagbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>toestand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>waarskuwingsvlak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energie-leeg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energie-vol</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>energie-vol-ontwerp</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>energie-koers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>spanning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>persentasie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ikoonenaam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon-versie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>op batterie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>deur is gesluit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>deur is aanwesig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritiese aktie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopieë</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>werk kansel na</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>werk hou tot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>werk prioriteit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>merker verandering tyd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>aantal op</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>oriëntasie aangevra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>draai-kleur-modus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer is werk aannehend</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer is gedeel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer is tansiem</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer maak en model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>printer status verandering tyd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>printer status redes</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>printer tipe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer-uri ondersteun</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>kante</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus-inligting</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logiese sektergrootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sektergrootte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometrie (logiese)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Toestelbeheerder</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Device Manager is 'n handige tool vir sien van hardeware-inligting en beheer van die toestelle.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Nuwe stuurprogramme beskikbaar! Installeer of dateer hulle nou.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Bekyk</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Inklusie van submappe</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Soek na stuurprogramme in hierdie pad</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 stuurprogramme-aktualiseringe beskikbaar'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Tyd gecheck: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Laai stuurprogramme vir %1 af...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Laai spoed: %1 Laai %2/%3 af'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Installeer stuurprogramme vir %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 stuurprogramme is geinstalleer, %2 stuurprogramme het misluk'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 stuurprogramme is geinstalleer'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Misluk om stuurprogramme te installeer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Netwerkfout. Herstel...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Laai spoed: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>U stuurprogramme is op datum</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Alle stuurprogramme is gekopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>ŉ Totaal van %1 stuurprogramme, waarvan %2 gekopieer is</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>U het %1 stuurprogramme wat gekopieer kan word, dit word aanbevolen om dit onmiddellik te doen</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>U het %1 stuurprogramme wat gekopieer kan word</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Kopieer die %1 stuurprogramme, 'n totaal van %2 stuurprogramme</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Kopieer: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 stuurprogramme is gekopieer, %2 stuurprogramme het misluk'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Misluk om stuurprogramme te kopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 stuurprogramme is gekopieer'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>U het %1 stuurprogramme wat herstel kan word</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Kies asseblief 'n stuurprogramme om te herstel</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Die bestuurder herstel...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Herstel: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>herlaai</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Vra asseblief %1 vir die geinstalleerde bestuurders om te werk</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Bekyk back-up-pad</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Back-up Alles</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>stel feedback in</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Vra asseblief weer of %1 na ons</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Installeer Alles</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Skenk weer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Kanselleer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Jy installeer 'n bestuurder, wat onderbroken sal word as jy verlaat.</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Wees jy seker jy wil verlaat?</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Verlaat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Kanselleer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Jy maak 'n back-up van bestuurders, wat onderbroken sal word as jy verlaat.</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Jy herstel bestuurders, wat onderbroken sal word as jy verlaat.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Bluetooth-adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Beeldingsapparaat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Skermadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Klinkkaart</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Netwerkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Draadloos netwerkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Installasie suksesvol</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Beeldapparaat</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Skermadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Klinkkaart</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Netwerkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Draadloos netwerkadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Installasie suksesvol</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Installasie misluk</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Lad</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Installasie</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Nie geinstalleer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Verouderde</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Wag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Nie gekopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Kopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Kopieer misluk</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Kopieer suksesvol</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Herstel</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Onbekende fout</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Netwerkfout</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Geannuleer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Kan geen stuurprogramme lêers kry</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Vernuwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Kopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Herstel</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Installeer</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Vernuwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Vernuwe stuurprogramme</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Deinstalleer stuurprogramme</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Staan dit toe om die rekenaar wakker te maak</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Aktiveer</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Vernuwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopieer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Deaktiveer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Beskikbaar</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Kies asseblief 'n plaaslike map</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Lui...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_am_ET.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_am_ET.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="am_ET">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>መግቢያ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>አይነ</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>በረድ</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ድጋፍ ምድቦች ለመግለጽ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>ማነጂድ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>በረድ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>መጥቀስ</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>ማጥፊያ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>ይቅር</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ማሽን ስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>ስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>መምጣ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ክიፕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>ቅንṭነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS ዓይነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ተጨማሪ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>ክርnels ማድረግ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>ማemory ዓድራስ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>ይቅር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>ማጥፊያ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>ስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>መምጣ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>ሞዱል</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>መምጣ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>እርግጥ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ክიፕሴት</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>አሊያስ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>ስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>መຜား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>نسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>မျိုးအမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>နှုန်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>အများအားဖြင့်အမြင့်ဆုံးအား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Driver နံပါတ်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>စွမ်းရည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ဘားအက်က် အချက်အလက်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>တိုင်းတာရေးအမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC လိပ်စာ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ရရှိနိုင်မည်မဟုတ်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>ပိတ်ပါ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>အမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>မှတ်ပုံတင်သူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>မျိုးအမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>နံပါတ်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ဘားအက်က် အချက်အလက်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>စွမ်းရည်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>အများအားဖြင့်အမြင့်ဆုံးအား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>နှုန်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>ရရှိနိုင်မည်မဟုတ်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>ပိတ်ပါ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>အမည်</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>မှတ်ပုံတင်သူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>အစိတ်အပိုင်း ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>သားလေးများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>የመስመር ምስሎች</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>ბოგომიფს</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>არქიტექტურა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>პიერი სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>პროცესორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>ბუნდები (დამხმარე)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ვირტუალიზაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>ფლაგები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>განვითარებები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 კაჩი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 კაჩი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i კაჩი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d კაჩი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>სტეპინგი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>მაქსიმალური სიჩქარე</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ვენდორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>გრაფიკული მეხსიერება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ფიზიკური იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>მეხსიერების მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO პორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>მაქსიმალური რეზოლუცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>მინიმალური რეზოლუცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>მიმდინარე რეზოლუცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>აღწერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>ԴՊ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>ԷԴՊ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>ՀԴՄԻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>ՎԳԱ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>ԴՎԻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Տեսական Արտագործություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Դիսպլե Արտագործություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Կարողանալիքներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>ԻՐԿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Վենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Բուս Տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Ամենամեծ Ծախս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Ռայդեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Կարողանալիքներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Սերիալ համар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Անջատել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Վենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Ինտերֆեյս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Բուս ՏեՂեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Ամենամեծ Ծախս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Ռայդեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>የሚችሉ የምር Eaton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>ውersion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>መጠቀም የለበ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>ውስጥ የለበ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>አጭር መግለጫ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>CPU ቁANTITY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>ማሽተርቦርድ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>ማሽተርቦርድ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>የመስመር የምር Eaton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>የነገር የምር Eaton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>ጠፋ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>ሌሎች PCI የምር Eaton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>ባትሪ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>ባሉት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>የነትዟ የምር Eaton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>ማውስ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>ክእይቦርድ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>ሞኒተር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>ሴዲ-ሮም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>ፕሪንተር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>ካሜራ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>ሌሎች የምር Eaton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>የምር Eaton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>ባለሙያ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>መጠን</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>ድርጅት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>ፍጥነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>የድምር ተግባራ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ማለት ተግባራ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>ስีሪያል ትን毅</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>ተወሰነ የቮልቴጅ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>መብዛcaf የቮልቴጅ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>ከፍተኛ የቮልቴጅ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>ተወሰነ የመquick</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ምረጋት ተግባራ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>ተመላሽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>ትይፕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>ማሳያ የግባ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ኢንቲርፍեይስ ቅድ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>መፍትሔ የመquick</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>አሁኑ የመquick</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>የማሳያ ምርት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>መንግ አስፈላ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ምጋ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>ስიሪያል ትን毅</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>ተመላሽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>ትይፕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>እdition</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ባስ አይነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>ተግባራ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ድራይቭር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ድራይቭር አይነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>ከፍተኛ የመquick</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>መደ ineligible የመquick</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>ፖርት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>მულტიკასტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>ბმული</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>დახურვის დრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>ფირმვერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>დუპლექსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>ბროდკასტ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ავტო ნეგოციაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>მემორიის მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ირკ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>მაკ მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ლოგიკური სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>გააქტივირება</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>შეყვანა/გამოყვანა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>მემორია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ირკ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>დახურვის დრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>შესაძლებლობები</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>የቅուշտ կարողություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Բացահայտող</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Ամենամեծ էներգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Սերիալ համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Ընդունել</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Վենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Սերիալ համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Տիպ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Կարգավիճա縠</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Ուղղակի կարգավիճա縠</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Լիցքավոլտաժ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Սլոտ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Նախագծված կարգավիճա縠</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Նախագծված լիցքավոլտաժ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS սերիալ համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS ստեղծման ամսաթիվ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS քիմիական բաղադրություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Ջերմաստիճան</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Վենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Սերիալ համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Անհատական</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Կարգավիճա縠</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>የ አገልግሎት አይነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>ይ-disable</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>መም្ទី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>የ አካል አይነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>መጠን</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>ወር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>የ ምርጫ እ特性</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>የ ባህል ወር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>ፍጥነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>ማ tả</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>ስეሪያል ቃል</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>የ አገልግሎት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>ማዞር መጋቢት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ያልተገኘ</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>አገልግሎት ለ የ አዘዉ የ ምርጫ አስተዳደር</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>ይህ አክል የ አዘዉ የ ምርጫ ምልክት የ አልተገኘ</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>የ አUDIO አገልግሎት ምረጫ የ አይነት መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>የ BIOS ምረጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>የ CD-ROM ምረጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>የ አገልግሎት ምረጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>የ CPU ምረጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>የ አገልግሎት ምረጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>የ ምርጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>የ ምርጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>የ ምርጫ መጠቀም...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>የ ምርጫ መጠቀም...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>ይ-disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ያልተገኘ</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>ይ-disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ያልተገኘ</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>DeviceInfo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>የመሳሪያ የክርክር መረጃ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>ዝጊዜ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>እርዳታ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>ኮፔ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>ስርዓት</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation> አክሲዮን</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>አዘጋጅ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>መሳሪያ ማነጋገር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>ሆደር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ድራይቨር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>ሞንዩተር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>ማዕከል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>የመሳሪያ የክርክር መረጃ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>ሴ.ዩ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>የነጂሩ የክርክር መረጃ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>ባትሪ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>በጣም</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ድራይቨር የፕላቶም ዋጋ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>ተገልባለ የድራይቨር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>ተገልበ የድራይቨር</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>አዘጋጅ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>መሰረዝ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>ቀጥሎ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>ውረጃ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ድራይቨር የመሰረዝ በኋላ ስርዓቱ የሚያገኙ የመሳሪያ ምንስያዊ መረጃ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>መሰረዝ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>መሰረዝ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>አዘጋጅ ይተገedo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>መሰረዝ ይተገedo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Update ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Uninstallation ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>შემდეგი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>არ არსებობს მონიშნული საქაღალდე, გთხოვთ აირჩიოთ ხელახლა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>წინა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>გამორჩეული პაკეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>არ ემატება პაკეტის არქიტექტურა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>არ არსებობს მონიშნული ფაილი, გთხოვთ აირჩიოთ ხელახლა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ეს არ არის დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>გადასაყვანებელია - არ არის ელექტრონული ხელმწერადობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>უცნობი შეცდომა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>დრაივერის მოდული ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>უარყოფითი მოდულის ფორმატი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>დრაივერის მოდულს აქვს დამოკიდებულებები</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>დრაივერის დასაყვანებლად</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>დრაივერის დასაბეჭდებლად</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>დრაივერის აღდგენა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>გამოყენების შეფასება</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>თქვენ არ გაქვს დრაივერები, რომ აღდგინოთ, გთხოვთ დასაბეჭდებლად გადაადგილოთ ჯერ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>დასაბეჭდებელი დრაივერის მიმართულებაზე</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>დასაბეჭდებელი ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>აღდგენის შესაძლებელი დრაივერები</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ექსპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>საშიდა ხედვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>დრაივერის დასაყვანებლად</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>დრაივერის დასაბეჭდებლად</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>დრაივერის აღდგენა</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>የឧปકરণ አስፈላጊነት በትክክል የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>የឧปકርණ አስፈላጊነት በትክክል የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>የឧપકరණ አስፈላጊነት በትክክል የለም: የឧપકርණ ምዝገባ ምስል የማግኝ የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ድራይቨር የማሻሻል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ድራይቨር የማስወገድ</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>አስተካክል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ምርጡ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ኮፔ ያድር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>መግለጫ</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>አስተካክል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ምርጡ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ኮፔ ያድር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>አስፈላጊ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ድራይቨር የማሻሻል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ድራይቨር የማስወገድ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>የឧપકርණ የኮምፔተር ምስል የማስተዳደር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>ማስተዳደር</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>የឧપકርණ አስፈላጊነት በትክክል የለም: የឧપಕርණ ምዝገባ ምስል የማግኝ የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>የឧપકርණ አስፈላጊነት በትክክል የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>የឧપકርණ አስፈላጊነት በትክክል የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ድራይቨር የማሻሻል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ድራይቨር የማስወገድ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>ፍር ማም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>ፍር የឧપકርණ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ድራይቨር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ድራይቨር መግለጫ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ድራይቨር አስፅ activation Cmd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>ክፍгу መግለጫ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>ማስታወቂነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>ፍር የឧપકርණ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>ბუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ბიოსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ბაზის პლატფორმის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>სისტემის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ჩეისის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ფიზიკური მემორიის მასივი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>გამოცემის თარიღი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>რუნტაიმის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM-ის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>თვისებები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ბიოსის რევიზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ფირმვერსიის რევიზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>პროდუქტის სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ასეტის ჭერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>თვისებები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ჩეისის მაგისტრალში მდებარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>ჩეისის ხელში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>შემცვლელი სამაგისტრალის ხელში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>გასაგების ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>የአባት የድርጅት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>መዝጊ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>የመነሻ የሁኔታ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>የኃይል የተሰጠ የሁኔታ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>የሙቀት የሁኔታ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>የስርዓት የሁኔታ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ኦኤም የሰነድ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ፍ props</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>የኃይል የተሰጠ የአጥፋት ቁጥር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>የተካተተ የአካላት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ቦታ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>የትክክል የመደበኛ ቁጥር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ከፍተኛ የስራ ቁጥር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>የትክክል የሰነድ ቁጥር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>የሚያገለ የaygı ቁጥር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ብኢኦሲ የሆነ የፍ props</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>የተቀ科技股份 የቀDate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ድርጅት የስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>ኤስኤምቢኦሲ የเวርዝjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ቸጋሪ ዓይነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>ይገቡት ዓይነቶች</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>አሁን ያገቡት ዓይነት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>ባድ የስም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>አ.ሲ.ኤል የመቲዩ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>ሲ.ሲ.ኦ የመቲዩ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>የፌክት የድርጅት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>የሊንክ የፖሊሲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>የሊንክ የሞድ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>ክлас</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>የሲቪስ የክлас</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>კласი აპარატი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>ქვემატარებული ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>აპარატი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>სერიალური იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>პროდუქტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>აღწერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>მუშაობს</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>გამოსაძებნად მოწყობილია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>გასაწყობად მოწყობილია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>მოდალიას</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>გამოსაძებნად მოწყობილია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>დრაივერის მოდულები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>აპარატის ფაილი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>აპარატის ფაილები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>აპარატის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>სამუშაო პროგრამა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>სტატუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ლოგიკური სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ანსი ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU მიმ implementer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU არქიტექტურა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU ვარიანტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU ნაწილი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU რევიზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>ერთი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>ოთხი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>სამეული</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>ثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>تسعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>عشرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>اثنا عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>أربعة عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>ستة عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>ثامنة عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>عشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>اثنان وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>أربعة وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ستة وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ثمانية وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>ثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>اثنان وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>أربعة وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>ستة وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>ثمانية وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>أربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>اثنان وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>أربعة وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>ستة وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>ثمانية وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>خمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>اثنان وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>أربعة وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ستة وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ثمانية وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>ستون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>اثنان وستون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>أربعة وستون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ოცდაექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ოცდაორმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>შვიდმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>შვიდმეტი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>შვიდმეტი და მოციხა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>შვიდმეტი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>შვიდმეტი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>შვიდმეტი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>შვიდმეტი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>შვიდმეტი და მოციხა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>შვიდმეტი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>შვიდმეტი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>ცხრამეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>ცხრამეტი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>ცხრამეტი და მოციხა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>ცხრამეტი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>ცხრამეტი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>ერთი ასეთი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>ერთი ასეთი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>ერთი ასეთი და მოციხა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>ერთი ასეთი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>ერთი ასეთი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>ერთი ასეთი და ათი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>ერთი ასეთი და თეგვერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>ერთი ასეთი და თოთხერთი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>ერთი ასეთი და თოთხექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>ერთი ასეთი და თოთხერვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>ერთი ასეთი და სამეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>ერთი ასეთი და სამეტი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>ერთი ასეთი და სამეტი და მოციხა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>126</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>128</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>192</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>256</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>የጆዲ የመemory የትናት</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU የተሰጠው</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU የትይፕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL የเวርዝን</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL የክሊንት አፌ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL የเวርዝን</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL የเวርዝን</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>ያልታወቅ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>ዩኒክ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>የሂዚዕ ደግሞ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>ማቴርቦርድ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>ማቴርቦርድ የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>ማemory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>ማemory የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>ስቶራጅ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>ዲስክ የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>የድራይቭር የመመጫት ተ scarred የለም!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>ባለን የሞተ ምንም የመመልሳት መግለጫ የሰጠው ይመልከቱ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>የድራይቭር የመደምደም ተ scarred የለም!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>የመሳሪያ የተሰጠው</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>ሞኒተር</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>ሞኒተር የለም</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Network Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>No network adapter found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Sound Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>No audio device found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>No Bluetooth device found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Other PCI Devices</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>No other PCI devices found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Power</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>No battery found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>No keyboard found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>No mouse found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>No printer found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>No camera found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>No CD-ROM found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Other Devices</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>No other devices found</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Form Factor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Set</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bank Locator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Type Detail</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Part Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Memory Technology</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>የማမորի աշխատանքային կարգի հնարավորություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Ֆուտվերի տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Մոդուլի ստեղծողի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Մոդուլի ապրանքի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Հիշողության սուստեմի կառավարիչի ստեղծողի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Հիշողության սուստեմի կառավարիչի ապրանքի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Անփոփոխ չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Փոփոխ չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Կաշի չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Ընթացիկ չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Ամսաթիվ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>IO դրոշ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>ցանց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>ակտիվացված</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>բնական ճանապարհ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>էլեկտրական ապացուցակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>թարմացված</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>ունի պատմություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>ունի տվյալներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>վերալիցքավորելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>անվտանգության մակարդակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>էներգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>էներգիա դադարեցված</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>էներգիա լիակատարված</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ամբողջական նախագծված էներգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>էներգիայի արագությու նի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>հոսանքի տարբերություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>տոկոս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>ტექნოლოგია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>სიმბოლოს სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ონლაინ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>დემონის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>ბატარიაზე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>კარი დახურულია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>კარი არსებულია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>კრიტიკული მოქმედება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>კოპიები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>შესრულების გაუქმება შემდეგ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>შესრულების დასაწყისის მიღება მითითებული დრომდე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>იმ შესრულების პრიორიტეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>მარკერის ცვლილების დრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>ნუმერუპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>მიმართულების მოთხოვნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>სამართალის რეჟიმი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>პრინტერი მუშაობს შესრილებების მიღების მიზნით</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>პრინტერი არის გააზრდილი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>პრინტერი არის საშიში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>პრინტერის მოდელი და მარკეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>პრინტერის მდგომარეობის ცვლილების დრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>პრინტერის მდგომარეობის მიზეზები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>პრინტერის ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>პრინტერის ური მხარდაჭერილია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>მხარეები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ლოგიკური სექტორის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>სექტორის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>تشكل (منطقي)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير الأجهزة هو أداة مفيدة لعرض معلومات الأجهزة وتنظيمها.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>تنزيلات جديدة! قم بتثبيتها أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>تضمين المجلدات الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>البحث عن مسارات تثبيت الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>%1 تحديثات لبرامج الأجهزة متاحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>وقت الفحص: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل برامج الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>سرعة التنزيل: %1 تم تنزيل %2/%3</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تثبيت برامج الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>%1 برامج أجهزة تم تثبيتها، %2 فشلت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>%1 برامج أجهزة تم تثبيتها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تثبيت برامج الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>سرعة التنزيل: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>برامج الأجهزة الخاصة بك محدثة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع برامج الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>إجمالي %1 برامج أجهزة، منها %2 تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 برامج أجهزة يمكن نسخها، يُنصح بالقيام بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 برامج أجهزة يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ %1 برامج أجهزة، إجمالي %2 برامج أجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>نسخ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>%1 برامج أجهزة تم نسخها، %2 فشلت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ برامج الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 برامج أجهزة تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 برامج أجهزة يمكن استعادةها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار برنامج جهاز للاستعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver አስገድቡ ይገኛል...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>አስገድብ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>መድረስ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>እባክዎ %1 እንደገና የተстанов የድራይቨር ማስገንዘብ ይከottaል</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Backup ዓይነቱን ያግኙ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>ყველაን የማስገንዘብ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>መតኝ የመስuggestions ተግባር</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>እባክዎ ውድ ያሞ ወይ እንደገና %1 እኛ እንደገና ያስገኛል</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>ყვეልაን የመстанов</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>ማስተካከል ያሞ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>መሰረዝ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>የማሽን ዓይነቱ የድራይቨር ማስተካከል ይከottaል... ውድ ያሞ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>ማስተካከል %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>ማስተካከል ምቻቸው</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>ነጂሩ ምቻቸው</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>እባክዎ እርስ ምቻቸው የሚገኝ የነጂሩ ተግባር ያሞ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>እባክዎ ውድ ያሞ ወይ እንደገና %1 እኛ እንደገና ያስገኛል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>እርስ የድራይቨር ማстанов ይከottaል፣ ይህ የሚያስገድቡ ይገኛል ወይ እርስ ያስገኛል ይገኛል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>እርስ ያስገኛል ይገኛል?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ውጣ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>መሰረዝ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>እርስ የድራይቨር ማስገንዘብ ይከottaል፣ ይህ የሚያስገድቡ ይገኛል ወይ እርስ ያስገኛል ይገኛል</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>እርስ የድራይቨር ማስገድብ ይከottaል፣ ይህ የሚያስገድቡ ይገኛል ወይ እርስ ያስገኛል ይገኛል</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>ብሉቱት ዓይነቱ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ማስተካከል ዓይነቱ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>መሳያ ዓይነቱ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>ድም ዓይነቱ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>ነጂሩ ዓይነቱ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>ውሃይ ነጂሩ ዓይነቱ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>ማстанов ይከottaል</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ው installation failed</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Downloading</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Installing</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Not installed</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Out-of-date</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Waiting</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Not backed up</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Backing up</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Backup failed</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Backup successful</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Restoring</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Unknown error</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Network error</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Canceled</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Failed to get driver files</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Update</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Restore</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Install</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Update drivers</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Uninstall drivers</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Allow it to wake the computer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Enable</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Copy</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>არ ხელმისაწვდომია</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>გთხოვთ აირჩიოთ ლოკალური ფოლდერი</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>ჩატვირთვა...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ar.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ar.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>التغذية الراجعة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>موافق</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">المزيد</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">التجويف</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>المزيد</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>المزيد</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>التجويف</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>المزيد</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>التجويف</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>اسم الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>اسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>رقاقة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>المهارات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>اسم المعرف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>معرف الفيزيائي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>مسار SysFS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>الوصف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>المحرك في الوضع kernel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>عنوان الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>خطوط الإخلاء</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>البائع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>الشريحة</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>الاسم المستعار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>البائع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>الطراز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>اسم المعرف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>المعرف المادي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>السرعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>الطاقة القصوى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>اصدار الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>برنامج التشغيل (ملف التعريف)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>القدرات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>معلومات الناقل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>الاسم المنطقي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>عنوان ماك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>الطراز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>معلومات الحافلة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>المهارات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>المحرك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>الطاقة القصوى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>السرعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>اسم الوحدة الفرعية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>معرف الفيزيائي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>معرف وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>معرف النواة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>الخيوط</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>الهندسة المعمارية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>عائلة وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>الطراز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>المعالج</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>النوى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>التقليد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>العلامات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>التوسيعات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>الكاش L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>مساحة التخزين المؤقت الثالثة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>مساحة التخزين المؤقت الثانية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>مساحة التخزين المؤقت_LEVEL 1 داخل المعالج</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>مساحة التخزين المؤقت_LEVEL 1 خارج المعالج</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>خطوة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>السرعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>أقصى سرعة</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>الطراز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>ذاكرة الرسومات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>اسم الوحدة الشبكي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>معرف الفيزيائي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>عنوان الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>منفذ الإدخال / الإخراج</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>معلومات الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>أقصى دقة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>أدنى دقة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>الدقة الحالية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>المحرك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>الوصف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>إخراج رقمي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>إخراج العرض</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>المهارات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>غير متاح</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>اسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>الطراز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>معلومات الحافلة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>اسم الوحدة الفرعية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>معرف المادي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>السرعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>الحد الأقصى للطاقة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation> trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>المهارات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>رقم التسلسل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>غير متاح</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>اسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>الطراز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>الوصلة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>معلومات الحافلة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>اسم الوحدة الفرعية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>معرف المادي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>السرعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation> الحد الأقصى للتيار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>المحرك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>المهارات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>overview</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>كمية المعالجات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>لوحة الأم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>مثبت الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>مثبت الصوت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>التخزين</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>أجهزة PCI الأخرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>البطارية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>بلوتوث</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>بطاقة الشبكة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>الفارة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>الكيبورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation> قرص مضغوط محرك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>طابعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>كاميرا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>أجهزة إدخال أخرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>جهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>نظام التشغيل</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>النوع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>السرعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>العرض الكلي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>الموقع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>رقم التسلسل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>التوتر المconfigure</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>أقصى جهد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>أدنى جهد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>السرعة المconfigure</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>عرض البيانات</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>النوع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>عرض المدخلات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>نوع الواجهة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation> دعم معدل التحديث</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation> معدل التحديث الحالي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>نسبة العرض</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>الشاشة الرئيسية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>رقم التسلسل</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>المورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>نوع الوسائط</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>المهارات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>اسم الوحدة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>معرف المادية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>إصدار البرنامج الثابت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>السرعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>الوصف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>رقم التسلسل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>الواجهة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>معدل الدوران</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>اختر trình điều khiển للتحديث</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>لم يتم العثور على برامج تشغيل في هذا المجلد</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>تحميل معلومات جهاز الصوت...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>تحميل معلومات BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>تحميل معلومات CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>تحميل معلومات نظام التشغيل...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>تحميل معلومات وحدة المعالجة المركزية...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>تحميل معلومات الأجهزة الأخرى...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>تحميل معلومات الطاقة...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>تحميل معلومات الطابعة...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>تحميل معلومات الفأرة...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>تحميل معلومات محول الشبكة...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>غير متاح</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>غير متاح</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>معلومات الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>عرض المقتطفات</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>المساعدة</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>نسخ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>النظام</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>تصدير</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>مدير الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>الأجهزة</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>المحركات</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>المراقب</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>مoverview</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>مثبت الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>معالج</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>مودم الشبكة</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>بطارية</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>المزيد</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>اسم</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>الإصدار الحالي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>إصدار نظام التشغيل للسائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>الحالة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>عمل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>المحركات القابلة للنسخ الاحتياطي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>المحركات المستنسخة احتياطيًا</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>التحديث</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>تحذير</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>سيصبح الجهاز غير متاح بعد إلغاء تثبيت السائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>إلغاء التثبيت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>يعمل على إلغاء التثبيت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>تم التحديث بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>تمت عملية الإلغاء بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>فشل التحديث</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>فشل عملية الإلغاء</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>المجلد المحدد غير موجود، يرجى إعادة الاختيار</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>حزمة معطوبة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>هيكل حزمة غير مطابق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>الملف المحدد غير موجود، يرجى إعادة الاختيار</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>ليس برنامجا تشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>غير قادر على التثبيت - لا وجود للتوقيع الرقمي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>خطأ غير معروف</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>لم يتم العثور على وحدة التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>تنسيق وحدة التشغيل غير صالح</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>توجد عناصر تعتمد عليها وحدة التشغيل</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>اسم الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>النسخة المتاحة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>الحجم</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>الحالة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>العمل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>الإصدار الجديد</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>الإصدار الحالي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>المحركات المفقودة (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>المحركات القديمة (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>المحركات محدثة (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>تثبيت برنامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>نسخ احتياطي السائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>استعادة السائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>التغذية الراجعة</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>لم يكن لديك أي سائقين يمكن استعادتها، يرجى القيام بالنسخ الاحتياطي أولا</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>اذهب إلى جهاز النسخ الاحتياطي للسائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>الإصدار الحالي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>إصدار النسخ الاحتياطي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>العمل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>السائق القابل للاسترداد</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>تصدير</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>مoverview</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>تثبيت السائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>نسخ احتياطي السائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>استعادة السائق</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>فشل في تمكين الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>فشل في تعطيل الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>فشل في تعطيله: عدم القدرة على الحصول على رقم.Serial الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>تحديث السائقين</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>إزالة السائقين</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>تصدير</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>نسخ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>الإجمالي</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>تمكين</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>السماح لها باستيقاظ الكمبيوتر</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>فشل تعطيله: عدم القدرة على الحصول على رقم.Serial الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>فشل تعطيل الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>فشل تمكين الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>تحديث برامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>إزالة برامج التشغيل</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>مورد فرعي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>جهاز فرعي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation> trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>حالة الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>cmd تنشيط الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>حالة التكوين</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>الضرر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>فيزيائي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>المتصرفون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>حدث غير متوقع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>مفتاح</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>إصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>خط</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>معلومات BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>معلومات اللوحة الأساسية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>معلومات النظام</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>معلومات الهيكل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>مصفوفة ذاكرة الوصول العشوائي الفعلية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>تاريخ الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>عنوان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>حجم التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>حجم ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>الميزات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>تحديث BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>تحديث البرامج الثابتة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>اسم المنتج</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>رقم التسلسل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>علامة الأصول</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>الميزات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>الموقع داخل الهيكل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>مقبض الهيكل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>النوع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>أيدي 对象 المخفية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>نوع الاستيقاظ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>رقم SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>العائلة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>قفل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>حالة التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>حالة إمداد الطاقة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>حالة الحرارة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>حالة الأمان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>معلومات OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>الارتفاع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>عدد أسلاك الطاقة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>المكونات المضمنة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>الموقع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>نوع تصحيح الأخطاء</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>السعة القصوى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>معالجة معلومات الخطأ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>عدد الأجهزة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>حجم ROM BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>تاريخ الإصدار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>اسم اللوحة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>إصدار SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>تنسيق beschrieben Sprache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>اللغات القابلة للتثبيت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>اللغة المثبتة حاليًا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>عنوان BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>نوع الحزمة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>سياسة الاتصال</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>وضع الاتصال</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>الفئة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>فئات الخدمة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>فئة الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>إصدار HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>إصدار LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>الإصدار الفرعي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>رقم التعريف السريع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>المنتج</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>الوصف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>مدعوم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>يمكن اكتشافه</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>يمكن الاقتران به</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>معرفات الترميز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>اكتشاف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>وحدات تشغيل الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>ملف الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>ملفات الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>رقم الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>التطبيق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>الحالة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>اسم منطقي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>إصدارAnswers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>مطور وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>هيكل وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>متغير وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>قطعة وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>تعديل وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>واحد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>اثنان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>أربعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>ستة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>ثمانية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>تسع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation> عشرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>اثنا عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>أربعة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>ستة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>ثمانية عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation> عشرون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation> عشرون وعشرون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation> عشرون وأربعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation> عشرون وستة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation> عشرون ثمانية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation> ثلاثون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation> ثلاثون واثنان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>ثلاثة وأربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>ثلاثة وستون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>ثلاثة وثمانون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>أربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>أربعون وعشرون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>أربعون وأربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>أربعون ستة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>أربعون ثمانية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>خمسون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>خمس وعشرون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>خمس وأربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>خمسون وستون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>خمسون ثمانية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>ستون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>ستون وعشرون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>ستون وأربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>ستون وستون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>ستون ثمانية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>سبعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>سبع وعشرون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>سبع وأربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>سبعون وستون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>سبعون ثمانية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>ثمانون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>ثمانون وعشرون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>ثمانية وأربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>ثمانية وستون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>ثمانية وثمانون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>تسعة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>تسعة عشر ونصف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>تسعة عشر وأربعون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>تسعة عشر وستون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>تسعة عشر وثمانون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>مائة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>مائة وأربعة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>مائة وأربع عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>مائة وأربع عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>مائة وأربع عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>مائة وخمسة عشر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>مائة وتسعة عشر وخمسون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>مائتان وخمسون وخمس十六条</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>سعة GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>مورد GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>نوع GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>إصدار EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>موارد برمجة تطبيقات EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>إصدار GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>إصدار GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>غير معروف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>مختلف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>فئة الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>معالج</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>لم يتم العثور على وحدة معالجة مركزية</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>لوحة الأم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>لم يتم العثور على لوحة أم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>ذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>لم يتم العثور على ذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>التخزين</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>لم يتم العثور على قرص</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>فشل إصلاح برنامج التشغيل!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>يرجى المحاولة مرة أخرى أو تقديم ملاحظات لنا</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>فشل النسخ الاحتياطي لبرنامج التشغيل!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>مثبت العرض</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>لم يتم العثور على معالج رسومات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>لم يتم العثور على جهاز العرض</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>موجه الشبكة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>لم يتم العثور على جهاز التوجيه الشبكي</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>مكبر الصوت</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>لم يتم العثور على جهاز صوت</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>بلوتوث</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>لم يتم العثور على جهاز بلوتوث</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>أجهزة PCI أخرى</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>لم يتم العثور على أجهزة PCI أخرى</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>الطاقة</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>لم يتم العثور على بطارية</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>مكبر الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>لم يتم العثور على جهاز صوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>لم يتم العثور على جهاز بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>أجهزة PCI أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>لم يتم العثور على أجهزة PCI أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>لم يتم العثور على بطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>الكيبورد</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>لم يتم العثور على لوحة مفاتيح</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>الفأرة</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>لم يتم العثور على الفأرة</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>الطابعة</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>لم يتم العثور على الطابعة</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>كاميرا</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>لم يتم العثور على الكاميرا</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation> قرص مضغوط-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>لم يتم العثور على قرص مضغوط-ROM</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>الفأرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>لم يتم العثور على الفأرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>لم يتم العثور على الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>كاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>لم يتم العثور على الكاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation> قرص مضغوط-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>لم يتم العثور على قرص مضغوط-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>أجهزة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>لم يتم العثور على أجهزة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>مقبض المصفوفة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>معامل الشكل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>تعيين</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>موقع الصندوق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>تفاصيل النوع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>رقم الجزء</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>الصف</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>تكنولوجيا الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>قدرة وضع تشغيل الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>إصدار البرنامج الثابت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>معرف مصنع وحدة المعالجة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>معرف منتج وحدة المعالجة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>معرف مصنع وحدة التحكم في وحدة الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>معرف منتج وحدة التحكم في وحدة الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>الحجم غير المتغير</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>الحجم المتغير</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>حجم التخزين المؤقت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>الحجم المنطقي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>بوصة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>أوجه</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>معلومات الحافلة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>حجم القطاع المنطقي</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>حجم القطاع</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>GUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>المجال (منطقي)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>مدير الأجهزة</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>مدير الأجهزة أداة مفيدة لعرض معلومات الأجهزة وإدارة الأجهزة.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>متوفرة برامج تشغيل جديدة! قم بتثبيتها أو تحديثها الآن.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>عرض</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation> incluye carpetas secundarias</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>ابحث عن برامج التشغيل في هذا المسار</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 برامج تشغيل متوفرة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>تم التحقق من الوقت: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>قيد تنزيل برامج تشغيل %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>سرعة التنزيل: %1 تم تنزيل %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>قيد تثبيت برامج تشغيل %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 برنامج تشغيل مثبت، %2 برنامج تشغيل فشل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 برنامج تشغيل مثبت</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>فشل في تثبيت برامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>سرعة التنزيل: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>برامج تشغيلك محدثة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>تم عمل نسخة احتياطية لجميع برامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>مجموع %1 برنامج تشغيل، من بينها %2 تم عمل نسخة احتياطية</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>&gt;- لديك %1 برنامج تشغيل يمكن عمل نسخة احتياطية، يوصى بعمل ذلك على الفور</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>لدينا %1 برنامج تشغيل يمكن عمل نسخة احتياطية</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>عمل نسخة احتياطية لبرنامج التشغيل %1، المجموع %2 برنامج تشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>عمل النسخة الاحتياطية: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 برنامج تشغيل عمل نسخة احتياطية، %2 برنامج تشغيل فشل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>فشل في عمل نسخة احتياطية للبرامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 برنامج تشغيل عمل نسخة احتياطية</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>لدينا %1 برنامج تشغيل يمكن استعادته</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>يرجى اختيار برنامج تشغيل لإعادة الاسترجاع</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>يقوم البرنامج التشغيل بإجراء عملية الاسترجاع...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>استعادة: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>إعادة التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>يرجى %1 للتأثير على برامج التشغيل المثبتة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>عرض مسار النسخ الس.Beanدة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>نسخ الاحتياطي للكل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>صمغ ردود الأفعال</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>يرجى المحاولة مرة أخرى أو %1 معنا</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>تثبيت الكل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>فحص مرة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>يتم الآن فحص برامج تشغيل الأجهزة، الرجاء الانتظار...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>جاري فحص 1%</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>فشلت عملية الفحص</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>الشبكة غير متاحة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>الرجاء التحقق من اتصال الشبكة الخاص بك</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>يرجى تصوير مرة أخرى أو %1 معنا</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>تتم الآن عملية تثبيت برامج التشغيل (ملفات التعريف)، وستتم تعطيل العملية في حالة الخروج.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد من أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>خروج</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>تتم الآن عملية النسخ الإحتياطي لبرامج التشغيل (ملفات التعريف)، وستتم تعطيل العملية في حالة الخروج.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>تتم الآن عملية استعادة برامج التشغيل (ملفات التعريف)، وستتم تعطيل العملية في حالة الخروج.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>فشل في الحصول على ملفات السائق</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>التحديث</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>النسخ الاحتياطي</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>استعادة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>تثبيت</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>تصدير</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>تحديث برامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>إلغاء تثبيت برامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>اسمح بتشغيل الكمبيوتر</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>تمكين</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>تحديث</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>تصدير</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>نسخ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>يرجى اختيار مجلد محلي</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>جارٍ التحميل...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ast.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ast.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ast">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Más</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>EC_NOTIFY_NETWORK</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>EC_REINSTALL</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Más</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Colapsar</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>No disponible</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Nome del dispositíu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Capacidades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Dirección de memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>No disponible</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modelu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>القوة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>نسخة برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>معلومات الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>الاسم المنطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>عنوان MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>معلومات الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>القوة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>رقم المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>رقم النواة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>الخيوط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arquitectura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Familia de CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Modelu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Procesador</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Núcleu(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualización</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Bandera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Extensiones</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>Cache L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>Cache L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>Cache L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>Cache L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Stepping</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Velocidat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Velocidat máxima</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Vendedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modelu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Memoria gráfica</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ID físico</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Direición de memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>Portu I/O</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Información del bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Resolución máxima</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Resolución mínima</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Resolución actual</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Conducción</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Descripción</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Salida Digital</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Salida de Pantalla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Capacidades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>No disponible</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Información del Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Velocidad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Potencia Máxima</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Conductor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Capacidades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Número de Serie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>No disponible</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interfaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Información del Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Velocidad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Corriente Máxima</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Conductor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>كمية المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>اللوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>بطاقة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>بطاقة الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>أجهزة PCI الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>بطاقة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>الماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>اللوحة المفاتيح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>الشاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>القرص الليزر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>الطباعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>الكاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>أجهزة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>نظام التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Anchura total</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Localizador</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Número de serie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Voltaje configuráu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Voltaje máximo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Voltaje mínimu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Velocidá configuráu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Anchura de datos</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Tipu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Entrada de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Tipu d'interfaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Resolución soportada</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Resolución actual</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Relación de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Monitor primariu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Tamañu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Número de serie</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Tipu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Información del bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Capacidaes</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Conducor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Versión del conducor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Tasa máxima</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Tasa de negociación</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Portu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Enlace</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latencia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Negociación automática</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Dirección de memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>Dirección MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Nome lóxicu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>No disponible</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modelu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Información de bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Entrada/Salida</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latencia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Conducción</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Capacidades</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modelu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Información de bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>المُطور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>المُصنع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>القدرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>الشريحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>القدرة المُصممة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>الجهد المُصمم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>نسخة SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>رقم تسلسل SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاريخ تصنيع SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>كيمياء SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>درجة الحرارة</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>المُصنع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>المُشاركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Tipu d'interfaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Proveedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Tipu de soportu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Tamañu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Capacidaes</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Versión de firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Velocidat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Descipción</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Numeru de serie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Interfaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Velocidat de rotación</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Inxestible</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Selecciona un conductor pa l'actualización</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Nun hai conductores encontrados n'esta carpeta</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Cargando información del dispositivu audio...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Cargando información del BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Cargando información del CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Cargando información del sistema operativu...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Cargando información del CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Cargando información d'otru dispositivos...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Cargando información de potencia...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Cargando información del impresor...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Cargando información del ratón...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Cargando información del adaptador de xarrada...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Inxestible</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Inxestible</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Información del dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Atajos de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Cerrar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Ayuda</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Refrescar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Administrador de dispositivos</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Controladores</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Vista general</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Adaptador de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Adaptador de red</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Batería</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Más</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Versión de la plataforma del controlador</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Controladores disponibles para copia de seguridad</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Controladores copiados de seguridad</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Actualizando</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Siguiente</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Advertencia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>El dispositivo no estará disponible después de la desinstalación del controlador</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Desinstalar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Desinstalando</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Actualización exitosa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Desinstalación exitosa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>التحديث فاشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>الإلغاء فاشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>أوك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>المجلد المختار لا موجود، من فضلك اختر مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>السابق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>حزمة متضررة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>أركيتكتور حزمة غير متوافق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>الملف المختار لا موجود، من فضلك اختر مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>إنه ليس مسند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>غير قادر على التثبيت - لا توقيع رقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>خطأ مجهول</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>لم يتم العثور على وحدة مسند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>صيغة وحدة غير صالحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>وحدة مسند لها اعتماديات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>تثبيت مسند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>نسخة احتياطية من مسند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>استعادة مسند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>التغذية الراجعة</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>لا تملك أي مسند للاستعادة، من فضلك أعد النسخة الاحتياطية أولاً</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>الذهاب إلى نسخة مسند احتياطية</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>نسخة احتياطية</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>مسند قابلة للإرجاع</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>تثبيت مسند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>نسخة احتياطية من مسند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>استعادة مسند</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>التعذر في تمكين الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>التعذر في إيقاف الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>التعذر في إيقافه: لا يمكن الحصول على رقم التسلسل الخاص بالجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>تحديث البرامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>إزالة البرامج</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>تمكين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>تحديث البرامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>إزالة البرامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>السماح له بتشغيل الحاسوب</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>إيقاف</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>التعذر في إيقافه: لا يمكن الحصول على رقم التسلسل الخاص بالجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>التعذر في إيقاف الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>التعذر في تمكين الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>تحديث البرامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>إزالة البرامج</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>العميل الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>الجهاز الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>حالة البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>명령 التفعيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>حالة التكوين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>التأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>الجسدي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Manexos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Información del BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Información del tableru principal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Información del sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Información del gabinet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Array de memoria física</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Fecha de lansamientu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Direición</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Tamañu de esecución</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Tamañu de ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Carauterístiques</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Revisión del BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Revisión del firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Nome del productu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Numeru de serie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Etiqueta de activu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Carauterístiques</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Llocalización nel gabinet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Manegu del gabinet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Tipu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Manexos d'objetus contenedores</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Tipu de despertu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Numeru de SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>الفاميليا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>القفل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>حالة التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>حالة التيار الكهربائي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>حالة الحرارة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>حالة الأمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>معلومات المصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>الارتفاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>عدد أسلاك الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>العناصر المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نوع تصحيح الخطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>السعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>اليدentifier للمعلومات عن الخطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>عدد الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>حجم BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاريخ الإصدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>اسم اللوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>نسخة SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>صيغة وصف اللغة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>اللغات المثبتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>اللغة المثبتة حاليًا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>عنوان BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>حجم MTU ACL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>حجم MTU SCO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>نوع البيانات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>سياسة الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>وضع الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>الصنف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>التصنيفات الخدمية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Clase del dispositivu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Versión HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Versión LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subversión</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Dispositivu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID serial</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>producto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>descripción</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Con pila</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Descubrible</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Pareable</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Descubriendo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Módulos de xestionador</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Fichero de dispositivu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Ficheros de dispositivu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Númberu de dispositivu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Aplicación</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>estadu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>nombe lóxicu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Implementador de CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Arquitectura de CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Variante de CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Parte de CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Revisión de CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Unu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Dos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Cuatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Ocho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Nueve</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Diez</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Doce</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Catorce</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Dieciséis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Dieciocho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Veinte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Veintidós</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Veinticuatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Veintiséis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Veintiocho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Treinta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Treintadós</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Treintacuatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Treintaséis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Treintaocho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Cuarenta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Cuarentadós</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Cuarentacuatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Cuarentaséis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Cuarentaocho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Cincuenta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Cincuentadós</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Cincuentacuatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Cincuentaséis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Cincuentaocho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Sesenta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Sesentadós</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Sesentacuatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ستين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ستين وثماني</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>سبعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>سبعون ودوي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>سبعون واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>سبعون وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>سبعون وثماني</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ثمانين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ثمانين ودوي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ثمانين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ثمانين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ثمانين وثماني</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>تسعين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>تسعين ودوي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>تسعين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>تسعين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>تسعين وثماني</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>مائة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>مائة ودوي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>مائة واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>مائة وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>مائة وثماني</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>مائة وعشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>مائة واثنى عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>مائة واربع عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>مائة وست عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>مائة وثماني عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>مائة وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>مائة واثنى وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>مائة واربع وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Ciento veintiséis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Ciento veintiocho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Ciento noventa y dos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Doscientos cincuenta y seis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Capacidad de GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Fabricante de GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Tipo de GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Versión EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>APIs EGL del cliente</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Versión GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Versión GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Desconocido</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Clase de hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>No se encontró CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>No se encontró motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>No se encontró memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Almacenamiento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>No se encontró disco</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>¡El restablecimiento del controlador falló!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Por favor, inténtelo de nuevo o dénos su retroalimentación</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>¡El respaldo del controlador falló!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Adaptador de visualización</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>No se encontró GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>No se encontró monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Adaptador de xeral</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Nun se atopó un adaptador de xeral</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Adaptador de son</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Nun se atopó un dispositivu d'audiencia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Nun se atopó un dispositivu Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Otres dispositivos PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Nun se atoparon otres dispositivos PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Enerxía</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Nun se atopó un bateríu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Tecláu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Nun se atopó un tecláu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Ratón</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Nun se atopó un ratón</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Nun se atopó una impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Cámara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Nun se atopó una cámara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Nun se atopó un CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Otres dispositivos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Nun se atoparon otres dispositivos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Manexu d'array</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Factor de formáu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Conxuntu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Localizador de bancu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Detallu de tipu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Numeru de part</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rangu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Tecnoloxía de memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Capacidad de Modo de Funcionamiento de Memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Versión del Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ID del Fabricante del Módulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID del Producto del Módulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ID del Fabricante del Controlador del Subsistema de Memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ID del Producto del Controlador del Subsistema de Memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Tamaño No Volátil</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Tamaño Volátil</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Tamaño de la Memoria caché</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Tamaño Lógico</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>pulgada</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Fecha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>puerto de entrada/salida</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>red</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>batería</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>ruta nativa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>alimentación de energía</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>actualizado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>tiene historial</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>tiene estadísticas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>recargable</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>estado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>nivel de advertencia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energía</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energía vacía</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energía llena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>diseño de energía llena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>tasa de energía</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>voltaje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>porcentaje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>tecnología</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>nombre del iconu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>en línea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>versión del daemon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>en batería</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>el portátil ta cerráu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>el portátil ta presente</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>acción crítica</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>copia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>cancelar trabayu despues</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>sostener trabayu hasta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>prioridá del trabayu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>momentu de cambéu del marcador</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>númberu por llomba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientación solicitada</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>modu de color pa imprimir</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>impresora ta aceptando trabayos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>impresora ta compartida</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>impresora ta temporal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>fabricante y modelu de la impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>momentu de cambéu d'estáu de la impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>razones d'estáu de la impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>tipu d'impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI d'impresora soportada</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>lados</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>información del bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>tamaño del sector lóxicu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>tamaño del sector</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>identificador único</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>الهندسة (المنطقية)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير الأجهزة هو أداة مفيدة لعرض معلومات الأجهزة ومدتها.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>تم العثور على موجهات جديدة! قم بتثبيتها أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>شامل الأدوار الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>البحث عن موجهات في هذا المسار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 تحديثات لموجهات متاحة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'وقت التحقق: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل موجهات لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تثبيت موجهات لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 موجهات مثبتة، %2 موجهات فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 موجهات مثبتة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تثبيت الموجهات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعة التنزيل: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>موجهاتك محدثة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع الموجهات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>إجمالي %1 موجهة، من بينها %2 تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 موجهة يمكن نسخها، يُنصح بالقيام بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 موجهة يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ الموجهة %1، إجمالي %2 موجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'النسخ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 موجهة تم نسخها، %2 موجهة فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ الموجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 موجهة تم نسخها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 موجهة يمكن استعادتها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار موجهة للاستعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>El conductor ta restaurando...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Restaurando: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>reboot</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Por favor %1 pa que los conductores instalados tengan efeu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Ver camínu d'apuestu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Apuestu total</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>presenta feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Por favor intenta de nuebe o %1 nos</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Instalación total</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Escanea de nuebe</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Anular</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Escaneando conductores de dispositivos hardware, por favor espera...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Escaneando %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Escaneu falló</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Xebru non disponible</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Por favor comproba la tú conexión de xebru</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Por favor escanea de nuebe o %1 nos</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Tas instalando un conductor, que será interrompíu si te salís.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>¿Seguro que quier salir?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Salir</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Anular</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Tas fagando un apuestu de conductores, que será interrompíu si te salís.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Tas restaurando conductores, que será interrompíu si te salís.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Adaptador de Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Dispositivu d'imaxe</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Adaptador de esploración</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Tarxeta de sonidu</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Adaptador de xebru</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Adaptador de xebru inalámbricu</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Instalación exitosa</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>La instalación falló</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Descargando</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Instalando</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>No instalado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Desactualizado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Esperando</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>No está copiado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Copiando</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>La copia falló</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>La copia foi exitosa</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Restaurando</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Error desconocíu</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Error de xarrada</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Canceláu</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Fallo na obtención de los arquivos del xunta</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Xuatá</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Restaurar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Instalar</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Refrescar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Xuatar xunta</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Desinstalar xunta</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Permitir que despierte l'ordenador</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Activar</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Refrescar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Desactivar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Inaccesible</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Selecciona una carpeta local por favor</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Cargando...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_az.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_az.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Rəy bildirişi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Daha çox</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Yığmaq</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Daha çox</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Daha çox</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Yığmaq</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Daha çox</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Yığmaq</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Cihazın adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Çip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Modulun alternativ adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fiziki İD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Təsviri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Buraxılış</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Yaddaş ünvanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Mikrosxem dəsti</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Ləqəb</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Modulun alternativ adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fiziki İD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Maksimum Güc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Sürücü versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Kanal haqqında məlumatlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Məntiqi ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC ünvanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Kanal haqqında məlumatlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maksimum Güc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Modulun alternativ adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fiziki İD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>Mərkəzi Prosessor ID-si</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Nüvə İD-si</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Axınlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Arxitektura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Mərkəzi prosessor ailəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Prosessor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Nüvə(lər)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Vizuallaşdırma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Bayraqlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Əlavələr</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 keş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 keş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 keş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i keşi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d keş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Addımlama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Maksimum sürət</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Qrafik yaddaş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Modulun alternativ adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fiziki İD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Yaddaş ünvanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Giriş/Çıxış portu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Kanal haqqında məlumatlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maksimum görüntü imkanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Minimum görüntü imkanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Mövcud görüntü imkanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Təsviri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>RəqəmsalÇıxış</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Cihaz çıxışı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Kanal haqqında məlumatlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Modulun alternativ adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fiziki İD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maksimum Güc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>İnterfeys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Kanal haqqında məlumatlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Modulun alternativ adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fiziki İD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Maksimum cərəyan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>İcmal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>Mərkəzi Prosessor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Mərkəzi Prosessor sayı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Ana plata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Yaddaş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Ekran uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Səs uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Saxlama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Digər PCİ qurğular</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Batareya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Şəbəkə uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Siçan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Klaviatura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Printer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Digər cihazlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Cihaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>ƏS</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Ölçü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Növ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Ümumi genişlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Lokator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Ayarlanmış gərginlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Maksimum gərginlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Minimum gərginlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Ayarlanmış sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Verilənlərin genişliyi</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Növ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Ekran girişi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>İnterfeys növü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Dəstəklənən görüntü imkanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Mövcud görüntü imkanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Görüntü nisbəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>İlkin monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Ölçü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>İstehsalçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Daşıyıcının növü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Ölçü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Modulun alternativ adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fiziki İD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Mikroproqram versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Sürət</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Təsviri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>İnterfeys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Dönmə dərəcəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Yeniləmək üçün sürücünü seçin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Bu qovluqda fayl tapılmadı</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Səs cihazı məlumatı yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BİOS məlumatı yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM məlumatı yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Əməliyyat Sistemi məlumatları yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Prosessor məlumatları yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Digər cihaz məlumatları yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Güc məlumatları yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Printer məlumatı yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Siçan məlumatı yüklənir...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Şəbəkə uzlaşdırıcısı məlumatları yüklənir...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Cihaz məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Kömək</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sİstem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Təzələmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Cihaz idarəetməsi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Avadanlıq</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Sürücülər</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>İcmal</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Ekran uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Mərkəzi Prosessor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Şəbəkə uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Batareya</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Daha çox</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Cari versiya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Sürücü platforması versiyası</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Əməl</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Ehtiyyat nüsxəsi saxlanılabilən sürücülər</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Ehtiyyat nüsxəsi saxlanılan sürücülər</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Yenilənir</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Sonrakı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Xəbərdarlıq</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Sürücü silindikdən sonra cihaz əlçatmaz olacaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Silinir</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Uğurla yeniləndi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Uğurla silindi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Yenilənmə alınmadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Silinmə uğursuz oldu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Sonrakı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Seçilmiş fayl mövcud deyil, lütfən yenidən seçin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Yeniləmə</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Əvvəlkilər</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Zədələnmiş paket</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Uyğun gəlməyən paket arxitekturası</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Seçilmiş fayl mövcud deyil, lütfən yenidən seçin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Bu sürücü deyil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Quraşdırmaq mümkün deyil - rəqəmsal imza yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Bilinməyən xəta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Sürücü modulu tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Səhv modul formatı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Sürücü modulunda asılılıqlar var</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Cihazın adı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Əlçatan versiya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Ölçü</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Əməl</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Yeni versiya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Cari versiya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Sürücülər çatışmır (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Köhnəlmiş sürücülər (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Yenilənmiş sürücülər (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Sürücü quraşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Sürücünün eht. nüsxəsini saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Sürücünü bərpa etmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OLDU</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Rəy bildirişi</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Bərpa ediləcək heç bir sürücünüz yoxdur, öncə eht. nüsxəsini saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Ehtiyyat nesxə sürücüsünə keçin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Cari versiya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Eht. nüsxə versiyası</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Əməl</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Bərpa ediləbilən sürücülər</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Təzələmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>İcmal</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Sürücü quraşdırmaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Sürücünün eht. nüsxəsini saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Sürücünü bərpa etmək</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Cihaz aktiv edilə bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Cihaz söndürülə bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Bunu söndürmək baş tutmadı: cihazın SN-ni əldə etmək mümkün deyil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Sürücüləri yeniləyin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Sürücüləri silin</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Təzələmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>İcmal</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Aktiv etmək</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Kompyuteri ayıltmağa ona icazə verin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Bunu söndürmək baş tutmadı: cihazın SN-ni əldə etmək mümkün deyil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Cihaz söndürülə bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Cihaz aktiv edilə bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Sürücüləri yeniləyin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Sürücüləri silin</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Podratçı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>AltCihaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Sürücünün vəziyyəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Sürücünü aktivləşdirmə əmri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Ayarlanma vəziyyəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>gecikmə</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>İcraçılar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>AÇAR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>BİOS məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Plata haqqında başlıca məlumat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Sistem haqqında</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Ana gövdə məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Fiziki yaddaş düzümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Buraxılış tarixi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Ünvan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>İcraolunma vaxt ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Özəllikləri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BİOS buraxılışı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Mikroproqram buraxılışı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Məhsulun adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Seriya nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Dəyər etiketi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>İmkanlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Ana gövdədəki yeri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Ana gövdə tanıtımı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Növ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Tərkibindəki obyektlərin göstəricisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Oyatma növü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>SKU nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Ailə</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Kilidləmək</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Açılma vəziyyəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Enerji təhcizatı vəziyyəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Termal vəziyyəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Təhlükəsizlik vəziyyəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Hündürlük</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Gec kabellərinin sayı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Tərkibindəki elementlər</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Yeri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Xəta düzəlmə növü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maksimum tutum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Xəta məlumatı tanıdılması</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Cihazların sayı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM ÖLÇÜSÜ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Buraxılış tarixi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Platanın adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS Versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Dil təsviri formatı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Quraşdırılmış Dillər</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Hal-hazırda quraşdırılan dil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD ünvanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Paket növü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Əlaqələndirmə siyasəti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Əlaqələndirmə rejimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Sinif</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Xidmət sinifləri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Cihaz sinifi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCİ versiyas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Alt versiya</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Cihaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Seriya İD-si</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>məhsul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>təsviri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>İşləyən</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Tapıla bilən</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Qoşulabilən</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Bağlama modu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Aşkarlanır</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Sürücü modulları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Cihaz faylı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Cihaz faylları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Cihazın nomrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Tətbiq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>məntiqi ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ANSİ versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Mərkəzi Prosessor icraçısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Mərkəzi Prosessor arxitekturası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Mərkəzi Prosessor variantı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Mərkəzi Prosessor bölümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Mərkəzi Prosessor buraxılışı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Bir</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>İki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Doqquz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>On</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>On iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>On dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>On altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>On səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>İyirmi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>İyirmi iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>İyirmi dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>İyirmi altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>İyirmi səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Otuz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Otuz iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Otuz dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Otuz altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Otuz səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Qırx</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Qirx iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Qırx dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Qırx altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Qırx səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Əlli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Əlli iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Əlli dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Əlli altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Əlli səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Altmış</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Altmış iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Altmış dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Altmış altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Altmış səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Yetmiş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Yetmiş iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Yetmiş dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Yetmiş altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Yetmiş səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Səksən</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Səksən iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Səksən dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Səksən altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Səksən səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Doxsan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Doxsan iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Doxsan dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Doxsan altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Dozsan səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Yüz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Yüz iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Yüz dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Yüz altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Yüz səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Yüz on</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Yüz on iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Yüz on dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Yüz on altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Yüz on səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Yüz iyirmi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Yüz iyirmi iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Yüz iyirmi dörd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Yüz iyirmi altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Yüz iyirmi səkkiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Bir yüz və Dixsan iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>İki yüz əlli altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR həcmi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Qrafik Prosessor istehsalçısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Qrafik Prosessor növü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL müştəri APİ-ləri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL versiyası</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Naməlum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Avadanlıq sinfi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>Mərkəzi Prosessor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Mərkəzi Orosessor tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Ana plata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Ana plata tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Yaddaş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Yaddaş tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Saxlama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Disk tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Sürücün bərpa etmək mümkün olmadı!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Yenidən cəhd edin və ya bizə rəy bildirin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Sürücünün eht. nüsxəsini saxlamaq mümkün olmadı!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Ekran uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Qrafik Prosessor tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Monitor tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Şəbəkə uzlaşdırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Şəbəkə uzlaşdırıcısı tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Səs uzlaşdırıcısı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Səs cihazı tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Bluetooth cihazı tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Digər PCİ qurğular</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Başqa PCİ qurğuları tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Güc</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Batareya tapılmadı</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Səs uzlaşdırıcısı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Səs cihazı tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Bluetooth cihazı tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Digər PCİ qurğular</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Başqa PCİ qurğuları tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Güc</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Batareya tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Klaviatura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Klaviatura tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Siçan</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Siçan tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Printer</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Printer tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Kamera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Kamera tapılmadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>CD-ROM tapılmadı</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Siçan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Siçan tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Printer tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Kamera tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM tapılmadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Digər cihazlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Başqa cihazlar tapılmadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Massiv göstəricisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Formfaktor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Ayarlamaq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Yuva aşkarlayıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Növ təfərrüatları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Hissə nömrəsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Dərəcə</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Yaddaş texnologiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Yaddaşın işləmə rejimi imkanı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Mikroproqram versiyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Modul istehsalçısı kimliyi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Modulun məhsul İD-si</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Yaddaş alt sistem nəzarətçisi məlumatları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Yaddaş alt sistem nəzarətçisinin İD-si</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Dəyişməz ölçü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Dəyişkən ölçü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Keş ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Məntiqi ölçü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>düym</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Tarix</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>tərəflər</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>kanal məlumatı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>məntiqi sektor ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sektor ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometriya (Məntiqi)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Cihaz idarəetməsi</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Cihaz İdarəetməsi avadanlıq haqqında məlumatlara baxmaq və cihazları idarə etmək üçün lazımlı bir vasitədir.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Yeni sürücülər əlçatandır! Onları indi quraşdırın və ya yeniləyin.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Baxış</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Alt qovluqlar daxil</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Sürücüləri bu yolda axtarın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 sürücü yenilənmələri əlçatandır</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Yoxlanılma vaxtı: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>%1 üçün sürücülər endirilir...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Endirmə sürəti: %1 Endirildi: %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>%1 üçün sürücülər quraşdırılır...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 sürücü quraşdırıldı, %2 sürücü alınmadı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 sürücüquraşdırıldı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Sürücülərin quraşdırılması baş tutmadı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Şəbəkə xətası. Yenidən qoşulur...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Endirmə srəti: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Sürücüləriniz köhnəlib</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Bütün sürücülərin ehtiyyat nüsxəsi saxlanılıb</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Cəmi %1 sürücü, bunlardan %2 sürücünün eht. nüsxəsi saxlanıldı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Eht. nüsxəsi saxlanıla biləcək %1 sürücü var, bunu dərhal etmək tövsiyyə olunur</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Eht. nüsxəsi saxlanıla biləcək %1 sürücünüz var</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>%1 sürücünün eht. nüsxəsi saxlanılır, cəmi %2 sürücü var</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Eht. nüsxəsi saxlanılır: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 sürücünün eht. nüsxəsi saxlanıldı, %2 sürücü mümkün olmadı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Sürücülərin eht. nüsxəsini saxlamaq mümkün olmadı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 sürücünün eht. nüsxəsi saxlanıldı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Bərpa edilə biləcək %1 sürücünüz var</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Bərpa ediləcək sürücünü seçin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Sürücü bərpa olunur...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Bərpa olunur: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>yenidən başladın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Sürücülərin işə düşməsi üçün lütfən %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Eht. nüsxə yoluna baxmaq</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Hamısının eht. nüsxəsini saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>rəy göndərin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Lütfən yenidən cəhd edin və ya bizə %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Hamısını quraşdırın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Yenidən axtarılsın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Sürücülər axtarılır, lütfən gözləyin...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>%1 axtarılır</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Axtarış baş tutmadı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>İnternet bağlantısı əlçatmazdır</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>İnternet bağlantınızı yoxlayın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Lütfən yenidən axtarın edin və ya bizə %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Sürücü quraşdırılır, indi çıxsanız quraşdırma pozulacaq.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Çıxmaq istədiyinizə əminsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Çıxış</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Sürücülərin eht. nüsxəsini saxlayırsınız, çıxış etsəniz bu əməliyyat yarımçıq qalacaq.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Sürücüləri bərpa edirsiniz, çıxış etsəniz bu əməliyyat yarımçıq kəsiləcək.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Sürücü faylları alına bilmədi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Yeniləmə</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Eht. nüsxə saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Bərpa etmək</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Quraşdırın</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Təzələmək</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Sürücüləri yeniləyin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Sürücüləri silin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Kompyuteri ayıltmağa ona icazə verin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Aktiv etmək</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Təzələmək</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>İxrac</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Söndürmək</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Əlçatmaz</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Yerli qovluğu seçin</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Yüklənir...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bg.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bg.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bg">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Обратна връзка</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Да</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Повече</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Известяване за мрежа</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Повторно инсталиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Повече</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Свиване</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Недостъпно</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Име на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Чип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Ревизия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Адрес на паметта</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Недостъпно</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Сет на чипове</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Псевдоним</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Максимална мощност</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Версия на драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Информация за шината</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Логично име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>Адрес MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Недостъпен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Информация за шината</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Максимална мощност</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Недостъпен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Идентификатор на процесора</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>Идентификатор на ядрото</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Потоци</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>БогоМИПС</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Архитектура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Семейство процесор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Процесор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Ядро(а)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Виртуализация</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Флагове</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Разширения</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 кеш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 кеш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i кеш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d кеш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Стъпка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Максимална скорост</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Провайдер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Графична памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Физически ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Адрес на паметта</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>И/О порт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Информация за шина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Максимална разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Минимална разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Текуща разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Цифров изход</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Изход за екран</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Недостъпен</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Информация за шина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Максимална мощ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Серийен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Недостъпен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Интерфейс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Информация за шина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Максимален ток</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Недостъпен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Обобщение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>Процесор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Брой процесори</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Майка-плата</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Адаптер за дисплей</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Адаптер за звук</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Съхранение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Други PCI устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Аккумулатор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Мрежов адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Мишка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Клавиатура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Принтер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Други устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ОС</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Размер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Общо ширина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Локатор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Серийен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Настроен напрежение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Максимално напрежение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Минимално напрежение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Настроена скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Ширина на данни</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Вход за изображение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Тип интерфейс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Поддръжка на разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Текущо разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Соотношение на изображение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Основен екран</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Размер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Серийен номер</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Информация за шина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Сървър</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Версия на сървъра</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Максимална скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Скорост на преговор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Мултикаст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Връзка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Задължителност</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>ИП</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Фирмвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Дуплекс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Разпространение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Автоматично споразумение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Адрес на паметта</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ИРК</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>Адрес на MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Логически име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Недостъпен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Провайдер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Информация за шина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Вход/изход</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ИРК</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Задължителност</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Сървър</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Провайдер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Информация за шина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Пилот</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Максимална мощност</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Серийен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Недостъпен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Серийен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Вид</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Състояние</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Капацитет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Напрежение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Слот</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Проектиран капацитет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Проектирано напрежение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>Версия SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>Серийен номер SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>Дата на производство SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>Химия SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Температур</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Серийен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Споделено</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Състояние</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Тип интерфейс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Производител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Вид носител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Размер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Версия на фир софтуер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Сериен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Интерфейс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Скорост на въртене</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Недостъпно</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Изберете драйвер за актуализация</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Няма намерени драйвери в този каталог</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Зареждане на информация за аудио устройство...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Зареждане на информация за BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Зареждане на информация за CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Зареждане на информация за операционната система...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Зареждане на информация за процесор...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Зареждане на информация за други устройства...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Зареждане на информация за енергия...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Зареждане на информация за принтер...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Зареждане на информация за мишка...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Зареждане на информация за мрежовия адаптер...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Недостъпно</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Недостъпно</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Информация за устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Покажи кратки пътечници</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Затвори</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Помощ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Копиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Експортиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Обновяване</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Управител на устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Хардуер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Обзор</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Адаптер за дисплей</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Мрежов адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Батерия</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Повече</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Версия на платформата за драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Драйвери, които могат да бъдат резервирани</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Резервирани драйвери</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Обновяване</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Отказ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Следващ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Устройството ще бъде недостъпно след демонтирането на драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Демонтиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Демонтиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Обновяване е успешно</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Демонтирането е успешно</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Актуализацията се провали</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Изтриването се провали</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Следващ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Избраната папка не съществува, моля, изберете отново</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Актуализиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Предишно</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Повреден пакет</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Несъответна архитектура на пакета</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Избраното файл не съществува, моля, изберете отново</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Не е драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Не може да се инсталира - няма цифров подпис</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Неизвестна грешка</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Драйверният модул не е намерен</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Невалиден модул</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Драйверният модул има зависимости</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Инсталиране на драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Резервно копие на драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Възстановяване на драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Обратна връзка</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Нямате драйвери за възстановяване, моля, направете резервно копие първо</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Отидете към резервното копие на драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Версия на резервното копие</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Възстановими драйвери</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Обновяване</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Експорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Обобщение</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Инсталиране на драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Резервно копие на драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Възстановяване на драйвер</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Неуспешно включване на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Неуспешно изключване на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Неуспешно изключване на устройството: не може да се получи серийният номер на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Актуализирай драйверите</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Демонтирай драйверите</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Обнови</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Експортирай</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Копирай</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Обобщение</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Обнови</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Експортирай</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Копирай</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Включи</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Актуализирай драйверите</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Демонтирай драйверите</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Разрешаване на включването на компютъра</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Изключи</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Неуспешно изключване на устройството: не може да се получи серийният номер на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Неуспешно изключване на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Неуспешно включване на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Актуализирай драйверите</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Демонтирай драйверите</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Подпредставител</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Подустройство</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Статус на драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Команда за активиране на драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Статус на конфигурацията</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>забавяне</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Физически</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Обработчици</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Бус</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Информация за BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Информация за основна плоча</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Информация за системата</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Информация за касета</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Физическо масив за памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Дата на излизане</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Адрес</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Размер на изпълнение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Размер на ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Характеристики</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Ревизия на BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Ревизия на софтуер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Име на продукт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Серийен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Етикет на актив</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Възможности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Разположение в касета</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Ръчка на касета</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Съдържащи обектни ръчка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Вид на събуждане</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Номер на SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Фамилия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Заключение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Състояние на стартиране</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Състояние на източника на енергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Термично състояние</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Статус на сигурността</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Информация за OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Височина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Брой кабели за енергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Съдържащи се елементи</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Разположение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Вид корекция на грешки</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Максимална капацитет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Ръчка за информация за грешка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Брой устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>Размер на BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Дата на излизане</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Име на платата</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>Версия на SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Формат на описанието на езика</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Инсталирани езикове</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Текущо инсталиран език</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>Адрес BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Вид пакет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Политика за връзка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Режим на връзка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Клас</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Класове на услуги</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Клас на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Версия на HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Версия на LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Подверсия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Сериен номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>продукт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>описание</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Включено</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Откриваемо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Парируемо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Откриване</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Модули за драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Файл на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Файлове на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Номер на устройството</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Приложение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>статус</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>логично име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>версия на ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Изпълнител на CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Архитектура на CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Вариант на CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>част от ЦП</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Ревизия на CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Един</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Два</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Девет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Десет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Дванадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Четиринадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Шестнадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Осемнадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Двадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Двадесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Двадесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Двадесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Двадесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Тридесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Тридесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Тридесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Тридесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Тридесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Четиридесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Четиридесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Четиридесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Четиридесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Четиридесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Петдесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Петдесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Петдесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Петдесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Петдесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Шестдесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Шестдесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Шестдесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Шестдесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Шестдесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Седемдесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Седемдесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Седемдесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Седемдесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Седемдесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Осемдесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Осемдесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Осемдесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Осемдесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Осемдесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Деветдесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Деветдесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Деветдесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Деветдесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Деветдесет и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Единствен стоти</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Единствен стоти и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Единствен стоти и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Единствен стоти и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Единствен стоти и осем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Единствен стоти и десет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Единствен стоти и дванадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Единствен стоти и четирнадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Единствен стоти и шестнадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Единствен стоти и осемнадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Единствен стоти и двадесет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Единствен стоти и двадесет и две</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Единствен стоти и двадесет и четири</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Единствението и дванайсети</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Единствението и дванайсети</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Единствението и деветдесет и дванайсет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Двайствението и петдесет и шест</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Капацитет на GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Производител на GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Тип на GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Версия на EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL клиентски API</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Версия на GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Версия на GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Неизвестен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Уникален</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Клас на хардуера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>Процесор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Няма намерен процесор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Маймърборд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Няма намерен маймърборд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Няма намерена памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Съхранение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Няма намерен диск</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Възстановяването на драйвера е провалено!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Моля, опитайте отново или ни дайте обратна връзка</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Резервното копие на драйвера е провалено!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Адаптер за дисплей</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Няма намерен GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Няма намерен монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Мрежови адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Не е намерен мрежови адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Звукови адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Не е намерено аудио устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Не е намерено Bluetooth устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Други PCI устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Не са намерени други PCI устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Енергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Не е намерена батерия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Клавиатура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Не е намерена клавиатура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Миш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Не е намерен миш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Принтер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Не е намерен принтер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Не е намерена камера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Не е намерен CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Други устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Не са намерени други устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Масив Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Формат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Сет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Локатор на банка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Детайли за тип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Номер на детайл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Ранк</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Меморија технологија</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Капацитет на режим на работа с памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Версия на софтуерен развой</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ИД на производителя на модул</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ИД на продукта на модул</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ИД на производителя на контролер на подсистемата за памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ИД на продукта на контролер на подсистемата за памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Размер на непроменяема памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Размер на променяема памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Размер на кеш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Логичен размер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>инч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Дата</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>иопорт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>мрежа</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>батерия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>нативен път</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>източник на енергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>обновен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>има история</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>има статистика</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>възобновяем</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>състояние</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>уровень на предупреждение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>енергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>енергия празна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>енергия пълна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>енергия пълна в проекция</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>енергия във скорост</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>напрежение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>процент</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>технология</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>име на иконата</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>онлайн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>версия на демона</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>на батерия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>капакът е затворен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>капакът е наличен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>критична операция</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>копии</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>отказ на задача след</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>задържане до</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>приоритет на задача</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>време за промяна на маркера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>брой на страниците</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ориентация, изисквана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>режим за цвят на принтера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>принтерът приема задачи</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>принтерът е споделен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>принтерът е временен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>производител и модел на принтера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>време за промяна на състоянието на принтера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>причини за състоянието на принтера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>тип на принтера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI на принтера, поддържан</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>странни</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>информация за шина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>размер на логическите сектори</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>размер на секторите</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ИД</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Геометрия (логическа)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Управител на устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Управител на устройства е удобен инструмент за преглед на информацията за хардуер и управление на устройствата.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Нови драйвери са налични! Инсталирайте или актуализирайте ги веднага.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Преглед</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Включете подпапки</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Търсете драйвери в този път</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 драйвера са налични за актуализация'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Време на проверка: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Сваляне на драйвери за %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Скорост на сваляне: %1 Сваляни %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Инсталиране на драйвери за %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 драйвера са инсталирани, %2 драйвера са се провалили'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 драйвера са инсталирани'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Неуспешно инсталиране на драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Мрежова грешка. Повторно свързване...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Скорост на сваляне: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Вашите драйвери са актуални</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Всички драйвери са били архивирани</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Общо %1 драйвера, от които %2 са били архивирани</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Имате %1 драйвера, които могат да бъдат архивирани, препоръчително е да го направите веднага</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Имате %1 драйвера, които могат да бъдат архивирани</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Архивиране на %1 драйвер, общо %2 драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Архивиране: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 драйвера са архивирани, %2 драйвера са се провалили'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Неуспешно архивиране на драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 драйвера са архивирани'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Имате %1 драйвера, които могат да бъдат върнати</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Моля, изберете драйвер за връщане</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Драйверът се възстановява...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Възстановяване: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>преподреждане</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Моля, %1 за да влезнат в сила инсталираните драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Погледнете пътя към резервната копия</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Резервно копиране на всичко</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>предадете обратна връзка</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Моля, опитайте отново или %1 до нас</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Инсталиране на всичко</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Сканиране отново</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Отказ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Сканиране на драйвери за хардуерни устройства, моля, изчакайте...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Сканиране на %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Сканирането е провалено</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Мрежата не е достъпна</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Моля, проверете вашата мрежова връзка</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Моля, сканирайте отново или %1 до нас</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Инсталирате драйвер, който ще бъде прекъснат, ако излезете.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Сигурни ли сте, че искате да излезете?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Изход</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Отказ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Резервирате драйвери, което ще бъде прекъснато, ако излезете.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Възстановявате драйвери, което ще бъде прекъснато, ако излезете.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Устройство за изображения</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Адаптер за видео</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Звукова карта</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Мрежов адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Безжичен мрежов адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Инсталацията е успешна</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Инсталацията се провали</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Сваляне</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Инсталация</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Не е инсталиран</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Стар</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Чакане</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Не е архивиран</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Архивиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Архивирането се провали</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Архивирането е успешно</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Възстановяване</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Неизвестна грешка</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Грешка в мрежата</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Отменено</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Не може да се получи файловете за драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Актуализиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Архивиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Възстановяване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Инсталиране</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Обновяване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Експорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Актуализирай драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Деинсталирай драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Разрешете му да възбуди компютъра</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Включване</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Обновяване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation> Експорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Копиране</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Изключване</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Недостъпно</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Моля, изберете локална папка</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Зареждане...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bn.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bn.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bn">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>okie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>ফেডব্যাক</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>okie (button)</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">আরও</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">ক্লেপ্ট</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>আরও</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>আরও</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>ক্লেপ্ট</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>আরও</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>ক্লেপ্ট</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>দাখিল না করা</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>স্পেক্ট্রাল নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>ব্যান্ডার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>চিপ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>ক্যাপাবিলিটি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>ম৉ডিউল অ্যালিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ফিজিক্যাল আইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>সিস্যাস_ফিস_প্যাথ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>বর্ণনা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>রিভিজন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>কার্নেল মোড ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>মেমরি ঠিকানা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>আইরিজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>অপারেটিভ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>দেরিতে</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>ব্যাংক্স্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>ভার্সিয়ন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>চিপসেট</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>আইলিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>ব্যাংক্স্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>ভার্সিয়ন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>মডেল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>মোডিউল আইলিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ফিজিক্যাল ইড</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>গতিবেগ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>মেক্সিমাল পাউর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>ড্রাইভার ভার্সিয়ন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>ক্যাপাবিলিটি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>বাস ইনফো</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>লজিকাল নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>ম্যাক অ্যাড্রেস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>অপারেটিভ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>বন্ধ করুন</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>বিক্রেতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>মডেল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>বৈদ্যকি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>বাস অর্থনীতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>ক্ষমতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>মৌলিক শক্তি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>গতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>মডুল অ্যালিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>বাস্তব আইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>অপরিচিত</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>বন্ধ করুন</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>বিক্রেতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU আইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>কর আইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>লাইন্স</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>স্ট্যাক অর্থনীতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU পরিবার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>মডেল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>প্রসেসর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>কর (সাই)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>ভিত্তিবিশীথকতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>ফ্যাল্গস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>একstenশনস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 কেশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 কেশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 কেশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i কেশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d কেশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>স্টেপিং</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>গতিবেগ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>মেক্সিমাল গতিবেগ</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>বিক্রাতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>মডেল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>ভাইজন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>গ্রাফিকস মেমরি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>মোডিউল অলিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ফিজিক্যাল আইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>মেমরি আইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>আইও পোর্ট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>বাস ইনফো</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>মেক্সিমাল রেজুল্যোলশন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>মিনিমাল রেজুল্যোলশন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>বর্তমান রেজুল্যোলশন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>বর্ণনা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
-        <translation type="unfinished"/>
+        <translation>ডিপি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
-        <translation type="unfinished"/>
+        <translation>ইডিপি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
-        <translation type="unfinished"/>
+        <translation>এইডিএমআই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
-        <translation type="unfinished"/>
+        <translation>ভিজেএআই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
-        <translation type="unfinished"/>
+        <translation>ডিভিআই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>ডিজিটাল আউটপুট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
-        <translation type="unfinished"/>
+        <translation>প্রদর্শন আউটপুট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>ক্যাপাসিটিভিটি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>আইরিজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>অপরিচিত</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>বেন্ডার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>মডেল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>বাস ইনফো</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>মোডিউল আইলিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ফিজিক্যাল আইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>গতিবেগ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>ম্যাক্সিমাম পাউর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>ক্যাপাসিটিভিটি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>সিরিয়াল নম্বর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>অপরিচিত</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>ব্যবধান</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>ব্যাকার নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>মডেল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>নেটিভ্যাস্টি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>বাস ইনফোরমেশন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>মোডিউল অ্যালিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>বাস্তব ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>গতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>মেশামেশি তোলা বেস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>ক্যাপাসিটিভিটি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>অপরাধী</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>ব্যবধান</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>সম্পর্কিত বিবরণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>সিপি যুনিট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>সিপি যুনিট সংখ্যা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>মাতালোক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>মেমরি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>দৃশ্য প্রদর্শন অ্যাডপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>স্বর প্রদর্শন অ্যাডপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>স্টোরেজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>অন্যান্য PCI ডিভাইস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>ব্যাটারি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>ব্লুটিথ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>নেটওয়ার্ক এড্যাপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>মাউস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>কেয়বোর্ড</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>মনিটর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>প্রিন্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>ক্যামেরা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>অন্যান্য ডিভাইস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>ডিভাইস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>বিক্রেতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>ধরন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>গতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>মোট প্রস্থ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>লকেটর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>ক্রমিক নম্বর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>সংক্ষিপ্ত দাবিদানের বিদ্যুত</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>মৌলিক বিদ্যুতের বেশিরভাগ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>মৌলিক বিদ্যুতের কমতমিক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>সংক্ষিপ্ত গতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>ডেটা প্রস্থ</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>বিক্রা�ter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>প্রকার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>প্রদর্শন ইনপুট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>সূচনার ধরন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>সমর্থিত রেসলুশন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>বর্তমান রেসলুশন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>প্রদর্শন অনুপাত</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>প্রধান প্রদর্শক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>সিরিয়াল নম্বর</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>বিক্রাতা</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>প্রকার</translation>
     </message>
@@ -1115,32 +1065,32 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>লেটেনসি</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
         <source>IP</source>
-        <translation type="unfinished"/>
+        <translation>আইপি</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
         <source>Firmware</source>
-        <translation type="unfinished"/>
+        <translation>ফায়ারওয়ার্স</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
         <source>Duplex</source>
-        <translation type="unfinished"/>
+        <translation>ডুপ্লেক্স</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
         <source>Broadcast</source>
-        <translation type="unfinished"/>
+        <translation>ব্রোডকাস্ট</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
         <source>Auto Negotiation</source>
-        <translation type="unfinished"/>
+        <translation>অটো নোটিশিয়েশন</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
@@ -1203,7 +1153,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
         <source>Input/Output</source>
-        <translation type="unfinished"/>
+        <translation>ইনপুট/আউটপুট</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
@@ -1218,7 +1168,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>লেটেনসি</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>ব্যবসায়িক দোকান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>মিডিয়া ধরন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>ভার্সন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>ক্যাপাসিটিভিটি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>মোডিউল অ্যালিয়াস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>বাস্তব ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>ফার্মওয়েরিয়াস ভার্সন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>গতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>বর্ণনা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>ক্রমিক নম্বর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>সূচনা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>পূর্ণ চালনা হার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>অপরিচিত</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>আপডেট জন্য একটি ড্রাইভার নির্বাচন করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>এই ফোল্ডারে কোনো ড্রাইভার পাওয়া যায় নি</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>স্বর ডিভাইস তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>অপারেটিং সিস্টেম তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>CPU তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>অন্যান্য ডিভাইস তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>পার্শ্ব তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>প্রিন্টার তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>মৌস তথ্য লোড করছে...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>নেটওয়ার্ক এডাপ্টার তথ্য লোড করছে...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>দেবৃত্ত করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>অপারেটিভ</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>দেবৃত্ত করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>অপারেটিভ</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>ডিভাইস তথ্য</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>ক্লিক করার জন্য সরাসরি কমান্ড প্রদর্শন করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>বন্ধ করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>বাহিনী</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>কপি করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>সিস্টেম</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>বাহিনী নেওয়া</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>পরিবর্তন করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>ডিভাইস ম্যানেজার</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>হ্যার্ডওয়্যার</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>মনিটর</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>বোঝাই</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>প্রদর্শন এডাপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>সিউইচি</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>নেটওয়ার্ক এডাপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>ব্যাটারি</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>আরও</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>বর্তমান ভার্সন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>ড্রাইভার প্ল্যাটফর্ম ভার্সন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>স্ট্যাটাস</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>অ্যাকশন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>সংরক্ষণযোগ্য ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>সংরক্ষিত ড্রাইভার</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>আপডেট হচ্ছে</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>বাতিল</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>পরবর্তী</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>বিজ্ঞাপন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>ড্রাইভার অনু�্রমে অটোমেটিক বাদ দিলে ডিভাইসটি নিরাপ্ত হবে</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>অটোমেটিক বাদ দিন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>অটোমেটিক বাদ দিচ্ছে</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>আপডেট সফল</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>অনুক্রমে অটোমেটিক বাদ দেওয়া সফল</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>@update বাড়িনি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>@uninstallation বাড়িনি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>স্বাস্থ্যমান</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>পরবর্তী</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>পছন্দের ফোল্ডার নেই, আবার নির্বাচন করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>আপডেট</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>পূর্ববর্তী</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>বিচ্ছিন্ন প্যাকেজ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>মেটা-প্যাকেজ শৈলী মিলিয়ে যায়নি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>পছন্দের ফাইল নেই, আবার নির্বাচন করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>এটি একটি ড্রাইভার নয়</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>ইনস্টল করতে অক্ষম - ডিজিটাল সাইনচার্ট নেই</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>অজানা ত্রুটি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>ড্রাইভার মোডিউল পাওয়া যায়নি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>মোডিউল ফর্ম্যাট অক্ষম</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>ড্রাইভার মোডিউল সম্ভাব্যতা রয়েছে</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>সেঞ্জের নাম</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>প্রার্থিত সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>স্থিতিস্থাপক</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>পদক্রম</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>নতুন সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>বর্তমান সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>মাকার ড্রাইভার (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>পুরোনো ড্রাইভার (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>সর্বশেষ ড্রাইভার (%1</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>ড্রাইভার ইnstall</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>ড্রাইভার ব্যাকাপ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>ড্রাইভার রিস্টোর</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>মোটামোটি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>ফেডব্যাক</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>ব্যাকাপ করার আগে কোনো ড্রাইভার রিস্টোর করার জন্য নেই, প্রথমে ব্যাকাপ করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>ব্যাকাপ ড্রাইভার এ যাও</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>নাম</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>বর্তমান সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>ব্যাকাপ সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>পদক্রম</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>রিস্টোর করার ড্রাইভার</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>রিফ্রেশ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>eksport</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>সারাংশ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>ড্রাইভার ইnstall</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>ড্রাইভার ব্যাকাপ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>ড্রাইভার রিস্টোর</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>সেবার সক্ষম করার অসমর্থ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>সেবার অসক্ষম করার অসমর্থ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>অসক্ষম করার অসমর্থ: সেবার SN পেতে অসমর্থ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>ড্রাইভার আপডেট করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>ড্রাইভার অ্যান্স্টল করুন</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>রিফ্রেশ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>eksport</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>কopi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>পরিসংখ্যান</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>ব্যবহার করুন</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>পরিকল্পনাটি কম্পিউটারটি জাগাতে দাও</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>দেওয়া না হওয়া</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>ডিভাইসটি দেওয়া না হওয়া সম্ভব নয়: ডিভাইসের SN পাওয়া যায় নাই</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>ডিভাইসটি দেওয়া না হওয়া সম্ভব নয়</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>ডিভাইসটি ব্যবহার করার সম্ভব নয়</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>ড্রাইভার হাইপার উঠান</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>ড্রাইভার বাতিল করুন</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>সূচক প্রদাতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>সূচক ডিভাইস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>ড্রাইভার অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>ড্রাইভার স্ক্রিপ্ট কমান্ড</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>কনফিগ অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>লেটেন্সি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>ফিজিক্যাল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>সিস্টেম ফাইলসিস্টেম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>হ্যান্ডলারস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>প্রপ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>কি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>বৈদ্যকি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>বাস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS তথ্য</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>ভেস বোর্ড তথ্য</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>সিস্টেম তথ্য</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>চ্যাসিস তথ্য</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>বাস্তব মেমরি অ্যারে</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>প্রকাশ তারিখ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>ঠিকানা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>রানটাইম সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>প্রযুক্তি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS পরিবর্তন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>ফাইরওয়্যার পরিবর্তন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>পণ্যের নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>সিরিয়াল নম্বর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>আসেট ট্যাগ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>ফিচারস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>চ্যাসিসে অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>চ্যাসিস হ্যান্ডল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>প্রকার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>বন্ধনীতুলিত পদার্থের হাউজিং</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>ছাইপাড়ার ধরন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU নম্বর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>গোষ্ঠী</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>লক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>প্রারম্ভিক অবস্থার অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>বিদ্যুৎ সরবরাহের অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>ঘর্ম অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>সুরক্ষার অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM তথ্য</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>উচ্চতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>বিদ্যুত ফিল্ডের সংখ্যা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>বন্ধনীতুলিত উপাদান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>স্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>ভুল সংশোধনের ধরন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>মৌলিক ক্ষমতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>ভুলের তথ্য হাউজিং</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>সেট্যাইজেড ডিভাইসের সংখ্যা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>প্রকাশিত তারিখ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>বোর্ডের নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>ভাষার বর্ণনার আকার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>স্থানান্তর্যমীয় ভাষা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>বর্তমানে ইnstalled ভাষা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD ঠিকানা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>প্যাকেট ধরন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>সংযোগ নীতি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>সংযোগ অ্যাডিম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>বর্গ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>সেবা বর্গ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>ব্যাক্তি বর্গ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>সূচনা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>ব্যাক্তি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>সিরিয়াল ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>প্রোডাক্ট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>বর্ণনা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>পাবলিশেড</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>অনুসন্ধানশীল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>সংযোজনশীল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>মডিউলাইনাস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>অনুসন্ধান করছে</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>ড্রাইভার মডিউলস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>ব্যাক্তি ফাইল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>ব্যাক্তি ফাইলস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>সেটেলিং নম্বর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>প্রযোগ্যস্ত প্রোগ্রাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>অবস্থান</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>লজিকাল নাম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>অন্সি ভারীসন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU অনুযায়ী প্রকাশক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU অর্কাইটেচার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU ব্যারিয়েন্ট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU অংশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU পরিবর্তন</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>এক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>দুই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>চার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>ছয়</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>আট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>নয়</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>দশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>বার্ষিক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>চৌদ্দ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>ছিঙ্কাশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>বার্ষিকী</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>বৈঠক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>বৈঠক দুই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>বৈঠক চার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>বৈঠক ছয়</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>২৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>৩০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>৩২</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>৩৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>৩৬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>৩৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>৪০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>৪২</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>৪৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>৪৬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>৪৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>৫০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>৫২</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>৫৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>৫৬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>৫৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>৬০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>৬২</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>৬৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>৬৬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>৬৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>৭০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>৭২</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>৭৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>৭৬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>সাতাঃ৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>আঠাঃ০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>আঠাঃ২</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>আঠাঃ৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>আঠাঃ৬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>আঠাঃ৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>ঘাড়াঃ০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>ঘাড়াঃ২</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>ঘাড়াঃ৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>ঘাড়াঃ৬</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>ঘাড়াঃ৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>এক হাজার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>এক হাজার এবং দুই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>এক হাজার এবং চার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>এক হাজার এবং ষোল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>এক হাজার এবং আঠাঃ০</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>এক হাজার এবং দশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>এক হাজার এবং বার্ষিকী</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>এক হাজার এবং চারাঃ৪</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>এক হাজার এবং ষোল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>এক হাজার এবং আঠাঃ৮</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>এক হাজার এবং দুইশ শত</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>এক হাজার এবং দুইশ শত এবং দুই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>এক হাজার এবং দুইশ শত এবং চার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>এক হাজার এবং দুইশ শত এবং ষোল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>এক হUNDRED আনD টWENTY-EIGHT</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>এক হUNDRED আনD নINETY-TWO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>দুই হUNDRED আND ফIFTY-SIX</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR কপাসিটি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU প্রদর্শক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU ধর্ম</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL ক্লিয়েন্ট API</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL সংস্করণ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>অজানা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>অনন্য</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>এমএসসি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>বাহ্যিক সুবিধার শ্রেণি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>CPU খুঁজে পাওয়া যায় নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>মাথাবোর্ড</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>মাথাবোর্ড খুঁজে পাওয়া যায় নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>মেমরি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>মেমরি খুঁজে পাওয়া যায় নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>স্টোরেজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>ডিস্ক খুঁজে পাওয়া যায় নি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>ড্রাইভার পুনরায় সংরক্ষণ সমাধান হয়নি</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>আবার চেষ্টা করুন বা আমাদের সাথে মন্তব্য দিন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>ড্রাইভার সংরক্ষণ সমাধান হয়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>প্রদর্শন অ্যাডপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>�োনো GPU পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>মনিটর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>কোনো মনিটর পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>নেটওয়ার্ক অ্যাডপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>কোনো নেটওয়ার্ক অ্যাডপ্টার পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>স্বর অ্যাডপ্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>কোনো স্বর ডিভাইস পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>ব্লুটিথ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>কোনো ব্লুটিথ ডিভাইস পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>অন্যান্য PCI ডিভাইস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>অন্যান্য PCI ডিভাইস পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>পাবলিক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>কোনো ব্যাটারি পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>কেয়বোর্ড</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>কোনো কেয়বোর্ড পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>মাউস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>কোনো মাউস পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>প্রিন্টার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>কোনো প্রিন্টার পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>ক্যামারা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>কোনো ক্যামারা পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>কোনো CD-ROM পায়নি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>অন্যান্য ডিভাইস</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>অন্যান্য ডিভাইস পাওয়া যায় নাই</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>মাস্টার হ্যান্ডল</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>সীমাবদ্ধ আকার</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>সেট</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>ব্যান্ক লোকেটর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>প্রকার বিস্তারিত</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>অংশের নম্বর</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>র্যান্ক</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>মেমরি টেকনোলজি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>মেমরি কাজের মডেল ক্ষমতা</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>ফাইরওয়ার্ড সংস্করণ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>মোডিউল প্রস্তুতকারক ইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>মোডিউল পণ্য ইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>মেমরি সাবসিস্টেম কন্ট্রোলার প্রস্তুতকারক ইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>মেমরি সাবসিস্টেম কন্ট্রোলার পণ্য ইডি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>নন-ভিলেবল সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>ভিলেবল সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>কেচ সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>লজিকাল সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>ইঞ্চি</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>তারিখ</translation>
     </message>
@@ -3692,313 +3453,294 @@
         <translation>পাশ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>বাস ইনফো</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>লজিকাল সেক্টর সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>সেক্টর সাইজ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>GUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>জেমিট্রি (লজিকাল)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>ডিভাইস ম্যানেজার</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>ডিভাইস ম্যানেজার হার্ডওয়্যারের তথ্য দেখতে এবং ডিভাইস ম্যানেজ করার জন্য একটি উপযোগী উপকরণ।</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>নতুন ড্রাইভার উপলব্ধ! তাদের এখন ইনস্টল বা আপডেট করুন।</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>দেখুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>সাবফোল্ডার অন্তর্ভুক্ত করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>এই পথে ড্রাইভার খোঁজুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 ড্রাইভার আপডেট উপলব্ধ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>পরীক্ষা সময়: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>%1 জন্য ড্রাইভার ডাউনলোড করা হচ্ছে...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>ডাউনলোড গতি: %1 ডাউনলোড করা: %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>%1 জন্য ড্রাইভার ইনস্টল হচ্ছে...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 ড্রাইভার ইনস্টল হয়েছে, %2 ড্রাইভার ইনস্টল করতে ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 ড্রাইভার ইনস্টল হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>ড্রাইভার ইনস্টল করতে ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>নেটওয়ার্ক ত্রুটি। আবার কনেকশন স্থাপন হচ্ছে...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>ডাউনলোড গতি: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>আপনার ড্রাইভার অপ্টেড হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>সব ড্রাইভার সংরক্ষিত হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>%1 ড্রাইভারের মোট, অন্তর্ভুক্ত করা হয়েছে %2</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>আপনার মোট %1 ড্রাইভার সংরক্ষিত করা যায়, তাই তা তখনই সংরক্ষণ করা উপযুক্ত</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>আপনার মোট %1 ড্রাইভার সংরক্ষিত করা যায়</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>%1 ড্রাইভার সংরক্ষণ হচ্ছে, মোট %2 ড্রাইভার</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>সংরক্ষণ হচ্ছে: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 ড্রাইভার সংরক্ষিত হয়েছে, %2 ড্রাইভার সংরক্ষণ করতে ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>ড্রাইভার সংরক্ষণ করতে ব্যর্থ হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 ড্রাইভার সংরক্ষিত হয়েছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>আপনার মোট %1 ড্রাইভার পুনরায় সংযোগ করা যায়</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>পুনরায় সংযোগ করতে একটি ড্রাইভার নির্বাচন করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>ড্রাইভার পুনরায় সংযোগ হচ্ছে...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>পুনরুদ্ধার করছি: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>পুনরায় শুরু করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>অ্যাস্টলাস ড্রাইভারগুলোর প্রভাব দেখার জন্য %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>ব্যাকাপ পথ দেখুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>সব ব্যাকাপ করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>আপনার মন্তব্য পাঠিজোন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>আবার চেষ্টা করুন বা %1 করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>সব ইনস্টল করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>আবার স্কান করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>বন্ধ করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>ডিভাইস ড্রাইভারগুলো স্কান করছে, একটু ক্ষমা চাইন্স...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>%1 স্কান করছে</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>স্কান অসফল হয়ে গেল</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>নেটওয়ার্ক উপযোগী নয়</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>আপনার নেটওয়ার্ক কনেকশনটি চে크 করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>আবার স্কান করুন বা %1 করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>আপনি একটি ড্রাইভার ইনস্টল করছেন, যা আপনি বের হলে অতিক্রান্ত হবে.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>আপনি কি বের হতে চান?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>বের হোন</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>বন্ধ করুন</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>আপনি ড্রাইভারগুলো ব্যাকাপ করছেন, যা আপনি বের হলে অতিক্রান্ত হবে.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>আপনি ড্রাইভারগুলো পুনরুদ্ধার করছেন, যা আপনি বের হলে অতিক্রান্ত হবে.</translation>
     </message>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>প্রতিবর্তন ডিভাইস</translation>
     </message>
@@ -4114,22 +3855,22 @@
         <translation>ড্রাইভার ফাইল পাওয়া ত্রাণ্ডিত</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>আপডেট</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>ব্যাকআপ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>রিস্টার্ব</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>ইনস্টল</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>দীক্ষতা করো</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>পুনরায় ছোট্ট করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>eksport করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>ড্রাইভার অপ্�дейট করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>ড্রাইভার অনিস্তল করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>কম্পিউটারটি উঠাতে দাও</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>ব্যবহার করুন</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>পুনরায় ছোট্ট করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>eksport করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>কপি করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>বন্ধ করুন</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>অপরিচিত</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>অনুগ্রহ করে একটি স্থানীয় ফোল্ডার বাছাই করুন</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>লোড হচ্ছে...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bo.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>གཏན་ཁེལ། </translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>སྨྲ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ། </translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">དེ་བས་མང་།</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">བསྡུ་བ།</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>དེ་བས་མང་།</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>དེ་བས་མང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>བསྡུ་བ།</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>དེ་བས་མང་།</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>བསྡུ་བ།</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>སྒྲིག་ཆས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>ཉིང་ལྷེབ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>བཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>ནང་གསོག་བྱེད་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>ཆད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>ཉིང་ལྷེབ་ཙུའུ།</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
-        <translation type="unfinished"/>
+        <translation>འགྲོ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>ནུས་ཆོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>སྒུལ་བྱེད་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>གཏན་ཚིགས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MACསྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>ནུས་ཆོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>སྒྲིག་གཅོད་ཆས།  ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ལྟེ་བ། ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>སྐུད་རིམ་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>གཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>ཁྱིམ་རྒྱུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>གཏན་ཚིགས་ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>ལྟེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>རྟོག་བཟོ་ཅན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>ཁྱད་གཤིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>རྒྱ་སྐྱེད་བཀའ་འདུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 འཚོ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3ཤོང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2ཤོང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1ཤོང་གསོག（བཀའ།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1ཤོང་གསོག（གཞི་གྲངས།）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>གོམ་བགྲོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>ཟློས་ཕྱོད་ཆེ་ཤོས།</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>འཆར་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>ནང་གསོག་བྱེད་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>I/Oམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>འབྱེད་ཕྱོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>འབྱེད་ཕྱོད་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>མིག་སྔའི་འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>ཕྱིར་འདྲེན་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>ཆད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>ནུས་ཆོད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>མཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>མ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>གློག་རྒྱུན་ཆེ་ཤོས། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>གནས་ཚུལ་རགས་བསྡུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>CPUགྲངས་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>མ་པང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>འཚམ་སྒྲིག་ཆས་མངོན་སྟོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>སྒྲ་ཟློས་འཚམ་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>གསོག་འཇོག་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>PCIསྒྲིག་ཆས་གཞན་དག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>གློག་རྫས། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>སོ་སྔོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>དྲ་བའི་འཚམ་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>ཙི་གུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>མཐེབ་གཞོང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>སྒྲིག་ཆས་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>པར་འདེབས་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>པར་རིས་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>སྒྲིག་ཆས་གཞན་དག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>བཀོལ་སྤྱོད་མ་ལག</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>སྤྱིའི་ཞེང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>འཇུག་ཤུར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>སྒྲིག་སྦྱོར་གློག་གནོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>གློག་གནོན་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>གློག་གནོན་ཆུང་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>སྒྲིག་སྦྱོར་ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>གཞི་གྲངས་ཞེང་ཚད།</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>ནང་འཇུག་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>མཐུད་སྣེའི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>རྒྱབ་སྐྱོར་ཐུབ་པའི་འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>མིག་སྔའི་འབྱེད་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>འཆར་བའི་བསྡུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>འཆར་ཆས་གཙོ་བོ། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>རིགས་གྲས།</translation>
     </message>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>བར་རྫས་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>བྱེད་ནུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>དཔེ་དུམ་གྱི་མིང་གཞན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>དངོས་ཁམས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>བརྟན་ཆས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>ཟློས་ཕྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>མཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>སྐོར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>གསར་སྒྱུར་བྱེད་དགོས་པའི་སྐུལ་བྱེད་བྱ་རིམ་འདེམས་དང་།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>བདམས་པའི་ཡིག་ཁུག་ལས་སྐུལ་བྱེད་ཡིག་ཆ་མ་རྙེད།</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>སྒྲ་ཟློས་སྒྲིག་ཆས་ཀྱི་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOSཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>སྡེར་སྐུལ་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>བཀོལ་སྤྱོད་མ་ལག་གི་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>ག་གཅོད་ཆས་ཀྱི་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>སྒྲིག་ཆས་གཞན་དག་གི་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>གློག་རྫས་ཀྱི་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>པར་འདེབས་ཆས་ཀྱི་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>ཙི་གུའི་ཆ་འཕྲིན་ཐོབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>དྲ་བའི་འཚམ་སྒྲིག་ཆས་ཀྱི་ཆ་འཕྲིན་ཐོབ་པ། </translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>སྒྲིག་ཆས་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>མྱུར་མཐེབ་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>རོགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>མ་ལག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>གསར་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>སྒྲིག་ཆས་དོ་དམ་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>མཁྲེགས་ཆས་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>སྐུལ་འདེད་དོ་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>སྒྲིག་ཆས་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>གནས་ཚུལ་རགས་བསྡུས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>འཚམ་སྒྲིག་ཆས་མངོན་སྟོན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>དྲ་བའི་འཚམ་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>གློག་རྫས། </translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>དེ་བས་མང་།</translation>
     </message>
@@ -1702,178 +1645,171 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>མིག་སྔའི་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྟངས་ཚོག་གི་པརྒྱུགས</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>བཀོལ་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>སྨྲ་བྱེད་བྱ་སོང་ཆོག་གྲུབ་སྨྲ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>སྨྲ་བྱེད་བྱས་གོང་གྲུབ་སྨྲ་བྱེད</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>གསར་སྒྱུར་བྱེད་བཞིན་པ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>རྗེས་མ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>དོ་སྣང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>མ་ལག་ཁྲོད་ནས་སྐུལ་བྱེད་བྱ་རིམ་འདི་བཤིག་རྒྱུ། བཤིག་རྗེས་སྒྲིག་ཆས་འདི་སྤྱོད་མི་རུང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>བཤིག་པ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>བཤིག་བཞིན་པ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>སྐུལ་བྱེད་བཤིག་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>སྐུལ་བྱེད་བཤིག་ཐུབ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>གཏན་ཁེལ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>རྗེས་མ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>བདམས་པའི་ཡིག་ཁུག་མི་འདུག་པས། ཡང་བསྐྱར་འདེམས་རོགས། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>སྔ་མ་དེ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>ཁུག་མའི་ཡིག་ཆ་འཕྲོ་བརླག་ཕྱིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>ཁུག་མའི་ཡིག་ཆ་དང་རྒྱུད་ཁོངས་ཀྱི་སྒྲོམ་གཞི་མི་མཐུན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>བདམས་པའི་ཡིག་ཆ་མི་འདུག་པས། ཡང་བསྐྱར་འདེམས་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>ཡིག་ཆ་འདི་ནི་སྐུལ་བྱེད་ཡིག་ཆ་མ་རེད། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>སྒྲིག་སྦྱོར་བྱེད་ཐབས་མེད། སྒྲིག་སྦྱོར་ཐུམ་ལ་ཨང་ཀིའི་མཚན་རྟགས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>མ་ཤེས་པའི་ནོར་འཁྲུལ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>སྒུལ་བྱེད་མ་དཔེ་དེ་ཉིད་མ་རྙེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>དཔེ་དུམ་རྣམ་གཞག་གོ་མི་ཆོད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>སྒུལ་བྱེད་མ་དཔེ་དེ་ཉིད་གཞན་གྱིས་བརྟེན་འདུག</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>སྒྲིག་ཆས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>པར་གཞི་སྒྲིག་འཇུག་བྱ་རུང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>བཀོལ་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>པར་གཞི་གསར་སྒྱུར་རུང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>མིག་སྔའི་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>སྐུལ་ཆས་སྒྲིག་འཇུག་རུང་བ།(%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>སྐུལ་ཆས་གསར་སྒྱུར་རུང་བ།(%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>སྐུལ་ཆས་གསར་སྒྱུར་བྱ་མི་དགོས།(%1)</translation>
     </message>
@@ -1939,132 +1870,126 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་འགེར</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྨྲ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྤྱིར</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>གཏན་ཁེལ། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>ཁ་གྲུབ་སྨྲ་བྱེད་མེད་པ་རེད། འགྲོ་བྱེད་བྱེད་ནས་སྨྲ་བྱེད་བྱེད་པ་གཉིས་བྱེད་བརྟེན་ན།</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>སྨྲ་བྱེད་གྲུབ་སྨྲ་བྱེད་ལ་གྱེར</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>སྨྲ་བྱེད་པའི་པརྒྱུགས</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>མིག་སྔའི་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>སྤྱིར་བྱེད་བྱ་སོང་ཆོག་གྲུབ་སྨྲ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>བཀོལ་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་འགེར</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>གསར་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>གནས་ཚུལ་རགས་བསྡུས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྨྲ་བྱེད</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྤྱིར</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>དགེ་བ་བཅོས་བྱེད</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>འགོ་སློང་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>སྤྱོད་མི་ཆོག་པ་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>སྒྲིག་ཆས་ཀྱི་རིམ་ཨང་ཐོབ་ཐབས་མི་འདུག་པས་སྤྱོད་མི་རུང་བ་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>སྐུལ་བྱེད་བཤིག་པ། </translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>གསར་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>གནས་ཚུལ་རགས་བསྡུས།</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>འགོ་སློང་བ།</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>གློག་ཀླད་སློང་ཆོག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>སྒྲིག་ཆས་ཀྱི་རིམ་ཨང་ཐོབ་ཐབས་མི་འདུག་པས་སྤྱོད་མི་རུང་བ་ཐུབ་མ་སོང་།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>སྤྱོད་མི་ཆོག་པ་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>འགོ་སློང་མི་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར། </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>སྐུལ་བྱེད་བཤིག་པ། </translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>བཟོ་མཁན་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>སྒྲིག་ཆས་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>སྒུལ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>སྒུལ་བྱེད་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>སྒུལ་བྱེད་སྐུལ་སློང་བཀའ་རྒྱ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>སྒྲིག་སྦྱོར་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>ནར་འགྱངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>ཐག་གཅོད་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>མ་སྐུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOSཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>མ་པང་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>མ་ལག་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>འཁོར་སྒམ་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>ནང་གསོག་འཇུག་ཤུར་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>ཡོངས་བསྒྲགས་བྱེད་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>འཁོར་རྒྱུག་ནང་གསོག་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROMཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>ཁྱད་གཤིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOSབཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>བརྟན་ཆས་བཟོ་བཅོས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>ཐོན་རྫས་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>རིམ་སྟར་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>རྒྱུ་ནོར་སྒྲིག་ཨང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>ཁྱད་ཆོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>འཁོར་སྒམ་ནང་གི་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>འཁོར་སྒམ་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>བྱ་ཡུལ་བྱ་རིམ་ཚུད་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>གཉིད་སད་པའི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKUཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>ཁྱིམ་རྒྱུད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>སྒོ་ལྕག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>འཕྲུལ་སྒོ་ཕྱེ་བའི་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>གློག་འདོན་པའི་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>དྲོད་འཐོར་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>བདེ་འཇགས་ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEMཆ་འཕྲིན། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>མཐོ་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>གློག་ཁུངས་སྐུད་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>ཡོད་པའི་སྒྲིག་ཆས་གྲངས་ཀ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>གནས་ས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>ནོར་བཅོས་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>ཤོང་ཚད་ཆེ་ཤོས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>ནོར་འཁྲུལ་ཆ་འཕྲིན་གྱི་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>གཱ་འཇུག་སའི་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>ཁྱབ་བསྒྲགས་བྱས་པའི་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>མ་པང་གི་མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOSཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>སྐད་བརྡ་ཞིབ་བརྗོད་རྣམ་བཞག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>སྒྲིག་སྦྱོར་བྱ་རུང་བའི་སྐད་བརྡའི་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>མིག་སྔའི་སྒྲིག་སྦྱོར་སྐད་བརྡ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>སོ་སྔོན་སྒྲིག་ཆས་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>གཞི་གྲངས་ཁུག་གི་རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>སྦྲེལ་མཐུད་དྲིད་ཇུས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>སྦྲེལ་མཐུད་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>ཞབས་ཞུའི་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>སྒྲིག་ཆས་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCIཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMPཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>པར་གཞི་ཡན་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>རིམ་སྟར་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>ཐོན་རྫས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>ཞིབ་བརྗོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>གློག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>ཤེས་རྟོགས་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>ཆ་འགྲིག་ཐུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>བཀའི་མིང་གཞན་སྒྲིག་བཀོད་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>འཚོལ་ཞིབ་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>སྒུལ་བྱེད་དཔེ་དུམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>སྒྲིག་ཆས་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>སྒྲིག་ཆས་ཡིག་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>སྒྲིག་ཆས་ཨང་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>ཉེར་སྤྱོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>ངང་ཚུལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>གཏན་ཚིགས་སྡོད་གནས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ANSIཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPUབྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPUགཞི་སྒྲོམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPUའགྱུར་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPUལྷུ་ལག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPUཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>རྐྱང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྤྱིར་བྱེད་མ་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>བཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>བཅུ་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>བཅུ་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>བཅུ་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>བཅོ་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>ཉི་ཤུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>ཉེར་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>ཉེར་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>ཉེར་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>ཕར་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>སུམ་ཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>སོ་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>སོ་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>སོ་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>སོ་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>བཞི་ཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>ཞེ་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>ཞེ་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>ཞེ་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>ཞེ་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>ལྔ་བཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>ང་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>ང་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>ང་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>ང་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>དྲུག་ཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>རེ་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>རེ་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>རེ་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>རེ་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>བདུན་ཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>དོན་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>དོན་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>དོན་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>དོན་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>བརྒྱད་ཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>གྱ་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>གྱ་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>གྱ་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>གྱ་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>དགུ་བཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>གོ་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>གོ་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>གོ་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>གོ་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>བརྒྱ་ཐམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>བརྒྱ་དང་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>བརྒྱ་དང་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>བརྒྱ་དང་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>བརྒྱ་དང་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>བརྒྱ་དང་བཅུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>བརྒྱ་དང་བཅུ་གཉིས། </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>བརྒྱ་དང་བཅུ་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>བརྒྱ་དང་བཅུ་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>བརྒྱ་དང་བཅོ་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>བརྒྱ་དང་ཉི་ཤུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>བརྒྱ་དང་ཉེར་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>བརྒྱ་དང་ཉེར་བཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>བརྒྱ་དང་ཉེར་དྲུག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>བརྒྱ་དང་ཉེར་བརྒྱད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>བརྒྱ་དང་གོ་གཉིས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>256</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDRཤོང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPUའདོན་སྤྲོད་བྱེད་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPUརིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGLམཐུད་སྣེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GLཔར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSLཔར་གཞི།</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>མི་ཤེས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>བརྟན་ཆས་རིགས་དབྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>ཐག་གཅོད་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>ཐག་གཅོད་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>མ་པང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>མ་པང་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>ནང་གསོག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>ནང་གསོག་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>གསོག་འཇོག་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>སྡུད་སྡེར་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>རེ་གཉིས་བྱེད་བརྟེན་ནས་སྨྲ་བྱེད་བྱེད་ན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྨྲ་བྱེད་མ་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>ཚོས་གྲུབ་སྨྲ་བྱེད་སྨྲ་བྱེད་བྱས་གོང་གི་གྲུབ་སྨྲ་བྱེད་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>འཚམ་སྒྲིག་ཆས་མངོན་སྟོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>GPUཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>སྒྲིག་ཆས་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>འཆར་བའི་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>དྲ་བའི་འཚམ་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>དྲ་བའི་འཚམ་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>སྒྲ་ཟློས་འཚམ་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>སྒྲ་ཟློས་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>སོ་སྔོན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>སོ་སྔོན་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>PCIསྒྲིག་ཆས་གཞན་དག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>PCIསྒྲིག་ཆས་གཞན་དག་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>གློག་རྫས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>གློག་རྫས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>མཐེབ་གཞོང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>མཐེབ་གཞོང་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>ཙི་གུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>ཙི་གུ་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>པར་འདེབས་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>པར་འདེབས་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>པར་རིས་སྒྲིག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>པར་རིས་སྒྲིག་ཆས་ཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>CD-ROMཤེས་རྟོགས་བྱུང་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>སྒྲིག་ཆས་གཞན་དག</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>སྒྲིག་ཆས་གཞན་དག་རྙེད་མ་བྱུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>གྲངས་ཚོ་བྱ་རིམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>ཚད་གཞི་བཟོ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>ནང་གསོག་རྒྱུ་ལམ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>རིགས་གྲས་ཞིབ་ཆ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>ལྷུ་ཆས་ཨང་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>གནས་སྟར།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>ནང་གསོག་ལག་རྩལ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>ནང་གསོག་བཀོལ་སྤྱོད་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>བརྟན་ཆས་པར་གཞི།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ལྷུ་ཆས་བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ལྷུ་ཆས་ཐོན་རྫས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ནང་གསོག་མ་ལག་ཡན་ལག་གྱི་ཚོད་འཛིན་ཆས་བཟོ་མཁན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ནང་གསོག་མ་ལག་ཡན་ལག་གྱི་ཚོད་འཛིན་ཆས་ཐོན་རྫས་ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>བོར་མི་སླ་བའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>བོར་སླ་བའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>ཤོང་གསོག་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>གཏན་ཚིགས་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>དབྱིན་ཚུན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>དུས་ཚོད།</translation>
     </message>
@@ -3692,315 +3453,296 @@
         <translation>པར་འདེབས་ངོས་གྲངས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>སྲ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>འཕྲུལ་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>ཆ་སྐུད་ཆ་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>གཏན་ཚིགས་ཁུལ་དབྱེའི་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>གཡབ་ཁུལ་ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>ཁྱོན་ཡོངས་ཀྱི་མཚོན་རྟགས་གཅིག་པུ།</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>དབྱིབས་རྩིས་གཞི་གྲངས།（གཏན་ཚིགས།）</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>སྒྲིག་ཆས་དོ་དམ་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>སྒྲིག་ཆས་དོ་དམ་ཆས་ནི་མཁྲེགས་ཆས་ལྟ་བ་དང་དོ་དམ་བྱེད་པའི་ཡོ་བྱད་ཅིག་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>ཁྱེད་ལ་སྐུལ་ཆས་སྒྲིག་འཇུག་གམ་གསར་སྒྱུར་བྱ་རྒྱུ་འདུག</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>ལྟ་བཤེར།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>ཡིག་ཁུག་བུ་ཚུད་པ། </translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>སྐུལ་བྱེད་གནས་ཡུལ་འདེམས་པ། </translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>སྐུལ་ཆས་(%1)སྒྲིག་འཇུག་གསར་སྒྱུར་བྱ་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>དཔྱད་འཇལ་དུས་ཚོད། %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>སྐུལ་ཆས་ཕབ་ལེན་བྱེད་བཞིན་པ་%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>ཕབ་ལེན་མྱུར་ཚད། %1 ལེགས་གྲུབ་བྱུང་བ། %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>སྐུལ་ཆས་%1སྒྲིག་འཇུག་བྱེད་བཞིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>སྐུལ་ཆས་%1སྒྲིག་འཇུག་བྱས་ཟིན་པ་དང་། %2ཕམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>ཁྱོན་སྐུལ་ཆས་%1སྒྲིག་འཇུག་ལེགས་གྲུབ་བྱུང་།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>སྐུལ་ཆས་སྒྲིག་འཇུག་བྱེད་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>དྲ་བ་རྒྱུན་འགལ་ཡིན་པས། ཡང་བསྐྱར་ཚོད་ལྟ་བྱེད་བཞིན་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>ཕབ་ལེན་མྱུར་ཚད། %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>སྐུལ་ཆས་གསར་ཤོས་ཡིན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་བྱས་གོང་གི་གྲུབ་སྨྲ་བྱེད་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་བྱས་ཆོག་རེད། འགྲོ་བྱེད་བྱེད་བརྟེན་ནས་སྨྲ་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>%1 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་བྱས་ཆོག་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་བྱས་ཆོག་གི་གྲུབ་སྨྲ་བྱེད་བྱས་ཆོག་གི་%2 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་བྱས་ཆོག་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>སྨྲ་བྱེད་བྱེད་བརྟེན་ནས་སྨྲ་བྱེད་བྱས་ཆོག་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>%1 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་བྱས་ཆོག་རེད། %2 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་མ་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>གྲུབ་སྨྲ་བྱེད་སྨྲ་བྱེད་མ་རེད</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>%1 འགྲོ་བྱེད་གྲུབ་སྨྲ་བྱེད་བྱས་ཆོག་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>གློག་ཀླད་བསྐྱར་སློང་།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>སྐུལ་ཆས་སྒྲིག་འཇུག་བྱས་ཟིན། ཏོག་ཙམ་ནས་%1གོ་ཆོད་པ་ཡིན།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>ཕྱིར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>སྐུལ་ཆས་སྒྲིག་འཇུག་ལེགས་གྲུབ་བྱུང་མེད། ཡང་བསྐྱར་ཚོད་ལྟ་བྱེད་པའམ་%1ང་ཚོར་སྤྲོད་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>ཐེངས་གཅིག་ལ་སྒྲིག་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>ཡང་བསྐྱར་དཔྱད་འཇལ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>མཁྲེགས་ཆས་སྐུལ་འདེད་བཤེར་བཞིན་ཡོད་པས། སྒུག་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>བཤར་འབེབས་བཞིན་པ།%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>དཔྱད་འཇལ་བྱེད་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>དྲ་བ་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>དྲ་སྦྲེལ་ལ་ཞིབ་བཤེར་བྱོས།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>ཡང་བསྐྱར་དཔྱད་འཇལ་བྱེད་པའམ་%1ང་ཚོར་སྤྲོད་རོགས།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>སྐུལ་ཆས་སྒྲིག་འཇུག་བྱེད་བཞིན་ཡོད་པས། ཉེར་སྤྱོད་ལས་ཕྱིར་དོན་རྗེས་ལས་འགན་ཆད་སྲིད།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>ཉེར་སྤྱོད་ལས་ཕྱིར་དོན་མི་དོན་གཏན་ཁེལ་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>ཕྱིར་འཐོན།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>པར་རིས་སྒྲིག་ཆས།</translation>
     </message>
@@ -4071,27 +3812,27 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4114,22 +3855,22 @@
         <translation>སྐུལ་ཆས་ཡིག་ཆ་ལེན་པ་རྒྱུན་འགལ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>གསར་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
         <translation>སྒྲིག་འཇུག</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>གསར་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>སྐུལ་བྱེད་གསར་སྒྱུར། </translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>སྐུལ་བྱེད་བཤིག་པ། </translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>གློག་ཀླད་སློང་ཆོག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>འགོ་སློང་བ།</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>གསར་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>ཕྱིར་འདྲེན།</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>སྤྱོད་མི་ཆོག</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>སྤྱོད་མི་རུང་།</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>གནས་དེ་གའི་ཡིག་ཁུག་འདེམས་རོགས། </translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>འཇུག་བཞིན་པ།</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_bqi.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_bqi.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bqi">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>تیچیک</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>بیشتر</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>اخطار شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>تکرار نصب</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>بیشتر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>بستن</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>دسترسی ندارد</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>نام دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>چیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>کیفیت ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>مسیر SysFS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ویرایش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>رانر ماژور کرنل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>آدرس حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>دسترسی ندارد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>چیپست</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>نام مستعار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>مصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>نسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>سرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>نسخة برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>برنامج تشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>معلومات الطرفية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>اسم منطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>عنوان MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>اسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>مصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>نسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>معلومات الطرفية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>برنامج تشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>سرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>اسم</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>اسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>مصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>هوية المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>هوية النواة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>الخيوط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجوميبيس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>الهيكلية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>عائلة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>الوحدة الأساسية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>الترميز الافتراضي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>العلميات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>التوسعات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>الذاكرة L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>الذاكرة L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>الذاكرة L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>الذاكرة L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>الخطوة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ذاكرة الرسومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ID الجسد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>عنوان الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>منفذ I/O</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>معلومات الاتصال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>الدقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>الدقة الدنيا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>المحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>الإخراج الرقمي (DP)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>الإخراج الرقمي (eDP)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>الإخراج الرقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>إخراج الشاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>القدرة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>المُطور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>إيقاف</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>التيار القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>المُطور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>عدد المعالجات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>اللوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>بطاقة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>بطاقة الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>أجهزة PCI الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>بطاقة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>الماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>اللوحة المفاتيح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>المونيتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>القرص الصلب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>الطباعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>الكاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>أجهزة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>نظام التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>العرض الكلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>الموضع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>الجهد المُحدد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>الجهد الأقصى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>الجهد الأدنى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>السرعة المُحددة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>عرض البيانات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>المدخل العرضي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>نوع الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>الدقة المدعومة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>نسبة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>الشاشة الرئيسية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>المقاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>نسخة البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>معدل المفاوضة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>المنفذ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>مُلْتِكَسْت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>لينك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>ليتنسي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>اِي. بي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>فَيرْمْوَر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>دُبْلِكْس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>برودكاست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>اوتُو نِوْتِيَشِن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>آدرسِ مِيمُرِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>اِي. آر. كيو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>آدرسِ ماك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>اِسمِ لُوجِيک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>اِسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحassi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>الدخل/الخرج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>اِي. آر. كيو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>التأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>المنفذ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>اِسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحassi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>القوة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>السعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>الشريحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>سعة التصميم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>جهد التصميم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>نسخة SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>رقم سريال SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاريخ صناعة SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>كيميائية SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>درجة الحرارة</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>المُشاركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>نوع واجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>عەدە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>مەلکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>نوع مادى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>چەمادى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>سەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>قابىلىتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>سەرە فايرمېۋار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>ھەزىمەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>تەرجىمە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>سېرىال نومر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>واجھە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>نەچىسى دېگىن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>مۇھاۋىل</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>نۇۋەت چىقىرىش ئۈچۈن چىقىرىشچىنى تاللاڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>بۇ ئابرىدا چىقىرىشچى يوق</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ئەۋزىيە ئۈچۈن مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>BIOS مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>CD-ROM مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>سىستېم مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>CPU مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>بەلگىسى ئەمەس ئۈچۈن مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>كۈچ مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>چىقىرىشچى مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>مۇس مەلۇماتنى يۈكلەۋاتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>ھەۋا ئاداپتېر مەلۇماتنى يېۈكلەۋاتىدۇ...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>عەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>مۇھاۋىل</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>عەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>مۇھاۋىل</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>معلومات الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>عرض المفاتيح القصيرة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>إغلاق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>مساعدة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>نظام</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>الهاردوير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>الدрайفرات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>المونيتور</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>البطاقة الرسومية</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>بطاقة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>المزيد</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>نسخة منصة الدрайفر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>الدрайفرات القابلة للنسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>الدрайفرات المنسوخة</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>جارٍ تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>تحذير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>سيصبح الجهاز غير متوفر بعد إزالة الدрайفر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>إزالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>جارٍ إزالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>تحديث ناجح</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>إزالة ناجحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>تحديث فاشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>فشل إزالة البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>حسنًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>الملف الذي تم اختياره لا موجود، من فضلك اختر مسارًا آخر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>السابق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>حزمة تالفة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>هيكل الحزمة غير متوافق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>الملف الذي تم اختياره لا موجود، من فضلك اختر ملفًا آخر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>هذا ليس برنامج تشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>غير قادر على التثبيت - لا يوجد توقيع رقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>خطأ غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>لم يتم العثور على وحدة البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>صيغة الوحدة غير صالحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>وحدة البرنامج تشتمل على اعتمادات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>تثبيت البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>نسخ احتياطي للبرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>استعادة البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>التغذية الراجعة</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>ليس لديك أي برامج تشغيل للاستعادة، من فضلك قم بنسخ احتياطي أولاً</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>اذهب إلى نسخة النسخ الاحتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>نسخة النسخ الاحتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>برامج التشغيل القابلة للاستعادة</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>تثبيت البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>نسخ احتياطي للبرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>استعادة البرنامج</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>فشل تفعيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>فشل تعطيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>فشل تعطيله: لا يمكن الحصول على رقم серий الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>تحديث الاتصالات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>إلغاء تثبيت الاتصالات</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>تفعيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>تحديث الاتصالات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>إلغاء تثبيت الاتصالات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>答应让它唤醒电脑</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>فشل تعطيله: لا يمكن الحصول على رقم серий الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>فشل تعطيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>فشل تفعيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>تحديث الاتصالات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>إلغاء تثبيت الاتصالات</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>الشركة الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>الجهاز الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>الاتصالات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>حالة الاتصالات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>명령어 활성화</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>حالة التكوين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>تأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>الجهاز الفيزيائي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>سيسفس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>المنشئات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>الشين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>معلومات BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>معلومات لوحة الأساس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>معلومات النظام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>معلومات الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>الذاكرة الفيزيائية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>تاريخ الإصدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>العنوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>حجم التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>حجم الـROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>الخصائص</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>مراجعة BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>مراجعة البرمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>اسم المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>الصفيحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>الموقع داخل الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>المنشئات المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>نوع الاستيقاظ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>رقم SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>خانواده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>قفل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>حالت راه اندازی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>حالت تامین برق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>حالت گرما</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>وضعیت امنیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>اطلاعات سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ارتفاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>تعداد سیم‌های برق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>عناصر محتوا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>محل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نوع تصحیح خطا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ظرفیت ماکسیمم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>آی‌دی اطلاعات خطا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>تعداد دستگاه‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>اندازه BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاریخ انتشار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>نام پیل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>نسخه SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>فرمت توصیف زبان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>زبان‌های قابل نصب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>زبان فعلی نصب شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>آدرس BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>نوع بسته</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>سیاست پیوند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>حالت پیوند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>کلاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>کلاس‌های خدمات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>کلاس دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>نسخه ایچی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>نسخه ایل ام پی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>زیر نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>آی دی سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>محصول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>توضیحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>مجهز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>قابل کشف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>قابل جفت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>مودالیاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>در حال کشف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>مدول های سیستم عامل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>فایل دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>فایل های دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>شماره دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>کاربرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>وضعیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>نام منطقی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>نسخه انسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>نام اجرایی CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>معماری CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>تغییر CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>بخش CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>ویرایش CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>یک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>هیچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>نِو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>دِس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>دویس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>چوہدرہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>سولہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>نوز درہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>دویسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>دویسی دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>دویسی چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>دویسی چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>دویسی اٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>تیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>تیسی دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>تیسی چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>تیسی چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>تیسی اٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>چوریس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>چوریس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>چوریس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>چوریس چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>چوریس اٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>پچیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>پچیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>پچیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>پچیس چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>پچیس اٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>سچیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>سچیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>سچیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ستين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ستين وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>سبعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>سبعون واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>سبعون واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>سبعون وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>سبعون وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ثمانين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ثمانين واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ثمانين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ثمانين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ثمانين وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>تسعين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>تسعين واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>تسعين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>تسعين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>تسعين وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>مائة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>مائة واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>مائة واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>مائة وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>مائة وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>مائة وعشرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>مائة واثنى عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>مائة و١٤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>مائة و١٦</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>مائة و١٨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>مائة و٢٠</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>مائة و٢٢</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>مائة و٢٤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>126</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>128</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>192</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>256</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>سعة GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>مصنّع GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>نوع GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>نسخة EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>واجهات EGL العميل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>نسخة GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>نسخة GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>الوحيدة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>فئة الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>وحدة المعالجة المركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>لم يتم العثور على وحدة معالجة مركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>لوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>لم يتم العثور على لوحة أم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>لم يتم العثور على ذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>لم يتم العثور على محرك أقراص</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>فشل استعادة برنامج التشغيل!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>يرجى المحاولة مرة أخرى أو تقديم ملاحظاتك</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>فشل نسخ برنامج التشغيل!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>مُوصِل العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>لم يتم العثور على GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>شاشة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>لم يتم العثور على شاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>اڈاپٹر نیٹ ورک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>اڈاپٹر نیٹ ورک نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>اڈاپٹر ساؤنڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>آڈیو دیوائس نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>بلوٹوٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>بلوٹوٹھ دیوائس نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>دیگر PCI دیوائس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>دیگر PCI دیوائس نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>اُرجن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>بیٹری نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>کیبورڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>کیبورڈ نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>ماؤس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>ماؤس نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>پرینر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>پرینر نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>کیمیرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>کیمیرا نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>دیگر دیوائس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>دیگر دیوائس نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>آرے ہینڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>فم فیکٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>سیٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>بنک لوکیٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>ٹائپ ڈیٹائل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>پارٹ نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>رینک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>میموری ٹیکنالوجی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>قدرة وضعية التشغيل الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>نسخة البرمجيات الثابتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>هوية مصنّع الوحدة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>هوية منتج الوحدة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>هوية مصنّع وحدة التحكم في النظام الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>هوية منتج وحدة التحكم في النظام الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>حجم الذاكرة غير المُعدّل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>حجم الذاكرة المُعدّل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>حجم الذاكرة المؤقتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>حجم الذاكرة المنطقية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>بوصة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>التاريخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>منفذ الإدخال والإخراج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>شبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>مسار الأصل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>مصدر الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>تم التحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>لديه سجل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>لديه إحصائيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>قابلة لإعادة الشحن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>مستوى التنبيه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>الطاقة فارغة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>الطاقة ممتلئة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>الطاقة ممتلئة بالتصميم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>معدل الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>النسبة المئوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تکنالوجی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>نام ایکون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>آنلاین</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>نسخه دیمون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>بر روی باتری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>کابه بسته است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>کابه حاضر است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>عملیات اساسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>کپی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>کار کنسل شود</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>کار تا زمانی یافت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>اولویت کار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>زمان تغییر نشانگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>تعداد به بالا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>جهت درخواست شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>حالت چاپ رنگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>چاپگر کار را پذیرفته است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>چاپگر به اشتراک گذاشته شده است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>چاپگر موقت است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>ساخت و مدل چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>زمان تغییر وضعیت چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>دلایل وضعیت چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>نوع چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI چاپگر پشتیبانی شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>سایدز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>اطلاعات بوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>اندازه بخش‌های منطقی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>اندازه بخش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>هېد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>هندسە (لۆجیکال)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مەنیجر دەیەڤی</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مەنیجر دەیەڤی ھەندسە تول بۆ چاک کردن ئەوەرە ھەندسە و مەنیج کردن دەیەڤی</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>جەدید دەیەڤی ھەندسە بەکارهێنراوە! ئەوەرە ھەندسە بەکارهێنرە یان بەهۆیا بەکارهێنرە</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>بینی</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>فۆلدرە چەکەکان بەکارهێنرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>بۆ چاک کردن دەیەڤی بەکارهێنرە لە چەنە بەکارهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 دەیەڤی ھەندسە بەکارهێنراوە'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'زمان چەک کردن: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>بۆ چاک کردن دەیەڤی بۆ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سەری داونلواد: %1 داونلواد کردن %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>بۆ چاک کردن دەیەڤی بۆ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 دەیەڤی بەکارهێنراوە، %2 دەیەڤی ناکردنەوە'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 دەیەڤی بەکارهێنراوە'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ناکردنەوە بۆ چاک کردن دەیەڤی</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>کارەوەری ھەتاوا. بەرەوچوونەوە...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سەری داونلواد: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>دەیەڤی شما بەکارهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>ھەموو دەیەڤی بەکارهێنراوە بەکارهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 دەیەڤی بەکارهێنراوە، %2 دەیەڤی بەکارهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 دەیەڤی بەکارهێنراوە کە بەکارهێنراوە بەکارهێنراوە، دەستکاری بەکارهێنرە بەهۆیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 دەیەڤی بەکارهێنراوە کە بەکارهێنراوە بەکارهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 دەیەڤی بەکارهێنراوە بەکارهێنراوە، %2 دەیەڤی بەکارهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'بەکارهێنرە: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 دەیەڤی بەکارهێنراوە، %2 دەیەڤی ناکردنەوە'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ناکردنەوە بۆ چاک کردن دەیەڤی</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 دەیەڤی بەکارهێنراوë'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 دەیەڤی بەکارهێنراوە کە بەکارهێنرە بەکارهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>لە بەکارهێنرە بەکارهێنرە بۆ چاک کردن دەیەڤی</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ڈرائیوئر ریاست کر رہا ہے...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>ریاست کر رہا ہے: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>ریبوٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>کیجئے %1 اسٹالڈ ڈرائیوئر کے لیے تاثیر ہو</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>بک اپ پٹھ کو دیکھیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>سیل بک اپ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>فیڈ باک سبمٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>کوشش کریں یا %1 ہم کو بھیجیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>سیل ڈرائیوئر اسٹال کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>اسکن کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>انسیل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>ہارڈ وئر ڈیوائس ڈرائیوئر کا اسکن کر رہے ہیں، اسٹاپ کریں...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>اسکن کر رہے ہیں %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>اسکن فیل ہو گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>نیٹ ورک دستیاب نہیں ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>کیجئے اپنی نیٹ ورک کنیکشن کو چیک کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>کوشش کریں یا %1 ہم کو بھیجیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>آپ ایک ڈرائیوئر اسٹال کر رہے ہیں، جو آپ نکل جائیں تو ٹورنٹ ہو جائے گا۔</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>آپ نکلنا چاہتے ہیں؟</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>نکل جائیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>انسیل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>آپ ڈرائیوئر کا بک اپ کر رہے ہیں، جو آپ نکل جائیں تو ٹورنٹ ہو جائے گا۔</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>آپ ڈرائیوئر کا ریاست کر رہے ہیں، جو آپ نکل جائیں تو ٹورنٹ ہو جائے گا۔</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>بلوٹوٹھ ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ایمیج کریکن ڈیوائس</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>ڈسپلے ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>ساؤنڈ کارڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>نیٹ ورک ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>وائرلس نیٹ ورک ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>اینستالیشن کامیاب ہو گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>تَحْمِيل نَجَح</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>تَحْمِيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>تَثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>غير مُثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>قديم</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>تَحْمِيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>غير مُخزن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>تَخْزِين</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>تَخْزِين نَجَح</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>تَخْزِين نَجَح</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>تَجْدِيد التَّثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>خطأ مُعَروف</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>خطأ في الشِّبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>ألغي</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>فشل في الحصول على ملفات الـdriver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>تَخْزِين</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>تَجْدِيد التَّثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>تَثبيت</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>إيقاف</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>تحديث ملفات الـdriver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>إلغاء تثبيت ملفات الـdriver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>مُرْخَصٌ لِتَنَفُّس الحَاسوب</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>تفعيل</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>إيقاف</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>ناممکن</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>لُطفاً انتخاب چه پوشه محلی کنید</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>بارگذاری...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_br.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_br.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="br">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Mais</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>إعادة توصيل الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>إعادة التثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Mais</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Encolher</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Desativar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Indisponível</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Nome do Dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Fornecedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Capacidades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisão</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Driver em Modo Kernel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Endereço de Memória</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Indisponível</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Desativar</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Fornecedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Fornecedor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versão</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Conjunto de chips</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Apelido</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>نسخة البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحوض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>الاسم المنطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>عنوان MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحوض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>هوية المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>هوية النواة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>الخيوط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجوميبس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>العمارة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>عائلة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>وحدة(s) معالجة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>التوظيف الافتراضي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>العلميات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>التوسعات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>الذاكرة التكميلية L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>الذاكرة التكميلية L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>الذاكرة التكميلية L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>الذاكرة التكميلية L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>الخطوة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ذاكرة الرسومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>المعرفة الجسدية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>عنوان الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>منفذ الإدخال/الإخراج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحزام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>الدقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>الدقة الدنيا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>المُشغِّل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>الإخراج الرقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>إخراج العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>الإصدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحassi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحassi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>التيار الأقصى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>عدد المعالجات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>اللوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>بطاقة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>بطاقة الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>أجهزة PCI الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>بطاقة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>الماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>اللوحة المفاتيح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>الشاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>القرص الليزر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>الطباعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>الكاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>أجهزة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>نظام التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>العرض الكلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>الجهد المُضبط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>الجهد الأقصى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>الجهد الأدنى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>السرعة المضبطه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>العرض البيانات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>المدخل العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>نوع الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>الدقة المدعومة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>نسبة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>الشاشة الرئيسية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحافلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>البرنامج المُساعد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>نسخة البرنامج المُساعد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>معدل التفاوض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>المنفذ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>البث المتعدد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>الرابط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>التأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>펌웨어</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>الدوبلكس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>البث العام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>التفاوض التلقائي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>عنوان الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>عنوان MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>اسم منطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحassi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>الدخول/الخروج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>التأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحassi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>المُحَرِّك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>القدرة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>السعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>الشريحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>السعة المُصمَّمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>الجهد المُصمَّد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>نسخة SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>رقم تسلسل SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاريخ تصنيع SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>كيمياء SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>درجة الحرارة</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>الموديل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>مُشترَك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>نوع الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>نوع الوسيلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>نسخة البرنامج الثابت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>معدل الدوران</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>اختر دراير للتحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>لا توجد دراير في هذا المجلد</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>جارٍ تحميل معلومات جهاز الصوت...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>جارٍ تحميل معلومات BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>جارٍ تحميل معلومات CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>جارٍ تحميل معلومات نظام التشغيل...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>جارٍ تحميل معلومات المعالج...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>جارٍ تحميل معلومات الأجهزة الأخرى...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>جارٍ تحميل معلومات الطاقة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>جارٍ تحميل معلومات الطابعة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>جارٍ تحميل معلومات الماوس...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>جارٍ تحميل معلومات بطاقة الشبكة...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>معلومات الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>عرض الأختصارات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>إغلاق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>مساعدة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>نظام</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>الهاردوير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>المقودات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>مراقب</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>لوحة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>بطاقة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>أكثر</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>نسخة منصة المقود</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>مقودات قابلة للنسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>مقودات تم نسخها</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>جارٍ التحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>تحذير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>سيصبح الجهاز غير متاح بعد إزالة المقود</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>إزالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>جارٍ إزالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>تحديث ناجح</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>إزالة ناجحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>تحديث فاشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>فشل إزالة البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>أوكي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>المسار الذي تم اختياره لا существует، الرجاء اختياره مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>السابق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>حزمة تالفة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>لا تطابق في بنية الحزمة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>الملف الذي تم اختياره لا существует، الرجاء اختياره مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ليس مُثبت برنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>غير قادر على التثبيت - لا توقيع رقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>خطأ غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>لم يتم العثور على وحدة مُثبت البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>تنسيق وحدة غير صحيح</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>وحدة مُثبت البرنامج تحتوي على اعتمادات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>تثبيت برنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>نسخ احتياطي للبرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>استعادة البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>التغذية الراجعة</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>ليس لديك أي برامج يمكن استعادتها، الرجاء إنشاء نسخة احتياطية أولاً</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>الانتقال إلى نسخة احتياطية للبرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>نسخة احتياطية</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>برامج قابلة للإعادة</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>تثبيت برنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>نسخ احتياطي للبرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>استعادة البرنامج</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>فشل في تمكين الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>فشل في تعطيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>فشل في تعطيله: لا يمكن الحصول على رقم تعريف الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>تحديث المُسَطَّرَات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>إزالة المُسَطَّرَات</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>تمكين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>تحديث المُسَطَّرَات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>إزالة المُسَطَّرَات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>السماح له بتشغيل الكمبيوتر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>فشل في تعطيله: لا يمكن الحصول على رقم تعريف الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>فشل في تعطيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>فشل في تمكين الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>تحديث المُسَطَّر ات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>إزالة المُسَطَّرَات</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>المُعَرِّف الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>الجهاز الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>المُسَطَّر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>حالة المُسَطَّر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>명령어 활성화</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>حالة التكوين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>تأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>الجسدي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>المُعالِجات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>الشِبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>معلومات BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>معلومات لوحة الأساس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>معلومات النظام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>معلومات الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>مصفوفة الذاكرة الفيزيائية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>تاريخ الإصدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>العنوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>حجم التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>حجم ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>الخصائص</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>مراجعة BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>مراجعة البرمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>اسم المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>مُلصق الممتلكات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>الموقع داخل الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>مقبض الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>المُعالِجات المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>نوع الاستيقاظ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>رقم SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>عائلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>قفل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>حالة التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>حالة التغذية الكهربائية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>حالة الحرارة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>حالة الأمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>معلومات المصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>الارتفاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>عدد أسلاك الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>العناصر المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نوع تصحيح الأخطاء</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>السعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>مقبض معلومات الخطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>عدد الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>حجم BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاريخ الإطلاق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>اسم اللوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>نسخة SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>تنسيق وصف اللغة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>اللغات المثبتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>اللغة المثبتة حاليًا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>عنوان BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>حجم MTU ACL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>حجم MTU SCO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>نوع البيانات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>سياسة الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>وضع الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>الصنف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>التصنيفات الخدمية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>فئة الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>نسخة بروتوكول HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>نسخة بروتوكول LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>الإصدار الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>مُفعَّل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>قابل للإكتشاف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>قابل للزوجة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>في عملية الإكتشاف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>وحدات القيادة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ملف الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ملفات الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>رقم الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>التطبيق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>الاسم المنطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>نسخة ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>مُبرمج المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>هيكل المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>نسخة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>جزء المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>نسخة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>واحد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>اثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>أربعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>ثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>تسعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>عشرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>اثنا عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>أربعة عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>ستة عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>ثمانية عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>عشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>اثنين وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>أربعة وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ستة وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ثمانية وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>ثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>اثنين وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>أربعة وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>ستة وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>ثمانية وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>أربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>اثنين وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>أربعة وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>ستة وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>ثمانية وأربعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>خمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>اثنين وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>أربعة وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ستة وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ثمانية وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>ستون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>اثنين وستون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>أربعة وستون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>sessenta e seis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>sessenta e oito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>setenta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>setenta e dois</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>setenta e quatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>setenta e seis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>setenta e oito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>oitenta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>oitenta e dois</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>oitenta e quatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>oitenta e seis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>oitenta e oito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>noventa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>noventa e dois</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>noventa e quatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>noventa e seis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>noventa e oito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>cem</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>cem e dois</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>cem e quatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>cem e seis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>cem e oito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>cem e dez</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>cem e doze</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>cem e catorze</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>cem e dezesseis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>cem e dezoito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>cem e vinte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>cem e vinte e dois</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>cem e vinte e quatro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>مائة واثنان وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>مائة واثنان وعشرون وثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>مائة وتسعة وعشرون واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>مائتا وخمسة وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>سعة ذاكرة GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>مُصنِّع وحدة معالجة الرسومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>نوع وحدة معالجة الرسومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>نسخة EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>واجهات برمجة تطبيق EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>نسخة GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>نسخة GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>مفرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>نوع الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>وحدة المعالجة المركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>لم يتم العثور على وحدة معالجة مركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>لوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>لم يتم العثور على لوحة أم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>لم يتم العثور على ذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>لم يتم العثور على محرك أقراص</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>فشل استعادة برنامج التشغيل!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>يرجى المحاولة مرة أخرى أو إعطاؤنا ملاحظات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>فشل نسخ برنامج التشغيل!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>جهاز العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>لم يتم العثور على وحدة معالجة الرسومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>شاشة عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>لم يتم العثور على شاشة عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>适配器网络</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>未找到网络适配器</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>适配器音频</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>未找到音频设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>蓝牙</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>未找到蓝牙设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>其他PCI设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>未找到其他PCI设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>电源</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>未找到电池</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>键盘</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>未找到键盘</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>鼠标</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>未找到鼠标</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>打印机</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>未找到打印机</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>摄像头</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>未找到摄像头</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>未找到CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>其他设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>未找到其他设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>阵列处理</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>外形规格</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>银行定位</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>类型详情</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>零件编号</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>等级</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>内存技术</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>قدرة وضعية التشغيل الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>نسخة البرمجيات الثانوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>هوية مصنّع الوحدة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>هوية منتج الوحدة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>هوية مصنّع وحدة التحكم في نظام الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>هوية منتج وحدة التحكم في نظام الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>حجم الذاكرة غير القابلة للمسح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>حجم الذاكرة القابلة للمسح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>حجم الكاش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>حجم المنطقية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>بوصة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>التاريخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>منفذ الإدخال/الإخراج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>شبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>بطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>مسار الأصل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>مصدر الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>لديه سجل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>لديه إحصائيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>قابلة لإعادة الشحن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>مستوى التنبيه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>الطاقة فارغة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>الطاقة ممتلئة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>الطاقة ممتلئة بالتصميم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>معدل الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>النسبة المئوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تقنية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>اسم الأيقونة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>متصل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>نسخة الديمون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>على البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>الغطاء مغلق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>الغطاء موجود</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>عملية حيوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>إلغاء المهمة بعد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>الاحتفاظ بالمهمة حتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>أولوية المهمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>وقت تغيير العلامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>عدد الصفحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>الاتجاه المطلوب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>وضع الطابعة للون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>الطابعة تقبل المهام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>الطابعة مشاركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>الطابعة مؤقتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>ماركة ونوع الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>وقت تغيير حالة الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>أسباب حالة الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>نوع الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI للطابعة المدعومة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>الجوانب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>حجم القطاعات المنطقية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>حجم القطاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>هوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>الهندسة (المنطقية)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير الأجهزة هو أداة مفيدة لعرض معلومات الأجهزة وإدارة الأجهزة.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>أحدث مُحدثات الأجهزة متاحة! قم بتركيبها أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>أضف المجلدات الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ابحث عن مُحدثات الأجهزة في هذا المسار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 مُحدثات أجهزة متاحة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'وقت التحقق: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل مُحدثات الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تثبيت مُحدثات الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 مُحدثات أجهزة تم تثبيتها، %2 مُحدثات أجهزة فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 مُحدثات أجهزة تم تثبيتها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تثبيت مُحدثات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعة التنزيل: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>مُحدثات الأجهزة الخاصة بك محدثة بالفعل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع مُحدثات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>إجمالي %1 مُحدثات أجهزة، منها %2 تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 مُحدثات أجهزة يمكن نسخها، يُنصح بالقيام بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 مُحدثات أجهزة يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ المُحدثة %1 من الأجهزة، إجمالي %2 مُحدثات أجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'النسخ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 مُحدثات أجهزة تم نسخها، %2 مُحدثات أجهزة فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ مُحدثات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 مُحدثات أجهزة تم نسخها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 مُحدثات أجهزة يمكن استعادتها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار مُحدثة جهاز للاستعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>المنتج هو إصلاح...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>إعادة الإصلاح: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>إعادة التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>يرجى %1 ليتم تفعيل المنتجات المثبتة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>عرض مسار النسخ الاحتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>نسخ احتياطي لجميع</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>أرسل ملاحظات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>يرجى المحاولة مرة أخرى أو %1 لنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>تثبيت جميع</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>مسح مجددًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>التحقق من مسح منتجات أجهزة الأجهزة، يرجى الانتظار...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>التحقق من %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>المسح فشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>الشبكة غير متاحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>يرجى التحقق من اتصال الشبكة الخاص بك</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>يرجى مسح مجددًا أو %1 لنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>أنت تقوم بتركيب منتج، وسيتم تعطيله إذا غادرت.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>هل أنت متأكد من رغبتك في الخروج؟</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>خروج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>أنت تقوم بعملية نسخ احتياطي للمنتجات، وسيتم تعطيله إذا غادرت.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>أنت تقوم بإصلاح المنتجات، وسيتم تعطيله إذا غادرت.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>مُعدّد بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>جهاز التصوير</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>مُعدّد العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>بطاقة الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>مُعدّد الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>مُعدّد الشبكة اللاسلكية</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>التركيب ناجح</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>التركيب فشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>جار التحميل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>جار التركيب</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>غير مثبت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>معطّل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>جار الانتظار</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>غير مشفر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>جار التشفير</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>فشل التشفير</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>تم التشفير بنجاح</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>جار استعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>خطأ غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>خطأ في الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>تم إلغاؤه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>فشل في الحصول على ملفات الاقتران</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>نسخ احتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>استعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>تثبيت</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>تحديث ملفات الاقتران</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>إلغاء تثبيت ملفات الاقتران</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>السماح له بتشغيل الحاسوب</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>تمكين</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Indisponível</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Por favor, selecione uma pasta local</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Carregando...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ca.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ca.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Informació de retorn</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Més</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Replega</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Més</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Més</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Replega</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Més</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Replega</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nom del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Xip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Àlies del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID físic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>Camí_SistFT</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Descripció</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>Controlador de mode de nucli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Adreça de la memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Conjunt de xips</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Àlies</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Àlies del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID físic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Energia màxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versió del controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Informació de Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nom lògic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Adreça MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Informació de Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Energia màxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Àlies del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID físic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID del nucli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Fils</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Arquitectura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Família de la CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Processador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Nucli/s</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualització</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Banderes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensions</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>Cau d&apos;L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Cau d&apos;L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Cau d&apos;L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Cau d&apos;L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Cau d&apos;L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Passos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Velocitat màxima</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Memòria gràfica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Àlies del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID físic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Adreça de la memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Port d&apos;E/S</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Informació de Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Resolució màxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Resolució mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Resolució actual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Descripció</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Sortida digital</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Sortida de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Informació de Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Àlies del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID físic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Energia màxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Número de sèrie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interfície</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Informació de Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Àlies del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID físic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Corrent màxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Resum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Quantitat de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Adaptador d&apos;àudio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Emmagatzematge</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Altres dispositius de PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Adaptador de xarxa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Ratolí</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Teclat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Impressora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Càmera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Altres dispostius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>SO</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Amplada total</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Localitzador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Número de sèrie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Voltatge configurat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Voltatge màxim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Voltatge mínim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Velocitat configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Amplada de dades</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Entrada de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Tipus d&apos;interfície</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Resolució admesa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Resolució actual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Taxa de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor primari</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Número de sèrie</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Proveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Tipus de mitjà</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Capacitats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Àlies del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID físic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versió del microprogramari</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Velocitat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Descripció</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Número de sèrie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interfície</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Taxa de rotació</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Seleccioneu un controlador per actualitzar-lo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>No s&apos;ha trobat cap controlador en aquesta carpeta.</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Es carrega la informació del dispositiu d&apos;àudio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Es carrega la informació del BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Es carrega la informació del CD_ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Es carrega la informació del sistema operatiu...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Es carrega la informació de la CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Es carrega la informació d&apos;altres dispositius...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Es carrega la informació d&apos;energia...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Es carrega la informació de la impressora...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Es carrega la informació del ratolí...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Es carrega la informació de l&apos;adaptador de xarxa...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Informació del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Dreceres de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Tanca</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Refresca</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Gestor de dispositius</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Maquinari</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Controladors</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Resum</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Adaptador de xarxa</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Més</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Versió actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Versió de la plataforma del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Estat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Acció</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Controladors que poden tenir una còpia de seguretat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Controladors que tenen una còpia de seguretat</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>S&apos;actualitza</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Següent</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Avís</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>El dispositiu no estarà disponible després de la desinstal·lació del controlador.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Desinstal·la</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Es desinstal·la</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Actualització correcta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Desinstal·lació correcta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Ha fallat l&apos;actualització.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Ha fallat la desinstal·lació.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Següent</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>La carpeta seleccionada no existeix, torneu a seleccionar-la.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualitza</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Paquet trencat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Arquitectura del paquet no coincident</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>El fitxer seleccionat no existeix, torneu a seleccionar-lo.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>No és un controlador.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>No es pot instal·lar: sense signatura digital</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Error desconegut</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>No s&apos;ha trobat el mòdul del controlador.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>El format del mòdul no és vàlid.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>El mòdul del controlador té dependències.</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Nom del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versió disponible</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Mida</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Estat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Acció</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Versió nova</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Versió actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Falten controladors (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Controladors obsolets (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Controladors actualitzats (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Instal·lació del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Còpia de seguretat del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Restauració del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>D&apos;acord</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Informació de retorn</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>No teniu cap controlador per restaurar. Primer feu-ne una còpia de seguretat.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Ves a la còpia de seguretat de controladors</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Versió actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Versió de la còpia de seguretat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Acció</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Controladors restaurables</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Refresca</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Resum</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Instal·lació del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Còpia de seguretat del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Restauració del controlador</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Ha fallat habilitar el dispositiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Ha fallat inhabilitar el dispositiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>No s&apos;ha pogut desactivar: no s&apos;ha pogut obtenir l&apos;SN del dispositiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Actualitza els controladors</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstal·la controladors</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Refresca</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Resum</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Habilita</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Permeteu que activi l&apos;ordinador.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>No s&apos;ha pogut desactivar: no s&apos;ha pogut obtenir l&apos;SN del dispositiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Ha fallat inhabilitar el dispositiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Ha fallat habilitar el dispositiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Actualitza els controladors</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstal·la controladors</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Subproveïdor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Subdispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Estat del controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>CMD d&apos;activació del controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Estat de la configuració</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>latència</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Gestors</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>CLAU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Informació del BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Informació de la placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Informació del sistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Informació del xassís</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Matriu de memòria física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Data de publicació</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Mida de la versió d&apos;execució</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Mida de ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Característiques</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revisió del BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revisió del microprogramari</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Nom del producte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Número de sèrie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Etiqueta d’actiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Característiques</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Ubicació al xassís</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Nansa del xassís</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Gestió d&apos;objectes continguts</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Tipus de desvetllament</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Número d&apos;SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Família</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Bloqueig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Estat de l&apos;arrencada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Estat del subministrament d&apos;energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Estat tèrmic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Estat de la seguretat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Informació d&apos;OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Alçada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Nombre de cables d&apos;energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elements continguts</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Ubicació</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Tipus de correcció d’error</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacitat màxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Gestió d&apos;informació d&apos;error</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Nombre de dispositius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>MIDAROM DEL BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Data de publicació</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nom de la placa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versió d&apos;SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format de la descripció de la llengua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Llengües instal·lables</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Llengua instal·lada actualment</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Adreça BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>MTU d&apos;ACL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>MTU d&apos;SCO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Tipus de paquet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Política d&apos;enllaç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Mode d&apos;enllaç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Classe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Classes de servei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Classe del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versió d&apos;HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versió d&apos;LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>ID de sèrie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>producte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>descripció</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Amb energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Descobrible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Aparellable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Es descobreix</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Mòduls del controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Fitxer del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Fitxers del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Número del dispositiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplicació</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>estat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>nom lògic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>versió d&apos;ansi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementador de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arquitectura de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variant de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Part de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revisió de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Un</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Nou</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Deu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dotze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Catorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Setze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Divuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Vint</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Vint-i-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Vint-i-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Vint-i-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Vint-i-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trenta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trenta-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Trenta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trenta-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Quaranta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Quaranta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Quaranta-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Quaranta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Quaranta-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cinquanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cinquanta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cinquanta-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cinquanta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cinquanta-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Seixanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Seixanta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Seixanta-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Seixanta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Seixanta-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Setanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Setanta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Setanta-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Setanta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Setanta-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Vuitanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Vuitanta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Vuitanta-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Vuitanta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Vuitanta-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Noranta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Noranta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Noranta-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Noranta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Noranta-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Cent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Cent dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Cent quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Cent sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Cent vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Cent deu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Cent dotze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Cent catorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Cent setze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Cent divuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Cent vint</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Cent vint-i-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Cent vint-i-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Cent vint-i-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Cent vint-i-vuit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Cent noranta-dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Dos-cents cinquanta-sis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacitat de GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Proveïdor de GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Tipus de GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versió d&apos;EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>APIs de client d&apos;EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versió de GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versió de GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Desconegut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Classe del maquinari</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>No s&apos;ha trobat cap CPU.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>No s&apos;ha trobat cap placa base.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>No s&apos;ha trobat cap memòria.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Emmagatzematge</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>No s&apos;ha trobat cap disc.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Ha fallat la restauració del controlador!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Si us plau, torneu-ho a provar o feu-nos-en comentaris.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Ha fallat la còpia de seguretat del controlador!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>No s&apos;ha trobat cap GPU.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>No s&apos;ha trobat cap monitor.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Adaptador de xarxa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>No s&apos;ha trobat cap adaptador de xarxa.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Adaptador d&apos;àudio</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>No s&apos;ha trobat cap dispositiu d&apos;àudio.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>No s&apos;ha trobat cap dispositiu de Bluetooth.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Altres dispositius de PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>No s&apos;ha trobat cap altre dispositiu de PCI.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Energia</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>No s&apos;ha trobat cap bateria.</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Adaptador d&apos;àudio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>No s&apos;ha trobat cap dispositiu d&apos;àudio.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>No s&apos;ha trobat cap dispositiu de Bluetooth.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Altres dispositius de PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>No s&apos;ha trobat cap altre dispositiu de PCI.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Energia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>No s&apos;ha trobat cap bateria.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Teclat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>No s&apos;ha trobat cap teclat.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Ratolí</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>No s&apos;ha trobat cap ratolí.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Impressora</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>No s&apos;ha trobat cap impressora.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Càmera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>No s&apos;ha trobat cap càmera.</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>No s&apos;ha trobat cap CD ROM.</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Ratolí</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>No s&apos;ha trobat cap ratolí.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Impressora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>No s&apos;ha trobat cap impressora.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Càmera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>No s&apos;ha trobat cap càmera.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>No s&apos;ha trobat cap CD ROM.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Altres dispostius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>No s&apos;ha trobat cap altre dispositiu.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Gestió de matriu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Factor de forma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Establiment</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Localitzador de bancs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Detall del tipus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Número de part</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Tecnologia de memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Capacitat del mode operatiu de memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versió del microprogramari</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID del fabricant del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID del producte del mòdul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID del fabricant del controlador del subsistema de memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID del producte del controlador del susbsistema de memòria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Mida no volàtil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Mida volàtil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Mida de la cau</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Mida lògica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>polzada/es</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>costats</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>info de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>mida de sector lògic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>mida de sector</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometria (Lògica)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Gestor de dispositius</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>El Gestor de dispositius és una eina pràctica per veure la informació del maquinari i gestionar els dispositius.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Nous controladors disponibles! Instal·leu-los o actualitzeu-los ara.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Mostra</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Inclou subcarpetes</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Cerca controladors en aquest camí</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 actualitzacions de controladors disponibles</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Hora de la comprovació: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Es baixen els controladors per a %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocitat de baixada: %1 Baixat: %2 / %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>S&apos;instal·len els controladors per a %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 controladors instal·lats, %2 controladors han fallat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 controladors instal·lats</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Ha fallat instal·lar els controladors.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Error de xarxa. Es torna a connectar...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Velocitat de baixada: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Els controladors estan actualitzats.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>S&apos;ha fet una còpia de seguretat de tots els controladors.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Un total de %1 controladors, de %2 dels quals s&apos;ha fet una còpia de seguretat.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Teniu %1 controladors dels quals es pot fer una còpia de seguretat. Es recomana fer-ho immediatament.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Teniu %1 controladors dels quals es pot fer una còpia de seguretat.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Es fa una còpia de seguretat del controlador %1, d&apos;un total de %2 controladors.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Se&apos;n fa una còpia de seguretat: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>S&apos;ha fet una còpia de seguretat de %1 controladors. %2 controladors han fallat.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Ha fallat fer una còpia de seguretat dels controladors.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>S&apos;ha fet una còpia de seguretat de %1 controladors.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Teniu %1 controladors que es poden restaurar.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Seleccioneu un controlador per restaurar.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Es restaura el controlador...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Es restaura: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>reinicieu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Si us plau, %1 perquè els controladors instal·lats tinguin efecte.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Mostra el camí de la còpia de seguretat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Fes una còpia de seguretat de tots</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>envieu comentaris</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Si us plau, torneu-ho a provar o %1.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Instal·la-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Torna a escanejar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>S&apos;escanegen els controladors de dispositius de maquinari, espereu...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>S&apos;escaneja %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Ha fallat l&apos;escaneig.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Xarxa no disponible</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Si us plau, comproveu la connexió de xarxa.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Si us plau, torneu a escanejar o %1.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>S&apos;instal·la un controlador, i s&apos;interromprà si en sortiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Segur que en voleu sortir?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Surt</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Es fa una còpia de seguretat dels controladors. S&apos;interromprà si en sortiu.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Es restauren controladors. S&apos;interromprà si en sortiu.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>No s&apos;han pogut obtenir els fitxers del controlador.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Actualitza</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Còpia de seguretat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Restaura</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Instal·la</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Refresca</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exporta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Actualitza els controladors</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Desinstal·la controladors</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Permeteu que activi l&apos;ordinador.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Habilita</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Refresca</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exporta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Inhabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Seleccioneu una carpeta local, si us plau.</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Es carrega...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_cs.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_cs.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>Zpětná vazba</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Více</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Sbalit</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Více</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Více</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Sbalit</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Více</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Sbalit</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Název zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Čip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fyzický identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
-        <translation type="unfinished"/>
+        <translation>SysFS Cesta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
-        <translation type="unfinished"/>
+        <translation>KernelMode řadič</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Adresa v paměti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>Přerušení (IRQ)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Čipová sada</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alternativní název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fyzický identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Nejvyšší odběr</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Verze ovladače</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Ovladač</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Informace o sběrnici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logický název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC adresa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Informace o sběrnici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Ovladač</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Nejvyšší odběr</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fyzický identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>Identif. procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Identifikátor jádra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Vláken</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Architektura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Generace procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Jader</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualizace</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Výčet rozšíření instrukční sady procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Rozšíření</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Mezipaměť 3. úrovně</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Mezipaměť 2. úrovně</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Mezipaměť 1. úrovně (instrukční)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Mezipaměť 1. úrovně (datová)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Číslo revize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Nejvyšší frekvence</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Paměť pro grafiku</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fyzický identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Adresa v paměti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Vst./výstup. port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Informace o sběrnici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Nejvyšší možné rozlišení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Nejnižší možné rozlišení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Stávající rozlišení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Ovladač</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>vnitřní DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Výstup zobrazení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>Přerušení (IRQ)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Informace o sběrnici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fyzický identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Nejvyšší odběr</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Ovladač</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Sériové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Rozhraní</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Informace o sběrnici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fyzický identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Nejvyšší napájecí proud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Ovladač</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Přehled</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Počet procesorů</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Základní deska</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Operační paměť</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Zobrazovací adaptér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Zvukový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Úložiště</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Ostatní PCI zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Akumulátor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Síťový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Myš</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Klávesnice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>Jednotka optických médií</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Tiskárna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Ostatní zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>Operační systém</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Celková šíře</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Slot paměti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Sériové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Nastavené napětí</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Nejvyšší napájecí napětí</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Nejnižší napájecí napětí</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Nastavená rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Datová šířka</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Vstup zobrazení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Typ rozhraní</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Podpora rozlišení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Stávající rozlišení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Poměr stran zobrazení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Hlavní monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Sériové číslo</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Typ média</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Schopnosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fyzický identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Verze firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Sériové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Rozhraní</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Otáčky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Vyberte ovladač k aktualizaci</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>V této složce nebyly nalezeny žádné ovladače</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Načítání informací o zvukovém zařízení…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Načítání informací o BIOS/UEFI…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Načítání informací o jednotce optických disků…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Načítání informací o operačním systému…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Načítání informací o procesoru…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Načítání informací o ostatních zařízeních…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Načítání informací o napájení…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Načítání informací o tiskárně…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Načítání informací o myši…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Načítání informací o síťovém adaptéru…</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Informace o zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit zkratky</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Systém</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Správa zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Vybavení</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Přehled</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Zobrazovací adaptér</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Síťový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Akumulátor</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Více</translation>
     </message>
@@ -1702,178 +1645,171 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Nynější verze</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>Verze platformy pro řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Stav</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Činnost</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Zálohovatelné řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Zálohované řadiče</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Aktualizace</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Pokud bude ovladač odinstalován, zařízení nebude k dispozici</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Odinstalovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Odinstalování</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Podařilo se aktualizovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Podařilo se odinstalovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Nepodařilo se aktualizovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Nepodařilo se odinstalovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Zvolená složka neexistuje, vyberte znovu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Poškozený balíček</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Architektura balíčku neodpovídá</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Zvolený soubor neexistuje, vyberte znovu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Toto není ovladač</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Není možné nainstalovat – chybí digitální podpis</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Neznámá chyba</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Modul ovladače nebyl nalezen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Neplatný formát modulu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Modul ovladače má závislosti</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Název zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Dostupná verze</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Stav</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Činnost</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nová verze</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Nynější verze</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Chybějící ovladače (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Zastaralé ovladače (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Aktuální ovladače (%1)</translation>
     </message>
@@ -1939,132 +1870,126 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Instalace řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Záloha řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Obnova řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>Nemáte žádné řadiče k obnovení, prosím, nejprve záložte</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>Jít na zálohu řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>Verze zálohy</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Nynější verze</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>Obnovitelné řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Činnost</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Instalace řadiče</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Přehled</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Záloha řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Obnova řadiče</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Devět</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Zařízení se nepodařilo zapnout</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Zařízení se nepodařilo vypnout</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Nepodařilo se zakázat: nedaří se získat sériové číslo zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Aktualizovat ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Odinstalovat ovladače</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Přehled</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Zapnout</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Umožnit probouzet počítač</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Nepodařilo se zakázat: nedaří se získat sériové číslo zařízení</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Zařízení se nepodařilo vypnout</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Zařízení se nepodařilo zapnout</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Aktualizovat ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Odinstalovat ovladače</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>Dílčí výrobce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>Dílčí zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Ovladač</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Stav ovladače</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Příkaz pro aktivaci ovladače</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Stav nastavení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>prodleva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fyz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Identif. záznamů</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Sběrnice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Informace o BIOS/UEFI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Informace o základní desce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Informace o systému</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Informace o šasi počítače</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Pole fyzické paměti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Datum vydání</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Velikost běhového prostředí</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Velikost ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Charakteristiky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revize BIOS/UEFI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revize firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Název produktu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Sériové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Inventární štítek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Funkce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Umístění v šasi počítače</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Identif. záznamu pro šasi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Identif. záznamů pro obsažená zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>Nikde se neopakující identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Typ probouzení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>Skladové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Generace</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Zámek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Stav startu systému</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Stav napájecího zdroje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Teplotní stav</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Stav zabezpečení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM informace</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Výška</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Počet napájecích kabelů</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Obsažené prvky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Umístění</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Typ oprav chyb</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Nejvyšší možná kapacita</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Identif. záznamu informací o chybě</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Počet zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>VELIKOST UEFI/BIOS ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Datum vydání</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Název desky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Verze SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Formát popisu jazyka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Jazyky, které je možné nainstalovat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Nyní nainstalované jazyky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Adresa BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Typ paketu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Zásada linky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Režim linky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Třída</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Třídy služby</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Třída zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>verze HCI rozhraní</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Verze LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Podverze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Identifikační sériové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produkt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>popis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Napájeno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Objevitelné</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Možné spárovat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Alternativní název modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Objevování</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Moduly ovladače</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Soubor zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Soubory zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Číslo zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplikace</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>stav</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>logický název</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansi verze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementátor procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Architektura procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Varianta procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Část procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revize procesoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Jeden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Obnova řadiče selhala!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Deset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dvanáct</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Čtrnáct</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Šestnáct</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Osmnáct</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Dvacet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Dvacet dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Dvacet čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Dvacet šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Dvacet osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Třicet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Třicet dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Třicet čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Třicet šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Třicet osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Čtyřicet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Čtyřicet dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Čtyřicet čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Čtyřicet šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Čtyřicet osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Padesát</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Padesát dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Padesát čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Padesát šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Padesát osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Šedesát</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Šedesát dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Šedesát čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Šedesát šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Šedesát osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Sedmdesát</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Sedmdesát dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Sedmdesát čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Sedmdesát šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Sedmdesát osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Osmdesát</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Osmdesát dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Devadesát čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Osmdesát šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Osmdesát osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Devadesát</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Devadesát dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Devadesát čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Devadesát šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Devadesát osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Jedno sto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Jedno sto a dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Jedno sto a čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Jedno sto a šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Jedno sto a osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Jedno sto a deset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Jedno sto a dvanáct</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Jedno sto a čtrnáct</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Jedno sto a šestnáct</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Jedno sto a osmdesát</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Jedno sto a dvacet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Jedno sto a dvacet dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Jedno sto a dvacet čtyři</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Jedno sto a dvacet šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Jedno sto a dvacet osm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Jedno sto a devadesát dva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Dvě stě a padesát šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Kapacita GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Výrobce graf. čipu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Typ graf. čipu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Verze EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>API rozhraní EGL klienta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Verze GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Verze GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Neznámé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Třída hardware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Nenalezen žádný procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Základní deska</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Nenalezena žádná základní deska</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Operační paměť</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Nenalezena žádná operační paměť</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Úložiště</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Nenalezen žádný disk</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>Prosím, zkus to znovu nebo nám dejte zpětnou vazbu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>Záloha řadiče selhala!</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>Všech řadičů bylo zálohováno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Zobrazovací adaptér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Nenalezen grafický čip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Nenalezen žádný monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Síťový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Nenalezen žádný síťový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Zvukový adaptér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Nenalezeno žádné zvukové zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Nenalezena žádná Bluetooth zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Ostatní PCI zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Nenalezena žádná další PCI zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Napájení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Nenalezen žádný akumulátor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Klávesnice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Nenalezena žádná klávesnice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Myš</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Nenalezena žádná myš</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Tiskárna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Nenalezena žádná tiskárna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Nenalezena žádná kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>Jednotka optických médií</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Nenalezena žádná jednotka optických disků</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Ostatní zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Nenalezena žádná další zařízení</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Identif. záznamu pro pole</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Fyzická podoba</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Sada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Lokátor paměťové banky</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Podrobnosti o typu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Katalogové číslo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Naráz přistupovaných čipů (rank)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Technologie paměti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Schopnost režimu fungování oper. paměti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Verze firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Identif. výrobce modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Produktový identif. modulu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Identif. výrobce řadiče paměťového podsystému</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Produktový identif. řadiče paměťového podsystému</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Neměnná velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Proměnlivá velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Velikost mezipaměti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logická velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>palců</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -3692,315 +3453,296 @@
         <translation>stran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>Úložiště bez pohyblivých součástek (SSD)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>Pevný disk (HDD)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>informace o sběrnici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>velikost logického sektoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>velikost sektoru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>globálně se neopakující identif.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometrie (logická)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Správa zařízení</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Správa zařízení je užitečný nástroj pro zobrazování informací o hardware a správu zařízení.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Jsou dostupné nové ovladače! Nainstalujte nebo aktualizujte je nyní.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Pohled</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Zahrnout podsložky</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Ovladače hledat v této cestě</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 dostupné aktualizace ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Kontrolovaný čas: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Stahují se ovladače pro %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Rychlost stahování %1 Staženo %2 z %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Instalují se ovladače pro %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 ovladačů nainstalováná, %2 selhalo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 ovladačů nainstalováno</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Instalace ovladačů selhala</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Chyba připojení. Opětovné připojování...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Rychlost stahování: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Všechny ovladače jsou aktuální</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Celkem %1 řadičů, z nichž %2 bylo zálohováno</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Máte %1 řadičů, které lze zálohovat, doporučuje se je zálohovat okamžitě</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>Máte %1 řadičů, které lze zálohovat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>Zálohování řadiče %1, celkem %2 řadičů</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>Zálohování: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>%1 řadičů bylo zálohováno, %2 řadičů selhalo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>Zálohování řadičů selhalo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>Selhalo zálohovat ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 řidičů zálohováno</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>Máte %1 řidiče, které lze obnovit</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>Vezměte prosím řidič, který chcete obnovit</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>Řidič se obnovuje...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>Obnova: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>restart</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Vydržte %1, aby se nainstalované ovladače projevily</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>Zobrazit cestu zálohy</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
+        <translation>Zálohovat vše</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>odeslat zpětnou vazbu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Zkuste to prosím znovu nebo %1 nám</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Nainstalovat vše</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Prohledat znovu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Kontrola ovladačů hardwarových zařízení, počkejte prosím...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Prohledává se %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Prohledání se nezdařilo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Síť není dostupná</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Zkontrolujte, prosím, své síťové připojení</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Prohledejte znovu nebo %1 nám</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Probíhá instalace ovladače, která se po ukončení přeruší.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Opravdu chcete odejít?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Ukončit</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Zálohujete řidiče, která bude přerušena, pokud ukončíte program.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Obnovujete řidiče, která bude přerušena, pokud ukončíte program.</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Zobrazovací zařízení</translation>
     </message>
@@ -4071,27 +3812,27 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>Nezálohováno</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>Zálohování</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>Záloha selhala</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>Záloha proběhla úspěšně</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>Obnova</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4114,22 +3855,22 @@
         <translation>Nepodařilo se získat soubory ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>Zálohovat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Obnovit</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
         <translation>Instalovat</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportovat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Aktualizovat ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Odinstalovat ovladače</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Umožnit probouzet počítač</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Zapnout</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportovat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Vypnout</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Nedostupný</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Vyberte, prosím, místní složku</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Načítání…</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_da.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_da.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Flere</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>EC_NOTIFY_NETWORK</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>EC_REINSTALL</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Flere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Indklik</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Utiliseret</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Enhedsnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Forhandler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisionsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Hukommelsesadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Utiliseret</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Forhandler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Forhandler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Driver version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logisk navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC-adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Kernel ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Tråde</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>CPU-familie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Processor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Kernel (er)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualisering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Flag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Ekstensioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Steg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Maksimal hastighed</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Forhandler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Grafisk hukommelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Fysiske ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Hukommelsesadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO-port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maksimal opløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minimum opløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Aktuel opløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Styring</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Beskrivelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Digital Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Display Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Færdigheder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Færdigheder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Grænseflade</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maksimal strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Oversigt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Antal CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Mainboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Hukommelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Displayadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Lydadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Lagring</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Andre PCI-enheder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Netværksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Tastatur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Andre enheder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Enhedsnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Totalbredde</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Lokator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Konfigureret spænding</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Maksimal spænding</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Minimum spænding</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Konfigureret hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Databredde</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Visningsindgang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Grænseflade type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Støtteopløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Aktuel opløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Visningsforhold</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Hovedskærm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Driver version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Maksimal hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Forhandlingshastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto-negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Hukommelsesadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC-adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logisk navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Indgang/udgang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Hukommelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Styrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Utilgængeligt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kapasitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Spænding</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Slette</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Design kapasitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Design spænding</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS-serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS-fabrikationsdato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS-kemi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Delvis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Søgningstype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Medietype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Firmware-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Hastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Beskrivelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Søgning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Omdrejningshastighed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Vælg en driver til opdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Ingen drivere fundet i denne mappe</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Indlæser lydudstyrsinformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Indlæser BIOS-information...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Indlæser CD-ROM-information...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Indlæser operativsysteminformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Indlæser CPU-information...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Indlæser andre enhederinformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Indlæser strøminformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Indlæser printerinformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Indlæser musinformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Indlæser netværksadapterinformation...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Utilgængelig</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Enheder info</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Vis hurtigeksempel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Lukk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Hjælp</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Opfrisk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Enhederhåndtering</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Styresprog</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Oversigt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Skærmadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Netværksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Flere</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Styresprogplatforms version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Backupbare styresprog</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Backupped styresprog</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Opdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Annullér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Næste</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Enheden vil være utilgængelig efter styresprogets deinstallation</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Deinstallér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Deinstallerer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Opdatering er vellykket</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Deinstallation er vellykket</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Opdatering mislykkedes</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Avinstallering mislykkedes</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Næste</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Den valgte mappe findes ikke, vælg venligst igen</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Opdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Tilbage</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Skadet pakke</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Ikke matchende pakkearkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Den valgte fil findes ikke, vælg venligst igen</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Det er ikke en drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Kan ikke installere - ingen digital signatur</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Ukendt fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Den drivermodul blev ikke fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Ugyldig modulformat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Den drivermodul har afhængigheder</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Installer drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Backup drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Gendan drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Du har ingen drivere til at gendanne, backup venligst først</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Gå til Backup Drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Backup version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Gendanne drivere</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Opfrisk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Oversigt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Installer drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Backup drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Gendan drivere</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Kunne ikke aktivere enheden</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Kunne ikke deaktivere enheden</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Kunne ikke deaktivere det: kan ikke hente enhedens serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Opdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Fjern drivere</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Opdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Oversigt</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Opdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Aktiver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Opdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Fjern drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Tillad det at vågne computeren</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Kunne ikke deaktivere det: kan ikke hente enhedens serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Kunne ikke deaktivere enheden</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Kunne ikke aktivere enheden</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Opdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Fjern drivere</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Underleverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Underenhed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Driver-status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Driver aktiveringskommando</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Konfigurationsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Fysisk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Håndtere</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>BIOS-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Baseboard-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>System-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Chassis-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fysiske hukommelsesarray</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Udgivelsesdato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Kørtimestørrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM-størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Egenskaber</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>BIOS-revision</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Firmware-revision</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Produktets navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Aktivtag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Beliggenhed i chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Chassis-håndtering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Indeholdte objekthåndteringer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Opstartstype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU-nummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Familie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Lås</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Starttilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Strømtilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Termisk tilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Sikkerhedsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Højde</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Antal strømkabler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Indeholdte elementer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Beliggenhed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Fejlkorrektionsform</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maksimal kapacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Fejlinformationshåndtering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Antal enheder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROM-størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Udgivelsesdato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Platfrom navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Sprogbeskrivelsesformat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Installerbare sprog</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Aktuelt installeret sprog</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD-adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Pakketype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Link-policyn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Link-mode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klasse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Tjenesteklasser</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Enhedsklasse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Underversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Enhedsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produkt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>beskrivelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Tændt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Opdagelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Parable</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Opdager</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Styresprogsmoduler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Enhedsfil</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Enhedsfiler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Enhedsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logisk navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU-implementer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU-arkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU-variant</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU-del</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU-revision</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>En</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>To</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>otte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>ni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>tolve</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>fjorten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>seksten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>atten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>tyve</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>tyve og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>tyve og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>tyve og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>tyve og otte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>tredive</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>tredive og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>tredive og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>tredive og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>tredive og otte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>fyrre</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>fyrre og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>fyrre og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>fyrre og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>fyrre og otte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>femtio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>femtio og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>femtio og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>femtio og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>femtio og otte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>seksio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>seksio og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>seksio og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Seksogtreds</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Syvogtreds</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Syvogtreds</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Halvfjerds</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Halvfjerds og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Halvfjerds og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Halvfjerds og åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Atti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Atti og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Atti og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Atti og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Atti og åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Nitti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Nitti og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Nitti og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Nitti og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Nitti og åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Et hundrede</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Et hundrede og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Et hundrede og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Et hundrede og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Et hundrede og otte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Et hundrede og ti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Et hundrede og tolv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Et hundrede og fjorten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Et hundrede og seksten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Et hundrede ogatten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Et hundrede og tyve</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Et hundrede og tyve og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Et hundrede og tyve og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>En hundrede og tyve-ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>En hundrede og tyve-åt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>En hundrede og nitt-i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>To hundrede og femti-ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR-kapasitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU-udbyder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU-type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL-klient-API'er</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Ukendt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Unik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Hardwareklasse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Ingen CPU fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Mainboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Ingen mainboard fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Hukommelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Ingen hukommelse fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Lager</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Ingen disk fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Genopretning af drivere fejlet!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Prøv igen eller giv os feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Backup af drivere fejlet!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Displayadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Ingen GPU fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Ingen monitor fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Netværksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Ingen netværksadapter fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Lydadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Ingen lydudstyr fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Ingen Bluetooth-enheder fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Andre PCI-enheder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Ingen andre PCI-enheder fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Kraft</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Ingen batteri fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Tastatur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Ingen tastatur fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Ingen mus fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Ingen printer fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Ingen kamera fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Ingen CD-ROM fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Andre enheder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Ingen andre enheder fundet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array-handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Formfaktor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Sæt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Banklokator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Typedetaljer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Delnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Hukommelsesteknologi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Funktion for minnes arbejdsmodus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Firmware-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Module-fabrikant-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Module-produkt-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Minnesubsystem-styringsfabrikant-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Minnesubsystem-styringsprodukt-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Stabil størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Værende størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Cache-størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logisk størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>tomme</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Dato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>IO-port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>Netværk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>Batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>Nativ-sti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>Strømforsyning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>Opdateret</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>Har historik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>Har statistik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>Ladbar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>Tilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>Energien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>Energien tom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>Energien fuld</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>Energien fuld i design</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>Energienhedsrate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>Spænding</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>Procent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ikone-navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>på batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>lås er lukket</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>lås er tilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritisk handling</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopiér</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>opgave annulleres efter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>opgave holdes indtil</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>opgave prioritet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>markør ændringstid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>antal op ad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientering anmodet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>print-farve-mode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer modtager opgaver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer er delvist</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer er midlertidig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer model og type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>printer tilstand ændringstid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>printer tilstand årsager</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>printer-type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer-uri understøttes</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>sider</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logisk sektorstørrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sektorstørrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>guid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometri (logisk)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Enhedsbehandler</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Enhedsbehandler er et praktisk værktøj til at vise hardwareinformation og administrere enheder.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Der er nye drivere tilgængelige! Installer eller opdater dem nu.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Vis</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Inkluder undermapper</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Søg efter drivere i denne sti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 opdateringer for drivere tilgængelige'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Tid tjekket: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Henter drivere for %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Downloadhastighed: %1 Downloadet %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Installerer drivere for %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 drivere installeret, %2 drivere fejlet'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 drivere installeret'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Fejl ved installation af drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Netværksfejl. Forbindelse genoprettes...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Downloadhastighed: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Dine drivere er opdaterede</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Alle drivere er blevet sikkerhedskopieret</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>'I alt %1 drivere, heraf %2 er blevet sikkerhedskopieret'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Du har %1 drivere, der kan sikkerhedskopieres, og det anbefales at gøre det umiddelbart</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Du har %1 drivere, der kan sikkerhedskopieres</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Sikkerhedskopierer %1 driver, i alt %2 drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Sikkerhedskopierer: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 drivere sikkerhedskopieret, %2 drivere fejlet'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Fejl ved sikkerhedskopiering af drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 drivere sikkerhedskopieret'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Du har %1 drivere, der kan gendannet</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Vælg venligst en driver til gendannelse</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Styreren gendanner...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Gendanner: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>Genstart</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Vennligst %1 for at de installerede drivere skal træde i kraft</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Vis sikkerhedskopi sti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Sikkerhedskopi alt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>send tilbagemelding</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Vennligst prøv igen eller %1 til os</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Installer alt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Scan igen</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Afbryd</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Scan af hardware drivere, venligst vent...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Scan %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Scan fejlede</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Netværk utilgængeligt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Vennligst tjek din netværksforbindelse</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Vennligst scan igen eller %1 til os</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Du installerer et driver, som vil blive afbrudt, hvis du forlader.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Er du sikker på, at du vil forlade?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Forlad</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Afbryd</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Du gør en sikkerhedskopi af drivere, som vil blive afbrudt, hvis du forlader.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Du gendanner drivere, som vil blive afbrudt, hvis du forlader.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Billedkamera</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Display adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Lydkort</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Netværksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Trådløst netværksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Installationen er vellykket</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Installation fejlede</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Downloader</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Installerer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Ikke installeret</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Uddat</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Venter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Ikke sikkerhedskopieret</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Sikkerhedskopierer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Sikkerhedskopiering fejlede</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Sikkerhedskopiering lykkedes</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Gendanner</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Ukendt fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Netværksfejl</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Annulleret</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Fejl ved at hente drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Opdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Sikkerhedskopi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Gendan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Installer</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Opfrisk</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Opdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Fjern drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Tillad det at vågner computeren</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Aktivér</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Opfrisk</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopiér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Utiliser</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Vælg venligst en lokal mappe</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Indlæser...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_de.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_de.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Rückmeldung</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Mehr</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Einklappen</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Mehr</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Mehr</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Einklappen</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Mehr</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Einklappen</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Gerätename</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Modul-Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Physische ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Pfad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeTreiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Speicheradresse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipsatz</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Modul-Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Physische ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Maximale Leistung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Treiber-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Bus-Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logischer Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC-Adresse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Bus-Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maximale Leistung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Modul-Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Physische ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Kern-ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Architektur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU-Familie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Prozessor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Kern(e)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualisierung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Flags</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Erweiterungen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Max. Geschwindigkeit</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Grafikspeicher</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Modul-Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Physische ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Speicheradresse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>EA-Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Bus-Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maximale Auflösung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Minimale Auflösung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Aktuelle Auflösung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalAusgang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Ausgabe anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Bus-Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Modul-Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Physische ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maximale Leistung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Seriennummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Schnittstelle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Bus-Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Modul-Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Physische ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Maximale Stromstärke</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Übersicht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>CPU-Anzahl</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Hauptplatine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Anzeigeadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Sound Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Weitere PCI-Geräte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Akku</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Netzwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Maus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Tastatur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Drucker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Weitere Geräte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Gerät</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>BS</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Gesamtbreite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Lokator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Seriennummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Konfigurierte Spannung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Maximale Spannung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Minimale Spannung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Konfigurierte Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Datenbreite</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Eingang anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Schnittstellentyp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Unterstützte Auflösung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Aktuelle Auflösung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Anzeigeverhältnis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Primärer Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Seriennummer</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Medientyp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Fähigkeiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Modul-Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Physische ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmware-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Seriennummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Schnittstelle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Drehgeschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Wähle einen Treiber für die Aktualisierung aus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>In diesem Ordner wurden keine Treiber gefunden</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Audiogerät-Info wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS-Info wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM-Info wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Betriebssystem-Info wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>CPU-Info wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Infos anderer Geräte laden…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Leistungsinfo laden…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Drucker-Info wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Maus-Info wird geladen ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Netzwerkadapter-Info wird geladen ...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Geräte-Info</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Kürzel anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Geräteverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Übersicht</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Anzeigeadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Netzwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Akku</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Mehr</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Aktuelle Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Treiberplattform-Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Sicherbare Treiber</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Gesicherte Treiber</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Wird aktualisiert</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Weiter</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Das Gerät kann nach der Deinstallation der Treiber nicht verwendet werden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Deinstallieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Wird deinstalliert</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Aktualisierung erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Deinstallation erfolgreich</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Aktualisierung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Deinstallation fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Weiter</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Der ausgewählte Ordner existiert nicht, bitte erneut auswählen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Vorheriges</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Kaputtes Paket</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Nicht übereinstimmende Paketarchitektur</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Die ausgewählte Datei existiert nicht, bitte erneut auswählen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Es ist kein Treiber</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Konnte nicht installieren - keine digitale Signatur</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Das Treibermodul wurde nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Ungültiges Modulformat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Das Treibermodul hat Abhängigkeiten</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Gerätename</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Version verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Neue Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Aktuelle Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Fehlende Treiber (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Veraltete Treiber (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Neueste Treiber (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
-        <source>Driver Install</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
-        <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
+        <source>Driver Install</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
-        <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
+        <source>Driver Backup</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
+        <source>Driver Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Rückmeldung</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Aktuelle Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Sicherungsversion</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Wieherherstellbare Treiber</translation>
     </message>
@@ -2011,60 +2013,60 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Übersicht</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Das Gerät konnte nicht aktiviert werden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Das Gerät konnte nicht deaktiviert werden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Konte nicht abgeschalten werde: Geräte SN konnte nicht gefunden werden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Treiber aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Treiber deinstallieren</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Übersicht</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Aktivieren</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Aufwecken des Computers erlauben</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Konte nicht abgeschalten werde: Geräte SN konnte nicht gefunden werdenKonte nicht abgeschalten werde: Geräte SN konnte nicht gefunden werden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Das Gerät konnte nicht deaktiviert werden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Das Gerät konnte nicht aktiviert werden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Treiber aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Treiber deinstallieren</translation>
     </message>
@@ -2165,1321 +2167,1321 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
-        <source>SubVendor</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
-        <source>SubDevice</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <source>SubVendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
+        <source>SubDevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Treiber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Treiber-Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Befehl zur Treiberaktivierung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Konfigurationsstatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>Latenz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Handler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>SCHLÜSSEL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>BIOS-Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>System-Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Gehäuse-Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Physikalischer Speicher</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Veröffentlichungsdatum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Laufzeitgröße</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM-Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS-Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware-Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Produktname</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Seriennummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Systemkennnummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Merkmale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Platz im Gehäuse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Chassis-Griff</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Enthaltene Objektgriffe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Aufwachtyp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>SKU Nummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Familie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Sperre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Boot-Up-Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Status Stromversorgung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Thermischer Zustand</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Sicherheitsstatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Höhe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Anzahl der Stromkabel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Enthaltene Elemente</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Ort</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Fehlerkorrekturtyp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maximale Kapazität</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Anzahl an Geräten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>ROM-Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Veröffentlichungsdatum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Platinenname</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format der Sprachbeschreibung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Installierbare Sprachen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Aktuell installierte Sprache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD-Adresse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Pakettyp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Klasse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Dienstklassen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Geräteklasse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Unterversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Gerät</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Serielle ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>Produkt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Eingeschalten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Auffindbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Koppelbar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Treiber-Module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Gerätedatei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Gerätedateien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Gerätenummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Applikation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>logischer Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ANSI-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU-Einbauer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU-Architektur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU-Variante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU-Teil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU-Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Eins</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Zwei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Vier</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Sechs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Acht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Zehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Zwölf</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Vierzehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Sechzehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Achtzehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Zwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Zweiundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Vierundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Sechsundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Achtundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Dreißig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Zweiunddreißig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Vierunddreißig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Sechsunddreißig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Achtunddreißig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Vierzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Zweiundvierzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Vierundvierzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Sechsundvierzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Achtundvierzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Fünfzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Zweiundfünfzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Vierundfünfzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Sechsundfünfzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Achtundfünfzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sechszig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Zweiundsechzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Vierundsechzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sechsundsechzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Achtundsechzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Siebzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Zweiundsiebzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Vierundsiebzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Sechsundsiebzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Achtundsiebzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Achtzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Zweiundachtzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Vierundachtzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Sechsundachtzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Achtundachtzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Neunzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Zweiundneunzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Vierundneunzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Sechsundneunzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Achtundneunzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Einhundert</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Einhundertzwei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Einhundertvier</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Einhundertsechs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Einhundertacht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Einhundertzehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Einhundertzwölf</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Einhundertvierzehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Einhundertsechzehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Einhundertachtzehn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Einhundertzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Einhundertzweiundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Einhundertvierundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Einhundertsechsundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Hundertachtundzwanzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Einhundertzweiundneunzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Zweihundertsechsundfünfzig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR-Kapazität</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU-Anbieter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU-Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL-Version</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Hardwareklasse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Keine CPU gefunden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Hauptplatine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Keine Hauptplatine gefunden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Kein Speicher gefunden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Keine Festplatte gefunden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Anzeigeadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Keine GPU gefunden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Kein Monitor gefunden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Netzwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Kein Netzwerkadapter gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Sound Adapter</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Kein Audiogerät gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Kein Bluetooth-Gerät gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Weitere PCI-Geräte</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Keine weiteren Geräte gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Akku </translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Kein Akku gefunden</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Sound Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Kein Audiogerät gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Kein Bluetooth-Gerät gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Weitere PCI-Geräte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Keine weiteren Geräte gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Akku </translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Kein Akku gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Tastatur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Keine Tastatur gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Maus</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Keine Maus gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Drucker</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Kein Drucker gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Kamera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Keine Kamera gefunden</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>Keine CD-ROM gefunden</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Maus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Keine Maus gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Drucker</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Kein Drucker gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Keine Kamera gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>Keine CD-ROM gefunden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Weitere Geräte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Keine weiteren Geräte gefunden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Formfaktor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Bank Lokator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Teilenummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Speichertechnologie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmware-Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Nicht-flüchtige Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Flüchtige Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Cache-Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logische Größe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>Zoll</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
         <source>ioport</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
@@ -3574,7 +3576,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
         <source>icon-name</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
@@ -3584,7 +3586,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
         <source>daemon-version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
@@ -3692,315 +3694,315 @@
         <translation>Seiten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>Bus-Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>logische-sektoren-grösse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>Sektorgröße</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometrie (logisch)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Geräteverwaltung</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Geräteverwaltung ist ein praktisches Werkzeug zur Anzeige von Hardware-Informationen und zur Verwaltung der Geräte.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Neue Treiber erhältlich! Jetzt installieren oder updaten.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Unterordner einbeziehen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Nach Treibern in diesem Pfad suchen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 Treiberaktualisierungen verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Zeit bestimmt: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Treiber für %1 werden heruntergeladen ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Herunterladegeschwindigkeit: %1 Heruntergeladen %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Treiber für %1 werden installiert ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 Treiber installiert, %2 Treiber fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 Treiber installiert</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Treiber konnten nicht installiert werden</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Netzwerkfehler. Verbindung wiederherstellen ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Herunterladegeschwindigkeit: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Ihre Treiber sind auf dem neuesten Stand</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Alle Treiber wurden gesichert</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Insgesamt %1 Treiber, von denen %2 gesichert wurden</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Sie haben %1 Treiber, die gesichert werden können, es wird empfohlen, dies sofort zu tun</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Sie haben %1 Treiber, die gesichert werden können</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Wird gesichert: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 Treiber gesichert, %2 Treiber fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 Treiber gesichert</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Sie haben %1 Treiber, die wiederhergestellt werden können</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Bitte wählen Sie einen Treiber zum Wiederherstellen aus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Treiber wird wiederhergestellt...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Wird wiederhergestellt: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>neustarten</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Bitte %1 um die installierten Treiber einzusetzen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Sicherungspfad ansehen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Alles sichern</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>Rückmeldung absenden</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Bitte nochmals versuchen oder an uns %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Alle installieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Erneut Scannen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Hardwaretreiber werden gescannt, bitte warten…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Scanne %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Scan fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Netzwerk nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Bitte überprüfen Sie Ihre Netzwerkverbindung</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Bitte nochmals scannen oder %1 an uns</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Ein Treiber wird installiert, was unterbrochen wird, wenn Sie weggehen.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sind Sie sicher, dass Sie beenden möchten?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
@@ -4114,22 +4116,22 @@
         <translation>Treiber konnten nicht bezogen werden</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Sichern</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Installieren</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Treiber aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Treiber aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Aufwecken des Computers erlauben</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Aktivieren</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Nicht verfügbar</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Bitte einen lokalen Ordner auswählen</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Wird geladen ...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_el.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_el.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="el">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Σχολιασμός</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Είναι ΟΚ</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Περισσότερα</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Ειδοποίηση Δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Επανεγκατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Περισσότερα</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Σύμπτωση</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Αναποστολή</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Όνομα Συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Κύκλος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>Συμβολοσειρά Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Επαναγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Ενσωματωμένος Προγραμματιστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Διεύθυνση Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Αναποστολή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Σύστημα Χιπς</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Παραλλαγή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Παραγωγός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Μέγιστη Ισχύ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Έκδοση Προγράμματος Ελέγχου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Πρόγραμμα Ελέγχου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Λογικό Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>Διεύθυνση MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Απρόσιτο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Παραγωγός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Πρόγραμμα Ελέγχου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Μέγιστη Ισχύ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Απρόσιτο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Παραγωγός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>Κωδικός CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Κωδικός Πυρήνα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Θραύσματα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>ΒογοΜΙΠΣ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Αρχιτεκτονική</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Οικογένεια ΚΕΠΙ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Επεξεργαστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Πυρήνας (ς)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Διαστολή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Σήματα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Προσθήκες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Βήμα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Μέγιστη Ταχύτητα</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Μνήμη Γραφικών</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Φυσικό ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Διεύθυνση Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>Πόρτα I/O</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συνδέσμου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Μέγιστη Ανάλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Ελάχιστη Ανάλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation> Παρούσα Ανάλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Διατροφή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Περιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Εξόδους Ψηφιακά</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Εξόδους Οθόνης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Μη διαθέσιμο</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Μέγιστη Ισχύ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Διαχειριστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός Σειράς</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Μη διαθέσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Διεπαφή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Μέγιστη Ροή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Διαχειριστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Μη διαθέσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Απενεργοποιήστε</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Περίληψη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>Επεξεργαστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Ποσότητα επεξεργαστή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Μητρική πλακέτα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Εσωτερική Μνήμη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Προσαρμογέας Εμφάνισης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Προσαρμογέας Ήχου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Αποθήκευση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Άλλα PCI Συσκευές</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Ακμή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Προσαρμογέας Δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Ποντίκι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Πληκτρολόγιο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Οθόνη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Εκτυπωτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Φωτογραφική Μηχανή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Άλλες Συσκευές</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Συσκευή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>Σύστημα Λειτουργιών</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Μέγεθος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Τύπος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Συνολικός Πλάτος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Οδηγός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός Σειράς</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Κατασκευασμένη Τάση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Μέγιστη Τάση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Ελάχιστη Τάση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Κατασκευασμένη Συχνότητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Πλάτος Δεδομένων</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Είδος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Είσοδος Εμφάνισης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Είδος Διασύνδεσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Επιτρεπτή Ανάλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Παρούσα Ανάλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Αναλογία Εμφάνισης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Κύριος Επεξεργαστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Μέγεθος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός Σειράς</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Είδος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συσκευασίας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Διαχειριστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Έκδοση Διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Μέγιστη Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Ταχύτητα Συμφωνίας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Πόρτα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Μονοπροσωπική</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Σύνδεση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Καθυστέρηση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Φλάσαρισμα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Διπλό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Διακήρυξη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Αυτόματη Συμφωνία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Διεύθυνση Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>Διεύθυνση MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Λογικό Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Μη διαθέσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Παραγωγός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Είσοδος/Εξόδος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Μνήμη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Καθυστέρηση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Διαχειριστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Παραγωγός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Πληροφορίες Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Διαχειριστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Μέγιστη Ισχύ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός Σειράς</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Μη διαθέσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός Σειράς</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Τύπος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Κατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Κεφαλαίο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Τάση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Περιοχή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Σχεδιασμένη Επεκτασιμότητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Σχεδιασμένη Τάση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>Έκδοση SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>Αριθμός Σειράς SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>Ημερομηνία Αναφοράς SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>Χημεία SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Θερμοκρασία</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Μοντέλο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Προμηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός Σειράς</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Κοινή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Κατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Τύπος διασύνδεσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Παραγωγός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Τύπος μέσου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Μέγεθος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Δυνατότητες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Έκδοση Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Ταχύτητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Περιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός σειράς</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Τύπος διασύνδεσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Ρυθμός περιστροφής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Ενεργός</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Επιλέξτε έναν προγραμματιστή για ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Δεν βρέθηκαν προγραμματιστές σε αυτό το φάκελο</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Φόρτωση πληροφοριών συσκευής ήχου...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Φόρτωση πληροφοριών BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Φόρτωση πληροφοριών CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Φόρτωση πληροφοριών Συστήματος Λειτουργίας...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Φόρτωση πληροφοριών CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Φόρτωση πληροφοριών άλλων συσκευών...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Φόρτωση πληροφοριών Ενέργειας...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Φόρτωση πληροφοριών εκτυπωτή...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Φόρτωση πληροφοριών ποντικιού...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Φόρτωση πληροφοριών διασύνδεσης δικτύου...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Ενεργός</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Ενεργός</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Πληροφορίες Συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Εμφάνιση συντομεύσεων</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Κλείσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Βοήθεια</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Αντιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Σύστημα</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Επαναφόρτωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Διαχειριστής Συσκευών</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Υλικό</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Διαχειριστές</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Επιτραπέζιο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Περίληψη</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Προσαρμογέας Οθόνης</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>Επεξεργαστής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Προσαρμογέας Δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Ακμή</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Περισσότερα</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Έκδοση πλατφόρμας διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Διαχειριστές που μπορούν να αποθηκευτούν</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Αποθηκευμένοι διαχειριστές</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Ακύρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Επόμενο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Προειδοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Η συσκευή θα γίνει αναπροσιτή μετά την απεγκείματο του διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Απεγκείματο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Απεγκείματο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Ενημέρωση επιτυχής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Απεγκείματο επιτυχής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Η αναβάθμιση απέτυχε</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Η απασχολήση απέτυχε</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Είναι</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Επόμενο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Ο φάκελος που επιλέχθηκε δεν υπάρχει, επιλέξτε ξανά</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Προηγούμενο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Κατεστραμμένο συσκευασμένο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Ασυμβατός αρχιτεκτονικός συσκευασμένο</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Το αρχείο που επιλέχθηκε δεν υπάρχει, επιλέξτε ξανά</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Δεν είναι διαχειριστής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Δεν μπορεί να εγκατασταθεί - χωρίς ψηφιακό υπογραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Άγνωστο σφάλμα</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Το μέτρο διαχειριστή δεν βρέθηκε</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Μη έγκυρος μορφός μέτρου</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Το μέτρο διαχειριστή έχει ανάλογα στοιχεία</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Εγκατάσταση Διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Αντίγραφο Ασφαλείας Διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Επαναφορά Διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Σχόλια</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Δεν έχετε κανέναν διαχειριστή για επαναφορά, εγκαταστήστε πρώτα</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Πάτε στο Αντίγραφο Ασφαλείας Διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Έκδοση Αντίγραφου Ασφαλείας</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Επαναφορά Διαχειριστών</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Περίληψη</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Εγκατάσταση Διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Αντίγραφο Ασφαλείας Διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Επαναφορά Διαχειριστή</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Αποτυχία ενεργοποίησης του συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Αποτυχία απενεργοποίησης του συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Αποτυχία απενεργοποίησής του: αδυναμία ανάκτησης του SN του συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Ενημέρωση Υποδειγμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Απεγκλωβισμός Υποδειγμάτων</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Ανανέωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Αντιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Περίληψη</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Ανανέωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Αντιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Ενεργοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Ενημέρωση υποδειγμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Απεγκλωβισμός υποδειγμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Επιτρέψτε την ενεργοποίηση του υπολογιστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Αποτυχία απενεργοποίησής του: αδυναμία ανάκτησης του SN του συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Αποτυχία απενεργοποίησης του συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Αποτυχία ενεργοποίησης του συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Ενημέρωση Υποδειγμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Απεγκλωβισμός Υποδειγμάτων</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Υποπρομηθευτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Υποσυσκευή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Υποδείγματα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Κατάσταση Υποδειγμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Ενεργοποίηση Υποδειγμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Κατάσταση Διαμόρφωσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>Καθυστέρηση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Φυσικό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Διαχειριστές</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Συστατικό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Πληροφορίες BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Πληροφορίες Βάσης Πλακέτας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Πληροφορίες Συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Πληροφορίες Κουτιού</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Φυσικός Πίνακας Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Ημερομηνία Εκδόσεως</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Διεύθυνση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Μέγεθος Λειτουργίας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Μέγεθος ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Χαρακτηριστικά</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Επεξεργασία BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Επεξεργασία Λογισμικού</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Όνομα Προϊόντος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Αριθμός Σειράς</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Ετικέτα Περιουσίας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Χαρακτηριστικά</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Τοποθεσία Στο Κουτί</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Επεξεργασία Κουτιού</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Τύπος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Επεξεργασία Αντικειμένων που Περιέχονται</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Τύπος Ενεργοποίησης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Αριθμός SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Οικογένεια</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Κλείδωμα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Κατάσταση εκκίνησης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Κατάσταση παροχής ενέργειας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Θερμική κατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Κατάσταση ασφαλείας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Πληροφορίες OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Ύψος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Αριθμός καλωδίων ενέργειας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Περιεχόμενα στοιχεία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Τοποθεσία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Τύπος διόρθωσης σφαλμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Μέγιστη χωρητικότητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Επεξεργασία σφαλμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Αριθμός συσκευών</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>Μέγεθος BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Ημερομηνία κυκλοφορίας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Όνομα πλακέτας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>Έκδοση SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Γλώσσα περιγραφής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Εγκαθιστήσιμες γλώσσες</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Προς τρέχουσα εγκατεστημένη γλώσσα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>Διεύθυνση BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Τύπος πακέτου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Πολιτική σύνδεσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Λειτουργία σύνδεσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Κλάση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Κλάσεις υπηρεσίας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Κλάση συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Έκδοση HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Έκδοση LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Υποέκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Συσκευή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Αναγνωριστικός Αριθμός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>προϊόν</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>περιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Ενεργοποιημένο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Εξαπαγορεύσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Συνδεόμενο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Μοδαλιας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Ανακάλυψη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Μέτρα Προγράμματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Αρχείο Συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Αρχεία Συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Αριθμός Συσκευής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Εφαρμογή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>κατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>λογικός όνομα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansi εκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Εκτελεστής CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Αρχιτεκτονική CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Εκδοση CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Τμήμα CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Επεξεργασία CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Ένα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Τέσσερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Εξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Οκτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Εννέα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Δέκα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Δωδέκα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Δεκατέταρτο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Δεκαέξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Δεκαοχτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Είκοσι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Είκοσι δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Είκοσι τέσσερις</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Είκοσι έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Είκοσι οχτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Εττόρις</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Εττόρις δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Εττόρις τέσσερις</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Εττόρις έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Εττόρις οχτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Εκατονταρις</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Εκατονταρις δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Εκατονταρις τέσσερις</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Εκατονταρις έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Εκατονταρις οχτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Πενήντα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Πενήντα δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Πενήντα τέσσερις</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Πενήντα έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Πενήντα οχτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Εξήντα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Εξήντα δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Εξήντα τέσσερις</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Εξήντα έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Εξήντα οκτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Εβδομήντα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Εβδομήντα δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Εβδομήντα τέσσερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Εβδομήντα έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Εβδομήντα οκτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Εικοσάδεκα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Εικοσάδεκα δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Εικοσάδεκα τέσσερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Εικοσάδεκα έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Εικοσάδεκα οκτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Ενενήντα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Ενενήντα δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Ενενήντα τέσσερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Ενενήντα έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Ενενήντα οκτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Εκατό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Εκατό και Δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Εκατό και Τέσσερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Εκατό και Εξί</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Εκατό και Οκτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Εκατό και Δέκα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Εκατό και Δωδέκα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Εκατό και Δεκατέταρτο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Εκατό και Δεκαέξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Εκατό και Δεκαοκτώ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Εκατό και Εικοσί</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Εκατό και Εικοσί δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Εκατό και Εικοσί τέσσερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Σε εκατόν δεκαπέντε</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Σε εκατόν δεκαεπτά</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Σε εκατόν ενενήντα δύο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Σε δύο εκατόν πενήντα έξι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Επίπεδο GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Προμηθευτής GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Τύπος GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Έκδοση EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API EGL Πελάτη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Έκδοση GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Έκδοση GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Άγνωστος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Επαναληπτικός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Κατηγορία Υλικού</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Δεν βρέθηκε CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Μητρική Πλακέτα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Δεν βρέθηκε μητρική πλακέτα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Μνήμη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Δεν βρέθηκε μνήμη</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Αποθήκευση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Δεν βρέθηκε δίσκος</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Η ανάκτηση του διαχειριστή απέτυχε!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Παρακαλούμε προσπαθήστε ξανά ή δώστε μας αντεπιστροφή</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Η αντίγραφος ασφαλείας του διαχειριστή απέτυχε!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Προσαρμογέας Απεικόνισης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Δεν βρέθηκε GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Επίπεδο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Δεν βρέθηκε επίπεδο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Διακόπτης Δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Δεν βρέθηκε διακόπτης δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Προσαρμογέας ήχου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Δεν βρέθηκε συσκευή ήχου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Δεν βρέθηκε συσκευή Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Άλλες συσκευές PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Δεν βρέθηκαν άλλες συσκευές PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Ενέργεια</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Δεν βρέθηκε μπαταρία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Πληκτρολόγιο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Δεν βρέθηκε πληκτρολόγιο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Ποντίκι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Δεν βρέθηκε ποντίκι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Εκτυπωτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Δεν βρέθηκε εκτυπωτής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Κάμερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Δεν βρέθηκε κάμερα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Δεν βρέθηκε CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Άλλες συσκευές</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Δεν βρέθηκαν άλλες συσκευές</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Διαμερισματικός Διαχειριστής</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Μορφή Συσκευασίας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Σύνολο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Οδηγός Τραπεζικού Καταστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Λεπτομέρειες Τύπου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Αριθμός Μέρους</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Προτεραιότητα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Τεχνολογία Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Δυναμική Ικανότητα Λειτουργίας Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Έκδοση Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Κωδικός Παραγωγού Μονάδας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Κωδικός Προϊόντος Μονάδας</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Κωδικός Παραγωγού Ελεγκτή Συστήματος Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Κωδικός Προϊόντος Ελεγκτή Συστήματος Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Μέγεθος Απρόσιτης Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Μέγεθος Προσιτής Μνήμης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Μέγεθος Καταχωρήσεων</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Λογικό Μέγεθος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>ιντσά</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Ημερομηνία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>είσοδος/έξοδος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>δίκτυο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>μπαταρία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>προσανατολισμένος δρόμος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>παροχή ισχύος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>ενημερωμενό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>έχει ιστορικό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>έχει στατιστικά</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ανακατασκευάσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>κατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>επίπεδο προειδοποίησης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>έργο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>έργο κενό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>έργο γεμάτο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>έργο πλήρες σχεδιασμός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ταχύτητα έργου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>τάση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>ποσοστό</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>τεχνολογία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>όνομα εικονιδίου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>σε σύνδεση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>έκδοση δαίμονα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>στην μπαταρία</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>το κάλυμμα είναι κλειδωμένο</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>το κάλυμμα υπάρχει</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>κρίσιμη δράση</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>αντίγραφα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>ακύρωση έργου μετά</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>κράτηση έργου μέχρι</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>προτεραιότητα έργου</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>χρόνος αλλαγής σήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>αριθμός αντικειμένων ανά σελίδα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ζεύγωση αιτούμενης κατεύθυνσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>λειτουργία χρωμάτων εκτύπωσης</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>το εκτυπωτής δέχεται έργα</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>το εκτυпωτής κοινός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>το εκτυπωτής προσωρινός</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>κατασκευαστής και μοντέλο εκτυπωτή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>χρόνος αλλαγής κατάστασης εκτυπωτή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>λόγοι κατάστασης εκτυπωτή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>τύπος εκτυπωτή</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI εκτυπωτή που υποστηρίζεται</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>πλευρές</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>πληροφορίες συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>μέγεθος τμημάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>μέγεθος τμημάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>guid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Γεωμετρία (Λογική)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Διαχειριστής Συσκευών</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Ο Διαχειριστής Συσκευών είναι ένα χρήσιμο εργαλείο για την προβολή πληροφοριών σχετικά με το υλικό και τη διαχείριση των συσκευών.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Υπάρχουν νέοι διαχειριστές! Εγκαταστήστε ή ενημερώστε τώρα.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Προβολή</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Περιλαμβάνετε υποκαταλόγια</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Αναζήτηση διαχειριστών σε αυτό το δρομολόγιο</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 ενημερώσεις διαχειριστή' διαθέσιμες</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Ώρα ελέγχου: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Λήψη διαχειριστών για %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Ταχύτητα λήψης: %1 Εγγραφές %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Εγκατάσταση διαχειριστών για %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 διαχειριστές εγκαταστάθηκαν, %2 διαχειριστές απέτυχαν'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 διαχειριστές εγκαταστάθηκαν'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Αποτυχία εγκατάστασης διαχειριστών</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Σφάλμα δικτύου. Επανασύνδεση...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Ταχύτητα λήψης: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Οι διαχειριστές σας είναι ενημερωμένοι</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Όλοι οι διαχειριστές έχουν αποθηκευτεί</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Σύνολο %1 διαχειριστών, από τους οποίους %2 έχουν αποθηκευτεί</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Έχετε %1 διαχειριστές που μπορούν να αποθηκευτούν, συνιστάται να το κάνετε αμέσως</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Έχετε %1 διαχειριστές που μπορούν να αποθηκευτούν</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Αποθήκευση του %1 διαχειριστή, σύνολο %2 διαχειριστών</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Αποθήκευση: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 διαχειριστές αποθηκευτείστε, %2 διαχειριστές απέτυχαν'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Αποτυχία αποθήκευσης διαχειριστών</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 διαχειριστές αποθηκευτείστε'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Έχετε %1 διαχειριστές που μπορούν να επαναφορτωθούν</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Παρακαλώ επιλέξτε έναν διαχειριστή για επαναφόρτωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Το διατροφικό είναι σε διαδικασία ανακατασκευής...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Ανακατασκευή: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>επανεκκίνηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Παρακαλούμε %1 για να γίνει ηρεμία των εγκατεστημένων διατροφικών</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Προβολή διαδρομής αναπαραγωγής</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Αναπαραγωγή Όλων</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>υποβολή σχολίων</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Παρακαλούμε προσπαθήστε ξανά ή %1 σε εμάς</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Εγκατάσταση Όλων</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Σάρωση Ξανά</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Ακύρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Σάρωση διατροφικών συσκευών, παρακαλούμε περιμένετε...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Σάρωση %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Η σάρωση απέτυχε</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Δίκτυο απρόσιτο</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Παρακαλούμε ελέγξτε ξανά τη σύνδεση σας με το δίκτυο</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Παρακαλούμε σάρωση ξανά ή %1 σε εμάς</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Εγκαταστάτε ένα διατροφικό, το οποίο θα διακοπεί αν αποχωρήσετε.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Είστε σίγουροι ότι θέλετε να αποχωρήσετε;</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Έξοδος</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Ακύρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Εγκαταστάτε ένα διατροφικό, το οποίο θα διακοπεί αν αποχωρήσετε.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Εγκαταστάτε ένα διατροφικό, το οποίο θα διακοπεί αν αποχωρήσετε.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Εξοδός Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Συσκευή εικόνας</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Εξοδός οθόνης</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Πλάκα ήχου</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Εξοδός δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Εξοδός ασύρματου δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Εγκατάσταση επιτυχής</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Η εγκατάσταση απέτυχε</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Λήψη</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Εγκατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Δεν εγκαταστάληκε</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Παλιό</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Αναμονή</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Δεν έχει αντιγραφή ασφαλείας</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Εκτέλεση αντιγραφής ασφαλείας</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Η αντιγραφή ασφαλείας απέτυχε</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Η αντιγραφή ασφαλείας επιτυχήθηκε</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Επαναφορά</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Άγνωστο σφάλμα</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Σφάλμα δικτύου</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Ακυρώθηκε</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Αποτυχία ανάκτησης αρχείων διαχειριστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Αντιγραφή ασφαλείας</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Επαναφορά</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Εγκατάσταση</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Ενημέρωση διαχειριστών</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Απεγκατάσταση διαχειριστών</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Επιτρέψτε την ενεργοποίηση του υπολογιστή</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Ενεργοποίηση</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Εξαγωγή</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Αντιγραφή</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Απενεργοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Αναποσπάσιμο</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Παρακαλώ επιλέξτε μια τοπική φάλτσα</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Φόρτωση...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_en_AU.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_en_AU.ts
@@ -1,29 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="en_AU">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_AU">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
-        <source>OK</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
+        <source>OK</source>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation>More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation>Collapse</translation>
     </message>
 </context>
 <context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation>More</translation>
     </message>
 </context>
 <context>
@@ -31,140 +46,121 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>EC_NOTIFY_NETWORK</source>
-        <translation type="unfinished"/>
+        <translation>EC_NOTIFY_NETWORK</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>EC_REINSTALL</source>
-        <translation type="unfinished"/>
+        <translation>EC_REINSTALL</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>EC_6</source>
-        <translation type="unfinished"/>
+        <translation>EC_6</translation>
     </message>
 </context>
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation>More</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
-        <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation>Collapse</translation>
     </message>
 </context>
 <context>
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
 </context>
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Device Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
-        <translation type="unfinished"/>
+        <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
-        <translation type="unfinished"/>
+        <translation>Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
-        <translation type="unfinished"/>
+        <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Memory Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,163 +202,163 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
-        <translation type="unfinished"/>
+        <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Driver Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logical Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Core ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Core(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualisation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Flags</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensions</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Max Speed</translation>
     </message>
@@ -488,488 +479,450 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Graphics Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Memory Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maximum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Minimum Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Current Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
-        <translation type="unfinished"/>
+        <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Display Output</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
 </context>
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maximum Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Maximum Current</translation>
     </message>
 </context>
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
-        <translation type="unfinished"/>
+        <translation>Maximum Current</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
-        <translation type="unfinished"/>
+        <translation>Number of CPUs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Motherboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Sound Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Storage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Other PCI Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Keyboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Printer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Other Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Device</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
-        <translation type="unfinished"/>
+        <translation>Operating System</translation>
     </message>
 </context>
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Total Width</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Configured Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Maximum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Minimum Voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Configured Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Data Width</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Display Input</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Interface Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Support Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Current Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Display Ratio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Primary Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
@@ -1090,12 +1040,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
         <source>Maximum Rate</source>
-        <translation type="unfinished"/>
+        <translation>Maximum Rate</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
         <source>Negotiation Rate</source>
-        <translation type="unfinished"/>
+        <translation>Negotiated Rate</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
@@ -1165,12 +1115,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
@@ -1286,12 +1236,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1324,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
         <source>Temperature</source>
-        <translation type="unfinished"/>
+        <translation>Temperature</translation>
     </message>
 </context>
 <context>
@@ -1422,154 +1372,149 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Media Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Capabilities</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Physical ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmware Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Speed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Rotation Rate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
 </context>
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
-        <translation type="unfinished"/>
+        <translation>Select a driver for update</translation>
     </message>
 </context>
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Loading Audio Device Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Loading BIOS Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Loading CD-ROM Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Loading Operating System Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Loading CPU Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Loading Other Devices Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Loading Power Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Loading Printer Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Loading Mouse Info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Loading Network Adapter Info...</translation>
     </message>
@@ -1577,116 +1522,114 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>No drivers found in this folder</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Device Info</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Device Manager</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
@@ -1694,400 +1637,382 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation>Drivers</translation>
     </message>
 </context>
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>More</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>Current Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>Driver Platform Version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Backupable Drivers</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
-        <translation type="unfinished"/>
+        <translation>Backed up Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>Warning</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>The device will be unavailable after the driver uninstallation</source>
-        <translation type="unfinished"/>
+        <translation>Updating</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
-        <source>Uninstall</source>
-        <comment>button</comment>
-        <translation type="unfinished"/>
+        <source>Warning</source>
+        <translation>Next</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>سيصبح الجهاز غير متاح بعد إزالة برنامج التشغيل</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>إزالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
-        <translation type="unfinished"/>
+        <translation>تتم إزالة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
-        <translation type="unfinished"/>
+        <translation>تحديث ناجح</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
-        <translation type="unfinished"/>
+        <translation>إزالة ناجحة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
-        <translation type="unfinished"/>
+        <translation>فشل التحديث</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
-        <translation type="unfinished"/>
+        <translation>فشل الإزالة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
-        <source>The selected folder does not exist, please select again</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
-        <source>Update</source>
-        <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>التالي</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>المسار المحدد غير موجود، من فضلك اختر مسارًا آخر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
-        <translation type="unfinished"/>
+        <translation>حزمة تالفة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
-        <translation type="unfinished"/>
+        <translation>نظام الحزمة غير متوافق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
-        <translation type="unfinished"/>
+        <translation>الملف المحدد غير موجود، من فضلك اختر ملفًا آخر</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
-        <translation type="unfinished"/>
+        <translation>ليس برنامج تشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
-        <translation type="unfinished"/>
+        <translation>غير قادر على التثبيت - لا توقيع رقمي</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
-        <translation type="unfinished"/>
+        <translation>خطأ غير معروف</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
-        <translation type="unfinished"/>
+        <translation>لم يتم العثور على وحدة برنامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
-        <translation type="unfinished"/>
+        <translation>تنسيق الوحدة غير صحيح</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
-        <translation type="unfinished"/>
+        <translation>توجد اعتمادات لوحدة برنامج التشغيل</translation>
     </message>
 </context>
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Device Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
-        <translation type="unfinished"/>
+        <translation>النسخة المتاحة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>الإجراء</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
-        <translation type="unfinished"/>
+        <translation>النسخة الجديدة</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>النسخة الحالية</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>برامج تشغيل مفقودة (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>برامج تشغيل قديمة (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>برامج تشغيل حديثة (%1)</translation>
     </message>
 </context>
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>تثبيت برنامج تشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>نسخة احتياطية لبرنامج التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>استعادة السائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation>موافق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>التغذية الراجعة</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>لا يوجد أي سائق يمكن استعادته، من فضلك قم بالنسخ الاحتياطي أولاً</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>انتقل إلى نسخة الاحتفاظ بالسائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>النسخة الحالية</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>نسخة الاحتفاظ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>الإجراء</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>السائقين القابلين للاستعادة</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>تثبيت السائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>نسخة الاحتفاظ بالسائق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>استعادة السائق</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
-        <translation type="unfinished"/>
+        <translation>فشل في تمكين الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
-        <translation type="unfinished"/>
+        <translation>فشل في إيقاف الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>فشل في إيقافه: لا يمكن الحصول على رقم تعريف الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
-        <translation type="unfinished"/>
+        <translation>تحديث السائقين</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
-        <translation type="unfinished"/>
+        <translation>إلغاء تثبيت السائقين</translation>
     </message>
 </context>
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
@@ -2111,1368 +2036,1204 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
-        <translation type="unfinished"/>
+        <translation>تمكين</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>تحديث السائقين</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>إلغاء تثبيت السائقين</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>السماح له بتشغيل الكمبيوتر</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>فشل في إيقافه: لا يمكن الحصول على رقم تعريف الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
-        <translation type="unfinished"/>
+        <translation>فشل في تمكين الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
-        <translation type="unfinished"/>
+        <translation>فشل في إيقاف الجهاز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
-        <translation type="unfinished"/>
+        <translation>تحديث السائقين</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
-        <translation type="unfinished"/>
+        <translation>إلغاء تثبيت السائقين</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>SubVendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>SubDevice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Driver Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Driver Activation Cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Config Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>latency</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Handlers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Base Board Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>System Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Chassis Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Physical Memory Array</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Release Date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Runtime Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Characteristics</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware Revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Product Name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Asset Tag</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Features</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Location In Chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Chassis Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Contained Object Handles</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Wake-up Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Family</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Lock</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Boot-up State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Power Supply State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Thermal State</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Security Status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM Information</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Height</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Number Of Power Cords</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Contained Elements</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Location</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Error Correction Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maximum Capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Error Information Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Number Of Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Release date</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Board name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Language Description Format</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Installable Languages</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Currently Installed Language</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Packet type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Link policy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Link mode</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Service Classes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Device Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Device</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Serial ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>product</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Powered</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Discoverable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Pairable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Discovering</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Driver Modules</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Device File</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Device Files</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Device Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Application</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>logical name</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU implementer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU variant</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU part</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU revision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>One</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>تسعة</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Ten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Twelve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Fourteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Sixteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Eighteen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Twenty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Twenty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Twenty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Twenty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Twenty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Thirty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Thirty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Thirty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Thirty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Thirty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Forty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Forty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Forty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Forty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Forty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Fifty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Fifty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Fifty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Fifty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Fifty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sixty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sixty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sixty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
-        <source>Sixty-six</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
-        <source>Sixty-eight</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
-        <source>Seventy</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
-        <source>Seventy-two</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
-        <source>Seventy-four</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
-        <source>Seventy-six</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
-        <source>Seventy-eight</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
-        <source>Eighty</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
-        <source>Eighty-two</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
-        <source>Eighty-four</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
-        <source>Eighty-six</source>
-        <translation type="unfinished"/>
+        <source>Sixty-six</source>
+        <translation>ستين وستة</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
-        <source>Eighty-eight</source>
-        <translation type="unfinished"/>
+        <source>Sixty-eight</source>
+        <translation>ستين وثمانية</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
-        <source>Ninety</source>
-        <translation type="unfinished"/>
+        <source>Seventy</source>
+        <translation>Seventy</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
-        <source>Ninety-two</source>
-        <translation type="unfinished"/>
+        <source>Seventy-two</source>
+        <translation>Seventy-two</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
-        <source>Ninety-four</source>
-        <translation type="unfinished"/>
+        <source>Seventy-four</source>
+        <translation>Seventy-four</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
-        <source>Ninety-six</source>
-        <translation type="unfinished"/>
+        <source>Seventy-six</source>
+        <translation>Seventy-six</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
-        <source>Ninety-eight</source>
-        <translation type="unfinished"/>
+        <source>Seventy-eight</source>
+        <translation>Seventy-eight</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
-        <source>One hundred</source>
-        <translation type="unfinished"/>
+        <source>Eighty</source>
+        <translation>Eighty</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
-        <source>One hundred and Two</source>
-        <translation type="unfinished"/>
+        <source>Eighty-two</source>
+        <translation>Eighty-two</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
-        <source>One hundred and four</source>
-        <translation type="unfinished"/>
+        <source>Eighty-four</source>
+        <translation>Eighty-four</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
-        <source>One hundred and Six</source>
-        <translation type="unfinished"/>
+        <source>Eighty-six</source>
+        <translation>Eighty-six</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
-        <source>One hundred and Eight</source>
-        <translation type="unfinished"/>
+        <source>Eighty-eight</source>
+        <translation>Eighty-eight</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
-        <source>One hundred and Ten</source>
-        <translation type="unfinished"/>
+        <source>Ninety</source>
+        <translation>Ninety</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
-        <source>One hundred and Twelve</source>
-        <translation type="unfinished"/>
+        <source>Ninety-two</source>
+        <translation>Ninety-two</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
-        <source>One hundred and Fourteen</source>
-        <translation type="unfinished"/>
+        <source>Ninety-four</source>
+        <translation>Ninety-four</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
-        <source>One hundred and Sixteen</source>
-        <translation type="unfinished"/>
+        <source>Ninety-six</source>
+        <translation>Ninety-six</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
-        <source>One hundred and Eighteen</source>
-        <translation type="unfinished"/>
+        <source>Ninety-eight</source>
+        <translation>Ninety-eight</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
-        <source>One hundred and Twenty</source>
-        <translation type="unfinished"/>
+        <source>One hundred</source>
+        <translation>One hundred</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
-        <source>One hundred and Twenty-two</source>
-        <translation type="unfinished"/>
+        <source>One hundred and Two</source>
+        <translation>One hundred and two</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
-        <source>One hundred and Twenty-four</source>
-        <translation type="unfinished"/>
+        <source>One hundred and four</source>
+        <translation>One hundred and four</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
-        <source>One hundred and Twenty-six</source>
-        <translation type="unfinished"/>
+        <source>One hundred and Six</source>
+        <translation>One hundred and six</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>One hundred and eight</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>One hundred and ten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>One hundred and twelve</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>One hundred and fourteen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>One hundred and sixteen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>One hundred and eighteen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>One hundred and twenty</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>One hundred and twenty-two</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>One hundred and twenty-four</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>One hundred and twenty-six</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>One hundred and Twenty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
-        <translation type="unfinished"/>
+        <translation>One hundred and ninety-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
-        <translation type="unfinished"/>
+        <translation>مائتين وخمسة وستين</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR capacity</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU vendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL client APIs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL version</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Unknown</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
-        <translation type="unfinished"/>
+        <translation>أُنِيْق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Hardware Class</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>No CPU found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Motherboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>No motherboard found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>No memory found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Storage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>No disk found</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>فشل استعادة السائق!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>يرجى المحاولة مرة أخرى أو تقديم ملاحظات لنا</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>فشل نسخ احتياطي السائق!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Display Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>No GPU found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>No monitor found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Network Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>No network adapter found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Sound Adapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>No audio device found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>No Bluetooth device found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Other PCI Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>No other PCI devices found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Power</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>No battery found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Keyboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>No keyboard found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>No mouse found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Printer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>No printer found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>No camera found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>No CD-ROM found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Other Devices</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>No other devices found</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Array Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Form Factor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Set</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Bank Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Type Detail</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Part Number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rank</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Memory Technology</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Memory Operating Mode Capability</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmware Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Module Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Module Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Memory Subsystem Controller Manufacturer ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Memory Subsystem Controller Product ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Non-Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Volatile Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Cache Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logical Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
@@ -3692,446 +3453,426 @@
         <translation>sides</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>bus info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>logicalsectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometry (Logical)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Device Manager</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Device Manager is a handy tool for viewing hardware information and managing the devices.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
-        <translation type="unfinished"/>
+        <translation>سائقين جدد متاحين! قم بتركيبهم أو تحديثهم الآن.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
-        <translation type="unfinished"/>
+        <translation>عرض</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
-        <translation type="unfinished"/>
+        <translation>شامل الفolders الفرعية</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
-        <translation type="unfinished"/>
+        <translation>ابحث عن السائقين في هذا المسار</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
-        <translation type="unfinished"/>
+        <translation>'%1 تحديثات سائق متاحة'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
-        <translation type="unfinished"/>
+        <translation>'وقت التحقق: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>تنزيل السائقين لـ %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation type="unfinished"/>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>تركيب السائقين لـ %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 سائق تم تركيبهم، %2 سائق فشل'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 سائق تم تركيبهم'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
-        <translation type="unfinished"/>
+        <translation>فشل تركيب السائقين</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
-        <translation type="unfinished"/>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
-        <translation type="unfinished"/>
+        <translation>'سرعة التنزيل: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
-        <translation type="unfinished"/>
+        <translation>سائقك محدث</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>تم نسخ جميع السائقين الاحتياطي</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>'إجمالي %1 سائق، منها %2 تم نسخها الاحتياطي'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>لديك %1 سائق يمكن نسخها الاحتياطي، يُنصح بأن تقوم بذلك فورًا</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>لديك %1 سائق يمكن نسخها الاحتياطي</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>نسخ السائق %1، إجمالي %2 سائق</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>'نسخ: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 سائق تم نسخها الاحتياطي، %2 سائق فشل'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>فشل نسخ السائقين</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>'%1 سائق تم نسخها الاحتياطي'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>لديك %1 سائق يمكن استعادتها</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>يرجى اختيار مُوصِل لاستعادة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>مُوصِل في استعادة...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>في استعادة: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
-        <translation type="unfinished"/>
+        <translation>إعادة التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
-        <translation type="unfinished"/>
+        <translation>يرجى %1 لكي تصبح المُوصِلات المُثبَّتة سارية المفعول</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>عرض مسار النسخ الاحتياطي</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
-        <source>submit feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
-        <source>Please try again or %1 to us</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
-        <source>Install All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
-        <source>Scan Again</source>
-        <translation type="unfinished"/>
+        <translation>نسخ احتياطي للجميع</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>أرسل ملاحظات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>يرجى المحاولة مرة أخرى أو %1 إلينا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>تثبيت جميع</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>مسح مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>يتم مسح مُوصِلات أجهزة الطرف، من فضلك انتظر...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
-        <translation type="unfinished"/>
+        <translation>يتم مسح %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
-        <translation type="unfinished"/>
+        <translation>المسح فشل</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
-        <translation type="unfinished"/>
+        <translation>شبكة غير متاحة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
-        <translation type="unfinished"/>
+        <translation>يرجى التحقق من اتصال الشبكة</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
-        <translation type="unfinished"/>
+        <translation>يرجى مسح مرة أخرى أو %1 إلينا</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>أنت تقوم بتثبيت مُوصِل، وسيتم تعطيله إذا غادرت.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"/>
+        <translation>هل أنت متأكد من رغبتك في الخروج؟</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>خروج</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>أنت تقوم بنسخ احتياطي للمُوصِلات، وسيتم تعطيله إذا غادرت.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>أنت تقوم باستعادة المُوصِلات، وسيتم توقفها إذا غادرت.</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
         <source>Bluetooth adapter</source>
-        <translation type="unfinished"/>
+        <translation>مُوصِل بلوتوث</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
-        <translation type="unfinished"/>
+        <translation>جهاز الصور</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="38"/>
         <source>Display adapter</source>
-        <translation type="unfinished"/>
+        <translation>مُوصِل العرض</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="40"/>
         <source>Sound card</source>
-        <translation type="unfinished"/>
+        <translation>بطاقة الصوت</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="42"/>
         <source>Network adapter</source>
-        <translation type="unfinished"/>
+        <translation>مُوصِل الشبكة</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="46"/>
         <source>Wireless network adapter</source>
-        <translation type="unfinished"/>
+        <translation>مُوصِل الشبكة اللاسلكي</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="66"/>
         <source>Installation successful</source>
-        <translation type="unfinished"/>
+        <translation>تثبيت ناجح</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="67"/>
         <source>Installation failed</source>
-        <translation type="unfinished"/>
+        <translation>تثبيت فشل</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="68"/>
         <source>Downloading</source>
-        <translation type="unfinished"/>
+        <translation>Downloading</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="69"/>
         <source>Installing</source>
-        <translation type="unfinished"/>
+        <translation>Installing</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="70"/>
         <source>Not installed</source>
-        <translation type="unfinished"/>
+        <translation>Not installed</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="71"/>
         <source>Out-of-date</source>
-        <translation type="unfinished"/>
+        <translation>Out-of-date</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="72"/>
         <source>Waiting</source>
-        <translation type="unfinished"/>
+        <translation>Waiting</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>Not backed up</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>Backing up</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>Backup failed</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>Backup successful</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>Restoring</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
         <source>Unknown error</source>
-        <translation type="unfinished"/>
+        <translation>Unknown error</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Network error</source>
-        <translation type="unfinished"/>
+        <translation>Network error</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Canceled</source>
-        <translation type="unfinished"/>
+        <translation>Canceled</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Failed to get driver files</source>
-        <translation type="unfinished"/>
+        <translation>Failed to get driver files</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
-        <translation type="unfinished"/>
+        <translation>Update</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Restore</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation>Install</translation>
     </message>
     <message>
         <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
@@ -4142,83 +3883,81 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>Update drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>Uninstall drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>Allow it to wake the computer</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
-        <translation type="unfinished"/>
+        <translation>Enable</translation>
     </message>
 </context>
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Refresh</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>Disable</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Unavailable</translation>
     </message>
 </context>
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
-        <translation type="unfinished"/>
+        <translation>Select a local folder please</translation>
     </message>
 </context>
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Loading...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_eo.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_eo.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eo">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Reago</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Bon</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Plu</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Malkovri reto</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Reinstali</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Plu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Kolapsi</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Malkovri</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Mankas</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Aparato Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Fabrikanto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chipo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Pado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revizio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModePiloto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Memoro Adreso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Mankas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Malkovri</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Fabrikanto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Fabrikanto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipseto</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Aliaso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Vendinto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Pentro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maksimuma potenco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Versio de la konduktoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Konduktoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Informo pri la buso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logika nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC-adreso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Ne disponeble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Malaktivigi</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Vendinto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Informo pri la buso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Konduktoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maksimuma potenco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Pentro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Ne disponeble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Malaktivigi</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Vendinto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>CPU-idento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>Kerno-idento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Treadoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Treadoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arĥitekturo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Familio de CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Procesoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Kerno(j)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualizado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Flago(j)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Ekstensiono(j)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Kerno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Kerno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Kerno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Kerno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Paso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Paco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Maksimuma Paco</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Vendo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Grafika Memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Fizika ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Adreso de Memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO Porto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Informo pri Buso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maksimuma Resolucio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minimuma Resolucio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Kurenta Resolucio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Kurso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Descrizio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Elipado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Elipado de ekranaro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Ne disponebla</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Vendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Informo pri buso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Pentro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maksimuma potenco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Piloto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Serio-numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Ne disponebla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Malaktivigi</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Vendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interfaco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Informo pri buso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Pentro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maksimuma kurento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Piloto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Malspezata</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Malaktivigi</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Prenuĵo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>Procesoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Nombro de procesoroj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Matrakoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Adaptoro por ekranigo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Sonadaptoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Stokado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Aliaj PCI aparatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Akumulatoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Retoadaptoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mikso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Klavo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Stampero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Aliaj aparatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Aparato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>Sistemo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Firmao</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Dimensio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Paco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Totala larĝo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Lokigilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Seria numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Konfigurita voltajo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Maksimuma voltajo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Minimuma voltajo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Konfigurita rapideco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Datolarĝo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Vendinto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Ekraniga eniro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Interfaco tipo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Suptena resolucio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Aktuala resolucio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Ekraniga rilato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Principa ekranilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Grando</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Seria numero</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Vendinto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Buso informo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Piloto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Piloto versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Maksimuma rapideco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Negocianta rapideco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Porto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multikasta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Lando</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latenteco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Dupliko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Braŭdikanto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Aŭto Negocio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Memoro Adreso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Adreso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logika Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Malsupene</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Malaktivigi</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Vendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Bus Informo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>En/El</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latenteco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Piloto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Vendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Bus Informo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Ŝuldre</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maksimuma potenco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Velocite</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Seria numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Ne disponeble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Malaktivigi</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Vendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Seria numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Stato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kapablo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Tensiono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Loko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Dizajna kapablo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Dizajna tensiono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS seria numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS produktadato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS kemio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Temperaturo</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Vendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Seria numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Komunigita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Stato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Tipo de interfaco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Malkapti</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Vendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Tipo de medio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Dimensio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Kapabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Versio de firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Velocite</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Priskribo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Seria numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Interfaco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Rotaĵa rapido</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Mankas</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Elektu konduktan programon por ĝisdatigo</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Neniu konduktanta programo troviĝis en tiu dosierujo</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Ŝteli Audio Device Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Ŝteli BIOS Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Ŝteli CD-ROM Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Ŝteli Sistemon de Operacio Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Ŝteli CPU Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Ŝteli Aliaj Device Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Ŝteli Potenco Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Ŝteli Printilo Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Ŝteli Muzo Info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Ŝteli Reto Adaptor Info...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Malkapti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Mankas</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Malkapti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Mankas</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Informacio pri aparato</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Montraj kurtajojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Fermi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Helpo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopii</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Sistemo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Eksporti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Refreski</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Aparatoadministrado</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hardvaro</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Pilotoj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitoro</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Ĝeneraligo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Montradilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Retmontradilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Akumulado</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Plu</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Versio de piloto-plato</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Pilotoj kies estas eble farigi kopion</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Kopiantaj pilotoj</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Ĝisdatigado</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Anule</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Sekvanta</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Averto</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>La aparato ne estos disponebla post la malfarigo de la piloto</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Malfarigu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Malfarigante</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Ĝisdatigo sukcesis</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Malfarigo sukcesis</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>La ĝisdatigo malsukcesis</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Malfare de instalado malsukcesis</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Sekvanta</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>La elektita dosierujo ne ekzistas, bonvolu elekti denove</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Ĝisdatigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Antaŭa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Malbona paketo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Ne koncorda arkitekturo de paketo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>La elektita dosiero ne ekzistas, bonvolu elekti denove</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Ĉi tio ne estas ĝisdatigilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Ne eblas instaligi - mankas digitala signaĵo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Nekonata eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>La ĝisdatigila modulo ne troveblas</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Nevalida modulformo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>La ĝisdatigila modulo havas dependecojn</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Instali ĝisdatigilon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Kopiĝi ĝisdatigilon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Restaŭri ĝisdatigilon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Reago</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Vi ne havas ĝisdatigilojn por restaŭri, bonvolu kopiĝi unu malfarante</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Iradi al Kopiĝo de ĝisdatigilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Kopio Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Restaŭrindaj ĝisdatigiloj</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Refarigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Eksporti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Ĝeneralaj informoj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Instali ĝisdatigilon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Kopiĝi ĝisdatigilon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Restaŭri ĝisdatigilon</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Malsukcesis aktivigi la dispozitivon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Malsukcesis malaktivigi la dispozitivon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Malsukcesis malaktivigi ĝin: ne eblas ricevi la SN de la dispozitivon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Ĝisdatigi la programojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Malfare la programojn</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Refreŝigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Eksporti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopii</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Prenu vian sinton</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Refreŝigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Eksporti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopii</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Aktivigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Ĝisdatigi la programojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Malfare la programojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Permesu al ĝi reŝalti la komputilon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Malaktivigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Malsukcesis malaktivigi ĝin: ne eblas ricevi la SN de la dispozitivon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Malsukcesis malaktivigi la dispozitivon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Malsukcesis aktivigi la dispozitivon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Ĝisdatigi la programojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Malfare la programojn</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>SubVendoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>SubDispozitivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Programo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Stato de la programo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Aktivigkomenzo de la programo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Konfigurado Statuso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latenco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Fizika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Manĝantoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Buso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Informacio pri BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Informacio pri baza plato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Informacio pri sistemo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Informacio pri kajuto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fizika memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Datumo de eligo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Adreso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Grandeco de tempo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Grandeco de ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Trajtoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Revido pri BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Revido pri firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Nomo de produkto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Seria numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Etikedo de aĵo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Funkcioj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Loko en kajuto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Manĝanto de kajuto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Objektoj enhavataj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Tipo de reŝoviĝo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Familio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Ŝlojo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Stato de starto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Stato de potenco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Terma stato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Sekureca stato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM informacio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Alto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Nombro de potencokabloj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Elementoj konsistantaj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Loko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Tipo de eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maksimuma kapablo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Manĝo de eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Nombro de aparatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ROMSIZE de BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Datumo de eldono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Nomo de plato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>Ŝtato de SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Formato de lingva priskribo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Instaleblaj lingvoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Lingvo instalita nun</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD Adreso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Tipo de paketo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Ligo politiko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Ligo modo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klaso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Servo klasoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Klaso de Dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Versio de HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Versio de LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subversio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Serial ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produkto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>priskribo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Potita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Detektigebla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Parebla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Detektigado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Moduloj de la Drenisto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Dosiero de la Dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Dosieroj de la Dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Nombro de la Dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Apliko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>stato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logika nomo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Implementanto de la CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Arĥitekturo de la CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Varianto de la CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Parto de la CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Revizio de la CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Unu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Niu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Deco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Dudek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Kvardeko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Sesdeko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Okto dek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Dukdeko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Dukdeko du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Dukdeko kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Dukdeko ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Dukdeko okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Trideko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Trideko du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Trideko kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Trideko ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Trideko okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Kvardeko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Kvardeko du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Kvardeko kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Kvardeko ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Kvardeko okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Kvindeko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Kvindeko du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Kvindeko kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Kvindeko ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Kvindeko okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Sesdeko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Sesdek-du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Sesdek-kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Kalkulo kalkulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Kalkulo okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Kalkulo sep</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Kalkulo sep kaj du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Kalkulo sep kaj kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Kalkulo sep kaj ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Kalkulo sep kaj okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Kalkulo okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Kalkulo okto kaj du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Kalkulo okto kaj kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Kalkulo okto kaj ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Kalkulo okto kaj okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Kalkulo naŭ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Kalkulo naŭ kaj du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Kalkulo naŭ kaj kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Kalkulo naŭ kaj ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Kalkulo naŭ kaj okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Cent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Cent kaj du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Cent kaj kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Cent kaj ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Cent kaj okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Cent kaj dek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Cent kaj dodek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Cent kaj dek kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Cent kaj dek ses</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Cent kaj dek okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Cent kaj dudek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Cent kaj dudek du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Cent kaj dudek kvar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Cent kaj dudek-seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Cent kaj dudek-okto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Cent kaj naŭdek-du</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Du cent kaj kvindek-seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapacito de GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Vendoro de GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Tipo de GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Versio de EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL klientaj API</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Versio de GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Versio de GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Malscienca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Unika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Klavo de hardwaro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Neniu CPU troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Matrakoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Neniu matrakoj troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Neniu memoro troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Memorilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Neniu disko troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Restaŭro de ĝidisto malsukcesis!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Bonvolu provi denove aŭ donu al ni retrofektion</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Kopio de ĝidisto malsukcesis!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Ekranilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Neniu GPU troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Neniu monitoro troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Rednetaŭto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Neniu rednetaŭto troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Sonataŭto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Neniu audio aparato troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Neniu Bluetooth aparato troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Aliaj PCI Aparatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Neniu aliaj PCI aparatoj troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Potenco</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Neniu akumulatorko troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Tavolo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Neniu tavolo troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mouso</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Neniu mouso troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Neniu printilo troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Neniu kamera troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Neniu CD-ROM troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Aliaj aparatoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Neniu aliaj aparatoj troveble</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Araĵo manĝilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Formo de la objekto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Aro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Banko lokigilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Tipo detalo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Parto numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Memoro teknologio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Kapablo de memoro-operacio-modo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Versio de firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Identiko de produktanto de modulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Identiko de produkto de modulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Identiko de produktanto de kontroldisko de memoro-sistemo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Identiko de produkto de kontroldisko de memoro-sistemo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Dimensio de ne-volata memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Dimensio de volata memoro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Dimensio de memoro en buffero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logika dimensio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>pinta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Datumo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>porto de ento kaj eliro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>reto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>akumulatorka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>nativa-pato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>alimentilo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>Ĝisdatigita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>havas historion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>havas statistikojn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ŝarĝeblaj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>stato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>nivelo de alerto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energio-malplena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energio-plena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>energio-plena-dizajno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>energio-rato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>tensio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>procento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>nomo de ikono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>versio de daemono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>sur baterio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>koverto fermiĝis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>koverto estas presentiĝinta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritika ago</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>malpermesi taskon post</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>teni taskon ĝis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>prioritato de tasko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>tempo de ŝanĝo de marko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>nombro supre</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientoo petita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>reĝimo de kolora printado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printero akceptas taskojn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printero estas kompartita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printero estas momenta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>fabrikanto kaj modelo de printero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>tempo de ŝanĝo de stato de printero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>kialoj por stato de printero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>tipo de printero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer-uri subtenata</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>latoj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>buso informo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logika sektorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sektorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>idento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometrio (Logika)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Dispozicia Gestoro</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Dispozicia Gestoro estas praktika ilo por vidi hardwaro informojn kaj kontroli la dispoziciojn.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Novaj dispoziciaj versioj disponeblas! Instalu aŭ metu ilin aldate.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Vidi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Inkluzi subdosierojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Serĉi dispoziciajn versiojn en tiu vojo</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 dispoziciaj versioj disponeblas'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Tempo kontrollita: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Ŝtorigas dispoziciajn versiojn por %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Ŝtoriga rapideco: %1, %2/%3 ĝis nun'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Instalas dispoziciajn versiojn por %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 dispoziciaj versioj instalitaj, %2 dispoziciaj versioj malsukcesis'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 dispoziciaj versioj instalitaj'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Malsukcesis instaligi dispoziciajn versiojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Reduktado de reto. Rekonekti...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Ŝtoriga rapideco: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Viaj dispoziciaj versioj estas aktualaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Ĉiuj dispoziciaj versioj estis konservitaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Totaŭo de %1 dispoziciaj versioj, el kiuj %2 estis konservitaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Vi havas %1 dispoziciajn versiojn kiuj povas esti konservitaj, oni konsilas faro tion tuj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Vi havas %1 dispoziciajn versiojn kiuj povas esti konservitaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Konservas la %1 dispoziciajn versiojn, totalo de %2 dispoziciaj versioj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Konservas: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 dispoziciaj versioj konservitaj, %2 dispoziciaj versioj malsukcesis'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Malsukcesis konservi dispoziciajn versiojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 dispoziciaj versioj konservitaj'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Vi havas %1 dispoziciajn versiojn kiuj povas esti malŝarĝitaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Bonvolu elekti dispoziciajn versiojn por malŝarĝi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>La ĉarĝilo estas rekonstruata...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Rekonstruado: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>reboot</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Bonvolu %1 por ke la instalitaj ĉarĝiloj efektivigas sin</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Vidu la salvopafon</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Salvigi ĉiujn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>envia revido</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Bonvolu provu denove aŭ %1 al ni</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Instali ĉiujn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Skanu denove</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Anuligi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Scaniĝas hardwaro ĉarĝiloj, bonvolu atendi...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Scaniĝas %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Scaniĝo mal sukcesis</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Rezo ne disponeblas</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Bonvolu kontrolli vian rezo konekton</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Bonvolu skani denove aŭ %1 al ni</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Vi instalu ĉarĝilon, kiu estos interrompita se vi eliros.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Ĉu vi certe volas eliri?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Eliri</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Anuligi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Vi faras kopion de ĉarĝiloj, kiu estos interrompita se vi eliros.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Vi rekonstruas ĉarĝilojn, kiu estos interrompita se vi eliros.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adaptilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Bildformadilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Ekranadaptilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Sonkarto</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Rezoadaptilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Senfina rezoadaptilo</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Instalo sukcesis</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Instalado malsukcese</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Elŝutado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Instalado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Ne instalita</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Malnovigita</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Atendado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Nenigis kopiĝis</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Kopiĝado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Kopiĝo malsukcese</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Kopiĝo sukcese</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Restarigado</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Nekonata eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Reĝimo eraro</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Malkoncigita</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Malsukcese ricevi programajn dosojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Ĝisdatigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Kopiĝi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Restarigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Instali</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Maldiskapigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Refroĝi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Esporti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Ĝisdatigi programajn dosojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Maldiskapigi programajn dosojn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Permesi ke ĝi malŝaltu la komputilon</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Aktivi</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Refroĝi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Esporti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Maldiskapigi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Malsufiĉa</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Bonvolu elekti lokan dosierujon</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Ŝargante...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_es.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_es.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Retroalimentación</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Más</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Contraer</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Contraer</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Más</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Contraer</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nombre del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias del módulo </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Dirección de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias del módulo </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Potencia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versión del controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Información de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nombre lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Dirección MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Información de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Potencia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias del módulo </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID del CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID del núcleo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Hilos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Arquitectura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Familia de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Procesador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Núcleo(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualización</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Banderas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensiones</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>Caché L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Caché L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Caché L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Caché L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Caché L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>N.° de revisión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Velocidad máxima</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Memoria gráfica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias del módulo </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Dirección de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Puerto I/O</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Información de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Resolución máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Resolución mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Resolución actual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Salida digital</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Salida de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Información de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias del módulo </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Potencia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interfaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Información de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias del módulo </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Potencia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Resumen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Cantidad de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Sonido</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Almacenamiento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Otros dispositivos PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Ratón</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Impresora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Cámara</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Otros dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>SO</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Ancho total</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Ubicación</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Voltaje configurado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Voltaje máximo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Voltaje mínimo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Velocidad configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Ancho de datos</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Entrada de la pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Tipo de interfaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Resolución compatible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Resolución actual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Relación de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor primario</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Tipo de medio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias del módulo </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versión de firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interfaz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Tasa de rotación</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Seleccione un controlador para actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>No se han encontrado controladores en esta carpeta</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Cargando información del dispositivo de audio…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Cargando información del BIOS…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Cargando información del CD-ROM…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Cargando información del sistema operativo…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Cargando información de CPU…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Cargando información de otros dispositivos...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Cargando información de energía...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Cargando información de impresora…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Cargando información del ratón...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Cargando información del adaptador de red...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Información del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Administrador de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Resumen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>GPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Versión actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Versión de la plataforma del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Controladores respaldables</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Controladores respaldados</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Actualizando</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Advertencia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>El dispositivo no estará disponible tras la desinstalación del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Desinstalando</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Actualización exitosa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Desinstalación exitosa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>La actualización falló</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>La desinstalación falló</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>La carpeta seleccionada no existe, por favor seleccione de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Paquete roto</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Arquitectura de paquetes inigualable</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>El archivo seleccionado no existe, por favor seleccione de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>No es un controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>No se puede instalar - no hay firma digital</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Error desconocido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>No se ha encontrado el módulo del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Formato de módulo inválido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>El módulo del controlador tiene dependencias</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Nombre del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versión disponible</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nueva versión </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Versión actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Controladores faltantes (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Controladores obsoletos (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Controladores actualizados (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Instalación de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Respaldo de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Restauración de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Retroalimentación</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>No tienes controladores para restaurar, por favor realice una copia de seguridad primero.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Ir a copia de seguridad del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Versión actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Versión de respaldo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Controladores restaurables</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Resumen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Instalación de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Respaldo de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Restauración de controladores</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>No se ha podido activar el dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>No se ha podido desactivar el dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>No se ha podido desactivar: no se ha podido obtener el SN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Actualizar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar controladores</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Resumen</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Permitir activar la computadora</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>No se ha podido desactivar: no se ha podido obtener el SN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>No se ha podido desactivar el dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>No se ha podido activar el dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Actualizar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar controladores</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Subvendedor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Subdispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Estado del controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Comando de activación del controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Estado de configuración</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>latencia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Manejadores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Información del BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Información de la placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Información del sistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Información de chasis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>El conjunto de la memoria física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Fecha de lanzamiento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Tamaño de tiempo de ejecución</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Tamaño de ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Caracteristicas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revisión del BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revisión de firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Nombre de producto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Etiqueta de activo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Características</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Ubicación en chasis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Manejador de chasis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Manejador de objeto contenido</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Tipo de despertador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Número SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Familia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Bloquear</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Estado de arranque</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Estado de fuente de alimentación</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Estado térmico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Estado de seguridad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Información de OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Número de cables de alimentación</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elementos contenidos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Ubicación</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Tipo de corrección de errores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacidad máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Manejador de información de errores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Número de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>Capacidad de la ROM del BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Fecha de lanzamiento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nombre de tarjeta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versión del SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Descripción de formato de Idioma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Idiomas instalables</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Idiomas actualmente instalados</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Tipo de paquete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Política de enlace</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Modo de enlace</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Clase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Clases de servicio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Clase de dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versión HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versión LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Serie ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>producto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Potenciado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Reconocible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Emparejable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Descubriendo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Módulos de controladores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Archivo del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Archivos del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Número del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Solicitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>estado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>nombre lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>versión ANSI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementador de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arquitectura de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variante de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Parte de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Versión de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Uno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Nueve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Diez</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Doce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Catorce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Dieciséis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Dieciocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Veinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Veintidós</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Veinticuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Veintiséis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Veintiocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Treinta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Treinta y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Treinta y cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Treinta y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Treinta y ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Cuarenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Cuarenta y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Cuarenta y cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Cuarenta y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Cuarenta y ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cincuenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cincuenta y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cincuenta y cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cincuenta y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cincuenta y ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sesenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sesenta y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sesenta y cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sesenta y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sesenta y ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Setenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Setenta y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Setenta y cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Setenta y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Setenta y ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Ochenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Ochenta y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Ochenta y cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Ochenta y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Ochenta y ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Noventa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Noventa y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Noventa y cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Noventa y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Noventa y ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Cien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Ciento dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Ciento cuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Ciento seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Ciento ocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Ciento diez </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Ciento doce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Ciento catorce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Ciento dieciséis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Ciento dieciocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Ciento veinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Ciento veintidós</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Ciento veinticuatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Ciento veintiséis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Ciento veintiocho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Ciento noventa y dos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Doscientos cincuenta y seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacidad de GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Vendedor de GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Tipo de GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versión de EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>Cliente de APIs EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versión de GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versión de GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Clase de hardware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>No se encontró ningún CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>No se encontró la placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>No se encontró la memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Almacenamiento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>No se encontró ningún disco</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>¡La restauración del controlador falló!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Por favor, inténtelo de nuevo o denos su opinión</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>¡La copia de seguridad del controlador falló!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>No se encontró ninguna GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>No se encontró ningún monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>No se encontraron adaptadores de red</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Sonido</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>No se encontraron dispositivos de audio</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>No se encontraron dispositivos Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Otros dispositivos PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>No se encontraron otros dispositivos PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Energía</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>No se encontró batería</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Sonido</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>No se encontraron dispositivos de audio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>No se encontraron dispositivos Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Otros dispositivos PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>No se encontraron otros dispositivos PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Energía</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>No se encontró batería</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>No se encontró teclado</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Ratón</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>No se encontró ningún ratón</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Impresora</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>No se encontraron impresoras</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Cámara</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>No se encontró ninguna cámara</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>No se encontró ningún CD-ROM</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Ratón</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>No se encontró ningún ratón</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>No se encontraron impresoras</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Cámara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>No se encontró ninguna cámara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>No se encontró ningún CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Otros</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>No se encontraron otros dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Manejador de arreglo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Factor de forma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Conjunto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Localizador de bancos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Detalle de tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Número de parte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rango</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Tecnología de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Capacidad de modo operativo de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versión de firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID del fabricante del módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID del producto del módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID del fabricante del controlador del subsistema de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID del producto del controlador del subsistema de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Tamaño no volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Tamaño volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Tamaño caché</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Tamaño lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>pulgadas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>lados</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>información de bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>tamaño de sector lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>tamaño de sector</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometría (lógica)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Administrador de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Administrador de dispositivos de Deepin es una herramienta útil para ver la información del hardware y administrarlo.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>¡Nuevos controladores disponibles! Instálelos o actualícelos ahora.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Incluir subcarpetas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Buscar controladores en esta ruta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 actualizaciones de controladores disponibles</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Tiempo de comprobación: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Descargando controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocidad de descarga: %1 Descargado %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Instalando controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 controladores instalados, %2 controladores que fallaron</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 controladores instalados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Error al instalar los controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Error de red. Reconectando...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Velocidad de descarga: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Sus controladores están actualizados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Todos los controladores han sido respaldados.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Un total de %1 controladores, de los cuales %2 han sido respaldados.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Tienes %1 controladores que pueden respaldarse, se recomienda hacerlo de inmediato.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Tienes %1 controladores que pueden ser respaldados.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Respaldando el controlador %1, un total de %2 controladores.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Respaldando: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 controladores respaldados, %2 controladores fallaron.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Error al respaldar los controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 controladores respaldados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Tienes %1 controladores que pueden ser restaurados.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Seleccione un controlador para restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>El controlador se está restaurando...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Restaurando: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Por favor espere, %1 para que los controladores instalados surtan efecto</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Ver ruta de respaldo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Respaldar todo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>Enviar comentarios</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Vuelva a intentarlo o %1 contáctenos</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Instalar todo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Buscando controladores para los dispositivos, espere...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Buscando %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>La búsqueda falló</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Red no disponible</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Por favor, compruebe su conexión de red</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Busque de nuevo o envíenos %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Está instalando un controlador, se interrumpirá si sale.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Está seguro de que quiere salir?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Está respaldando controladores, lo cual se interrumpirá si sale.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Está restaurando controladores, lo cual se interrumpirá si sale.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Error al obtener los archivos del controlador</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Copia de seguridad</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Actualizar los controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Desinstalar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Permitir activar la computadora</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Deshabilitar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>No disponible</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Seleccione una carpeta local</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Cargando…</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_et.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_et.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="et">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Tagasiside</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Vajuta OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Lisainfo</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Lülita kinni</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Lisainfo</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Lisainfo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Lülita kinni</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Lisainfo</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Lülita kinni</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Põhjasta</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Seade nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Müüja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Khipu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Mõõdukused</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Moduuli alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Füüsiline ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS tee</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Kirjeldus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Muutujapikkus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Ei kättesaadav</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Katkesta</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Müüja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Kaksik</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Müüja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Mudel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Moduuli alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Füüsiline ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Kiirus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Maksimaalne energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Täringu versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Täring</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Võimet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Busi info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logiiline nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC aadress</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Ei kättesaadav</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Pika</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Tootja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Mudel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Busi info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Mõõtmed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Juhtija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maksimaalne energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Värv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Müügiväärne alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Füüsiline ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Pole saadaval</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Pika</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Tootja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Kõrpi ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Liinid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Arhitektuur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU perekond</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Mudel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Protsessor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Koer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtuaalne seadistus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Märgid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Rakendused</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Liikumisspeed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Maksimaalne liikumisspeed</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Mõistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Vaatamismuutujate muutuja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Müügimüügikirjeldus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Füüsiline ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Muutujate aadress</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Bussi info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maksimaalne resolutsioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Mínimumresolutsioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Päringuline resolutsioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Draiver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Kirjeldus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
-        <translation type="unfinished"/>
+        <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>Digitaal väljund</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Monitori väljund</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Võimekus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Pole saadaval</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>NimiNimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Tootja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Mudel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Busi info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Mooduli alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Füüsiline ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Kiirus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maksimaalne energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Draiver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Võimekus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Seeranumber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Pole saadaval</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Keel käskutus</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Müüja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Mudel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Väljund</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Busi info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Moduuli alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Füüsiline ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Tehnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Maksimaalne tõusu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Taastööri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Mõjukused</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Pole saadaval</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Keel käskutus</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Ülevaade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>Protsessor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Protsessoride arv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Müügikast</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Muist</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Kuvateisendaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Äänesteisendaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Hoidmiseks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Muid PCI-e seadeid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Aktsennaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation> võrkuvõtja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>hiire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>kastike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>prинтер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Muid esineusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Esineus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>Süsteem</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Maksettaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Tüüp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Kiirus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Kokku laius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Režiim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Sarionumber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Sättitud tõusu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Maksimaalne tõus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Mínimumtõus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Sättitud kiirus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Andmelaius</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Müüja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Display Input</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Interface Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Support Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Current Resolution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Display Ratio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Primary Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Serial Number</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Müüja</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
@@ -1135,12 +1085,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
         <source>Broadcast</source>
-        <translation type="unfinished"/>
+        <translation>Kanalitelevisioon</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
         <source>Auto Negotiation</source>
-        <translation type="unfinished"/>
+        <translation>Automaatne hinnang</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
@@ -1203,7 +1153,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
         <source>Input/Output</source>
-        <translation type="unfinished"/>
+        <translation>Sisend/Väljund</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Mõjuja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Média tüüp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Funktsioonid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Moduuli alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Füsiiline ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmware versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Kiirus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Kirjeldus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Sarionumber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Pööramise kiirus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Ei ole saadaval</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Vali uuendamiseks jõesaaja</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>见不到此文件夹中的驱动程序</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Laadimine auhindade info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Laadimine BIOS info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Laadimine CD-ROM info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Laadimine tööriista info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Laadimine CPU info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Laadimine muude seadeid info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Laadimine energia info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Laadimine prindimisestumi info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Laadimine nahali info...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Laadimine võrguüksiku info...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Päraa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Pikaerakord</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Päraa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Pikaerakord</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Seadeinfo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Näita pikaerakordi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Sulge</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Mõista</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopeeri</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Süsteem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Eksporti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Värskenda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Seatedhallinäitaja</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Vaatlikkus</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Juhtmed</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Müüja</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Ülevaade</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Kuvaadja</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Protsessor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Võrguadja</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Bateri</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Lisainfo</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Päringuvõrreldud versioon</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>Juhtmete platvormiversioon</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Staatus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Tegevus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Kopeeritavad juhtmed</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Kopeeritud juhtmed</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Värskendamine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Lõpeta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Järgmine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Hoiatus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Seadme kasutamine tuleb lõpetada juhitud juhtmehi eemaldamiseni</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Eemalda</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Eemaldamine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Värskendamine õnnestus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Eemaldamine õnnestus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Värskendamine ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Eemaldamine ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Võimalik</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Järgmine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Valitud kausta ei eksisteeri, vali uuesti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Värskendamine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Eelmis</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Lõhke pakett</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Paketi arhitektuur ei vasta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Valitud faili ei eksisteeri, vali uuesti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>See ei ole juhusliides</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Ühendust ei saa püüada estada - mitte digitaalset allkirjastust</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Tundmatu viga</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Juhusliidesmoduuli ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Vigane moduuli formaat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Juhusliidesmoduul on sõltuvused</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Seadmete nimi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Kättesaadav versioon</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Suurus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Staatus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Tegevus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Uus versioon</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Praegune versioon</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Puuduvad juhusliidid (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Vana versioonilised juhusliidid (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Järgmised jõudlased jõudlused (%1</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>Installige jõudlused</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>Jõudluse varundamine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>Jõudluse tagasimõistmine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Tagasiside</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Ära on määramata jõudlusi tagasi mõistmiseks. Toeta varundamise enneni.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Loe varundatud jõudluse kohta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Nykyinen versioon</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Varundamise versioon</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Tegevus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Tagasi mõistmatak jõudlused</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Värskenda</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Eksportige</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Ülevaade</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Installige jõudlused</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Jõudluse varundamine</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Jõudluse tagasimõistmine</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Vigas saadeti seadme käivitamise</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Vigas saadeti seadme väljastamise</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Vigas saadeti selle väljastamiseks: ei saa saadetse SN saada</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Uuenda jõudlusi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Eemalda jõudlused</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Värskenda</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Eksporteerida</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopeerida</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Ülevaade</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Luba kasutamiseks</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Luba selle eemaldamiseks arvutist</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Keela kasutamiseks</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Ei suuda keelata seda: ei saa saata eesmärkide numbri</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Seda eesmärgi ei suuda keelata</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Eesmärgi ei suuda lubada kasutamiseks</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Uuenda juhtprogramme</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Eemalda juhtprogrammide</translation>
     </message>
@@ -2165,1316 +2088,1154 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>Alamväljaandja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>Alamlahtet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Juhtprogramm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Juhtprogrammi staatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Juhtprogrammi aktiveerimise käsk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Konfigureerimisstaatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>sagedus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Füüsiline</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Käsitlejad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>VÄLJATSEMASTI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS teave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Base Board teave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Süsteemiteave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Koju teave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Füsiiline muusika massiiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Lähtise päev</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Aadress</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Tööaegne suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Omadused</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS muutmine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware muutmine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Üksikasjade nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Sarialoendusnumber</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Asset märk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Funktsioonid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Koju asukoht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Koju käsitleja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Vajalikkus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Sisestatud objekti käsud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Kuulamine tüüp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Famili</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Lukk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Pärast käivitamist olek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Tõusuandja olek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Temperatuuri olek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Varaolukoodi olek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM teave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Kõrgus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Tõusuümbrikuid arv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Sisestatud elementid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Asukoht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Viga korralduse tüüp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maksimaalne haldusvõime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Viga teabe käsus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Seadeid arv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Lähtekoht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Põhikasti nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Keelide kirjelduse vorming</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Installitavate keelte kogu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Poletoon installitud keel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD-osoituse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Pakett tüüp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Ühenduse politika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Ühenduse režiim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Klass</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Teenuse kategooriad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Seadmete klass</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Alamversioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Seade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Sarial number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>toote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>kuva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Täpitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Leiduv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Paaris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Leidmine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Driverimoduulid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Seade fail</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Seade failid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Seadist номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplikaatsioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>olukord</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>loogiline nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU implementeerija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU arhitektuur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU variant</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU osa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU muutmine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Üks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Neli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Kuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Kaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Üheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Kümme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Kaheksa külge</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Kaheksa külge kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Kaheksa külge neli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Kaheksa külge kaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Kaks kümme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Kaks kümme kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Kaks kümme neli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Kaks kümme kuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Kaheksaksüsem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Kolmkümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Kolmkümmendkaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Kolmkümmendnelik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Kolmkümmendkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Kolmkümmendkaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Nelikümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Nelikümmendkaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Nelikümmendnelik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Nelikümmendkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Nelikümmendkaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Vimikümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Vimikümmendkaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Vimikümmendnelik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Vimikümmendkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Vimikümmendkaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Kuuskümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Kuuskümmendkaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Kuuskümmendnelik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Kuuskümmendkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Kuuskümmendkaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Kümmendseits</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Kümmendseitskaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Kümmendseitsnelik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Kümmendseitskuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>seitskümmsetseks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>kaheksakümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>kaheksakümmend kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>kaheksakümmend neli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>kaheksakümmend kuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>kaheksakümmend kaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>üheksakümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>üheksakümmend kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>üheksakümmend neli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>üheksakümmend kuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>üheksakümmend kaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>sada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>sada kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>sada neli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>sada kuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>sada kaheksa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>sada kümme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>sada kakskümme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>sada nelikümme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>sada kuuskümme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>sada kaheksakümme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>sada kakskümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>sada kakskümmend kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>sada kakskümmend neli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>sada kakskümmend kuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Üksteistkaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Üksteiskümmend kaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Kakspekümmend kuuskümmend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR pikkus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU tootja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU tüüp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL klienti API-d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL versioon</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Tundmatu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Unikaal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Lahterklas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>Protsessor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Protsessori ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Majapaneel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Majapaneeli ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Muist</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Muisti ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Sagedusruum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Plaadit ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Müüja taaskasutamine ebaõnnestus!
 </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>Proovige uuesti või anna meile põhjendust</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Müüja varundamine ebaõnnestus!
 </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Küpsisüsteem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>GPÜ ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Müütor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Müütori ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Võrgusüsteem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Võrgusüsteemi ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Helüks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Helikihtit ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Bluetooth-eini ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Muid PCI-eini</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Muid PCI-eini ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Tõenõud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Tõenõudu ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Klahvikotti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Klahvikotti ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Müse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Müse ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Prindi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Prindi ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Käeper</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Käeperi ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>CD-ROM-i ei leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Muid eini</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Muut eesmärgikomponendid pole leitud</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Mangufi hanndle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Vormikuju</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Määra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Pankloektor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Tüüpi detail</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Komponenti number</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rann</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Muus tehnoloogia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Muus tööolukoha võimet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmware versioon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Moduuli tootja ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Moduuli tootmisaasta ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Muus susteemikohtade kontrolleri tootja ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Muus susteemikohtade kontrolleri tootmisaasta ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Muutuvate andmete suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Muutuvate andmete suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Cache suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logilise suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>tõmmik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Kuupäev</translation>
     </message>
@@ -3694,313 +3455,294 @@
         <translation>küljed</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>busi-infot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>logilised-sektorigi suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sektorigi suurus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geomeetria (logiline)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Seadmete juhtimine</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Seadmete juhtimine on kasulik liikmeskogemus seadmete andmete vaatamiseks ja seadmete juhtimiseks.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Üleuudised juhendite saadaval! Installide või uuenduste eest tehisjuhenditele nüüd.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Vaata</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Lisa alamkõrged</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Otsi jõurivaid see tee</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 jõurivu uuendust on saadaval</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Aeg kontrollitud: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Allalaadimine: %1 jõuriveid...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Allalaadimisnoor: %1 Saadetud %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Installitakse jõuriveid %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 jõurivu installitud, %2 jõurivu eemaldatud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 jõurivu installitud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Jõuriveid ei installitud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Võrguvea. Uuesti ühendust yritatakse...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Allalaadimisnoor: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Teie jõurivud on ajakohased</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Kõik jõurivud on varundatud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Kokku %1 jõurivu, millest %2 on varundatud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Teie on %1 jõurivu, mis on võimalik varundada, soovitatakse teha see hetkel</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Teie on %1 jõurivu, mis on võimalik varundada</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Varundatakse %1 jõurivu, kokku %2 jõurivu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Varundamine: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 jõurivu on varundatud, %2 jõurivu eemaldatud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Jõuriveid ei varundatud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 jõurivu on varundatud</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Teie on %1 jõurivu, mis on võimalik tagasi astuda</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Vali jõuriv, mida soovid tagasi astuda</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Jõuriv tagastatakse...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Uuesti ülelaadimine: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>lülita uuesti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Palun %1, et laetud jõulud tõlgenduks</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Näe varundamise tee</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Varundage kõik</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>lahenda tagasiside</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Palun proovige uuesti või %1 meile</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Installi kõik</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Skaneerige uuesti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Kehita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Ühendatakse peresüsteemide juhenditega, palun oota...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Skaneerimine %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Skaneerimine ebaõnnestus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Võrguüksus puudub</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Palun kontrolli oma võrguüksust</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Palun skaneerige uuesti või %1 meile</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Sul installitakse jõulut, mis lõpetub, kui sulgege seda.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Oled sa kindel, et tahad sulgeda? </translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Välju</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Kehita</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Sul varundatakse jõulut, mis lõpetub, kui sulgege seda.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Sul uuesti ülelaaditakse jõulut, mis lõpetub, kui sulgege seda.</translation>
     </message>
@@ -4011,7 +3753,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Imaatoride seade</translation>
     </message>
@@ -4116,22 +3857,22 @@
         <translation>Ei saa driverifailid päästa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Uuendus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Varundus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Tagastamine</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Installimine</translation>
     </message>
@@ -4144,39 +3885,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Püsita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Värskendamine</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Uuenda juhtivaid</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Eemalda juhtivad</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Luba teda hulka panna arvutit</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Luba</translation>
     </message>
@@ -4184,27 +3923,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Värskendamine</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopeeri</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Keela</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Pole saadaval</translation>
     </message>
@@ -4212,7 +3951,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Vali palun kohalik kaust</translation>
     </message>
@@ -4220,7 +3959,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Laadimine...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_eu.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_eu.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eu">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Gehu</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Egoia</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Berrizinstalazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Gehu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Zerratz</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Gailuaren izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chipa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Inplikazioak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>NukleuModuDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Hitzaren helbidea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipseta</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Aliasa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Hodi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maximoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Driverren bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driverra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Inplementazio-eraginkizunak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Busaren informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logiko izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC helbidea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Busaren informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Inplementazio-eraginkizunak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driverra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maximoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Hodi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Core ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Gurutzak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arquitectura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Saila CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Modelua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Prozesorea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Corea (ren)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualizazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Banderak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Hartzeak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Cachea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Cachea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Cachea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Cachea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Hizkuntza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Hizkuntza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Hizkuntza maximoa</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Eragilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modelua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Grafiko memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ID fisikoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Hizkuntza helbidea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO porta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Bus informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Resoluzio maximoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Resoluzio minimoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Resoluzio aktualea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Driver-rea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Deskribapena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Bertsaila Digitala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Bertsaila Erakutsi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Eskatzen Ditudan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Bus Informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Hodi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maximoa Energia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Gida</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Eskatzen Ditudan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Saria Zutabea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Desaktibatu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Egilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interfazea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Bus Informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Hodi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maximoa Bide</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Gida</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Egiaztapenak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Bilakaera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>CPU kantitatea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Aurkiturak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Gurutzatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Argazki adaptera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Soinu adaptera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Biltegia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Beste PCI gailuen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Bateria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Zuhaitz adaptera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Txartelak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Inprimatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Beste gailuen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Gailua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Eragilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Tamaina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Hiztegia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Zuzenaren luzera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Lokatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Konfiguratutako tentsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Maximo tentsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Minimo tentsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Konfiguratutako abiadura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Datuaren luzera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Eragilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Argazkiaren sarrera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Interfaz mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Onartzen den bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Korrigutako bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Argazkiaren proporsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Honetako argazkia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Eragilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Bus informatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Inplikazioak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Driver bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Maximo txanoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Txanoaren negosiazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Porta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Sakoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Lag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto Negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Memory Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logical Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Aurkezlea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Bus Info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Sarrera/irteera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Hitzak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Lag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Eskatzen dutenak</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Aurkezlea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Bus Info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Eskalazioak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Gida</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maximoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Hiztegia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Seriale</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Ez da eskuragarri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Desaktibatu</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Eragilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Seriale</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Egoera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Bolumena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Bateria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Bost</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Eskatutako bolumena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Eskatutako bateria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS seriale</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS ekoizpen data</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS kimika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Termotera</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Modeloa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Eragilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Seriale</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Zabaldu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Egoera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Mota interfaze</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Eragilea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Media mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Inbertsioak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Firmware bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Hiztegia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Deskribapena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Saria zenbaki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Mota interfaze</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Biraketa azalera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Aukeratu jarraitzea ari den driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Ez dago driverrik zorrotan</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Karga egiten ari da audio gailuen informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Karga egiten ari da BIOS informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Karga egiten ari da CD-ROM informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Karga egiten ari da Sistema Operatzaileko informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Karga egiten ari da CPU informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Karga egiten ari da beste gailuen informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Karga egiten ari da energia informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Karga egiten ari da printer informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Karga egiten ari da muskukatze informazioa...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Karga egiten ari da hiriketa adapter informazioa...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Ez da erabilgarria</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Sakauskidea</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Itxi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Laguntza</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopiatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Esportatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Berriztu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Gailuen kudeatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Harderra</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Driverak</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitoria</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Bilakaera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Pantaila adaptera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Zigilua adaptera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Baterria</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Garrantzitsua</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Driver platforma bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Backup egin daitezen diren driverak</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Backup egin diren driverak</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Bertsioa eguneratzen</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Utzi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Hurrengoa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Abisua</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Drivera desinstalatzean gailua ezin izango da erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Desinstalatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Desinstalatzen</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Eguneratzea ondo egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Desinstalatzea ondo egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Eguneratzea huts egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Desinstallatzea huts egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>On</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Hurrengoa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Aukeratutako karpeta ez da existitzen, aukeratu berriro</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Eguneratu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Aurrenera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Zerrenda ez da egokia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Zerrenda ez da egokia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Aukeratutako fitxategia ez da existitzen, aukeratu berriro</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Ez da driver bat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Instalatu ezinezkoa - ez dago sinatze digitala</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Errorea ez da ezagutzen</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Driver modulua ez da aurkitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Modulua ez da egokia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Driver modulua zalekatu egiten du</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Driver Instalatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Driver Kopia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Driver Berreskuratu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Itzulik</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Ez duzu driverik berreskuratzeko, lehendik kopia egiteko</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Kopia Driverera jo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Kopia Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Berreskuragarriak Driverak</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Berriztu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Iportatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Bilakaera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Driver Instalatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Driver Kopia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Driver Berreskuratu</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Ezgeratzea ez da ezarri</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Ezgeratzea ez da desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Ezgeratzea ez da desgaitu: ezezkoa da dispositiboko SNa lortzea</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Gailuak Begiratu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Desinstalatu Gailuak</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Berriztu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Esportatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Azterketa</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Berriztu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Esportatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Gaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Gailuak Begiratu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Desinstalatu gailuak</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Mesedez, komputagarria ezarri</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Ezgeratzea ez da desgaitu: ezezkoa da dispositiboko SNa lortzea</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Ezgeratzea ez da desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Ezgeratzea ez da ezarri</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Gailuak Begiratu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Desinstalatu gailuak</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>SubBertsor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>SubDispositibo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Gailua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Gailuaren Egoera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Gailuaren Aktibazio Komenta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Konfigurazio Egoera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latentsia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Fisiko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>BIOSaren informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Oinarrizko pultsaren informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Sistema informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Chassisaren informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fisikoa memoria erregistroa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Eragile data</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Helbidea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Runtime neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Ezaugarriak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>BIOS bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Firmware bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Produktu izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Seriako zenbaki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Asset etiketa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Ezaugarriak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Chassisaren kokapena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Chassis handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Zentzuan jartzen den objektu handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Berregainketaren mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU zenbaki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Saila</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Karratua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Egoera hastapena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Egoera energia-erakarpena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Egoera termiko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Segurtasun egoera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM informazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Altura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Power Cords kopurua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Hartzen diren elementuak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Posizioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Erroreakorreko mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maximo kapazitatea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Errore informazioa handlea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Gailuen kopurua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Eragungarri data</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Platina izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Hizkuntza deskribapen formatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Instalatu daitezkeen hizkuntzak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Orain instalatutako hizkuntza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD helbidea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Pakete mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Lotura politika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Lotura modua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klasua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Servizio klasuak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Kategoria gailua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subbertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Gailua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Serial ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produktua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>deskribapena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Powers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Zerrendatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Paregatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Zerrendatzen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Driver modulua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Gailu fitxategia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Gailu fitxategiak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Gailu zenbakia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Aplikazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>estatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logikoa izena</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU implementatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU arquitectura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU variantea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU zatia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Bat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Hortz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Lauro</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Sex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Zortzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Hamar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Hamar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Hitzetzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Hitzetzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Hitzetzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Hitzetzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Hogeita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Hogeita bi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Hogeita laur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Hogeita sei</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Hogeita zazpi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Hogeita hamar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Hogeita hamar eta bi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Hogeita hamar eta laur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Hogeita hamar eta sei</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Hogeita hamar eta zazpi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Hogeita hamar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Hogeita hamar eta bi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Hogeita hamar eta laur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Hogeita hamar eta sei</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Hogeita hamar eta zazpi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Hogeita hamar eta hamar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Hogeita hamar eta hamar eta bi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Hogeita hamar eta hamar eta laur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Hogeita hamar eta hamar eta sei</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Hogeita hamar eta hamar eta zazpi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Hogeita hamar eta hamar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Hogeita hamar eta hamar eta bi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Hogeita hamar eta hamar eta laur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Sesak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Sesako</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Hetzat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Hetzak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Hetzak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Hetzak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Hetzak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Zortzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Zortziko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Zortziko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Zortziko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Zortziko</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Zortzika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Zortzika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Zortzika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Zortzika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Zortzika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Hundred</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Hundred eta Bi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Hundred eta Berria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Hundred eta Eita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Hundred eta Zortzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Hundred eta Berde</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Hundred eta Zortzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Hundred eta Berde</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Hundred eta Zortzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Hundred eta Zortzi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Hundred eta Eita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Hundred eta Eita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Hundred eta Eita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Hundred and Twenty-six</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Hundred and Twenty-eight</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Hundred and Ninety-two</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Two hundred and fifty-six</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR capacity</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL client APIs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Ezinik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Hardware Class</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU ez da aurkitu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Motherboard ez da aurkitu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Memory ez da aurkitu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Storage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Diska ez da aurkitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Driver berreskuratzea huts egin du!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Sare ezagutu dena edo feedback emateko</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Driver kopiatzea huts egin du!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Display Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU ez da aurkitu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Monitor ez da aurkitu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Adaptegintza Netzwerk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Adaptegintza Netzwerk bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Adaptegintza Ondoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Ondoa zaile bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Bluetooth zaile bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Beste PCI zaileak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Beste PCI zaile bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Energia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Bateria bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Txartelak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Txartel bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Sarraskia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Sarraskia bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Inprimatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Inprimatzaile bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Kamera bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Beste zaileak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Beste zaile bat aurkitu ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Zerrenda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Banku Lokatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Mota Fineza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Zatia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Lekua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Hitzaren Teknologia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Egiaztapen modua memoria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Bertsioa firmwarea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Modulua ekoizlea ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Modulua produktua ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Memory Subsystem kontrolatzailea ekoizlea ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Memory Subsystem kontrolatzailea produktua ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Non-Volatil neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Volatile neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Cache neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logikoa neurria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>inch</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>network</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>energia-erreparatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>eguneratua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>Historia dauka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>Estatistikoa dauka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>Berrizkargatzen da</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>Egoera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>Advertitzio-nivelua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>Energia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>Energia hutsa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>Energia bete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>Energia bete diseinua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>Energia erroa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>Bateria tentsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>Prozentua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ikona-izenburua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon-ren bertsioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>bateria-aldaraz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>lid-ekin-ikus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>lid-ekin-egon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritis-ekin</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopiak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>lanean-ansan-ansan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>lanean-ansan-ansan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>lanean-ansan-ansan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>markatuen-aldaketa-denbora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>zenbakia-horren</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>kontsulta-orientazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>print-color-modoa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer-ekin-lanean-ansan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer-ekin-izendatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer-ekin-izendatua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer-ren-izena-eta-modelua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>printer-ren-estatua-aldaketa-denbora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>printer-ren-estatua-arrazoak</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>printer-ren-mota</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer-ren-uri-erabilgarria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>artea</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus-aren-izenburua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logikoa-sektore-izenburua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sektore-izenburua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>guid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometria (Logikoa)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Gailuen kudeatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Gailuen kudeatzailea gailuen informazioa ikusteko eta gailuen kudeatzea ahalbidetzen duen erabilgarria den tresna da.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Zuriak gailuen kudeatzaile berriak! Instalatu edo eguneratu ezazu orain.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Ikusi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Inkluzu subkarpetak</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Bilatu gailuen kudeatzaile hauetan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 gailuen kudeatzaile eguneraketa erabilgarria'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Denboraz egiaztatua: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 gailuen kudeatzailea deskargatzen... </translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Deskargatze azalera: %1 Deskargatuta %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 gailuen kudeatzailea instalatzen...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 gailuen kudeatzaile instalatuta, %2 gailuen kudeatzaile huts egin da'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 gailuen kudeatzaile instalatuta'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Gailuen kudeatzaileak instalatzea huts egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Zerbitzarorako errorea. Berrizkonektatzen...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Deskargatze azalera: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Zure gailuen kudeatzaileak egunekoak dira</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Gailuen kudeatzaile guztiak kopiatu dira</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 gailuen kudeatzaile guztira, %2 dela kopiatu dira</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 gailuen kudeatzaileak kopiatu daitezke, ezagutzan egin behar da azkar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Zure %1 gailuen kudeatzaileak kopiatu daitezke</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 gailuen kudeatzailea kopiatzen, %2 gailuen kudeatzaile guztira</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Kopiatzen: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 gailuen kudeatzaile kopiatu, %2 gailuen kudeatzaile huts egin da'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Gailuen kudeatzaileak kopiatzea huts egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 gailuen kudeatzaile kopiatu'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Zure %1 gailuen kudeatzaileak berreskuratu daitezke</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Mesedez, aukeratu gailuen kudeatzaile bat berreskuratzeko</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver-a berreskatzen ari da...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Berreskatzen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>berrabiarazi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Mesedez %1 instalatutako driver-ak efektua izateko</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Ikusi backup bidea</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Backup dena</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>feedback bidali</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Mesedez saiatu berriro edo %1 gertatu zara</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Install dena</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Berriskatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Utzi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Gaitutako gaitasunak eskannatzen ari da, mesedez etorri...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Eskannatzen %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Eskannatzeak huts egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Hartzea ez da helduta</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Mesedez egiaztatu zure hartzea</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Mesedez saiatu berriro edo %1 gertatu zara</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Driver bat instalatzen ari zara, eta dena utzi dezakezu esan ez bezain ere huts egingo da.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Ziur zaude irten nahi duzula?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Irten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Utzi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Driver-ak backup egin ditzakezu, eta dena utzi dezakezu esan ez bezain ere huts egingo da.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Driver-ak berreskatzen ari zara, eta dena utzi dezakezu esan ez bezain ere huts egingo da.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adaptatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Imaginazio gailua</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Izugarpen adaptatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Ondoa kartela</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Hartzea adaptatzailea</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Hartzea adaptatzailea, hizkuntza ez duena</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Instalazioa ondo egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Instalazioa huts egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Jasotzen</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Instalatzen</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Instalatua ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Aldatua ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Zain</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Bakalatua ez da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Bakalatzen</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Bakalazioa huts egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Bakalazioa ondo egin da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Berreskuratzen</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Errore ondo ezagutua</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Hartze errorea</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Utzi da</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Driver fitxategiak lortu ezin izan dira</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Xehetasuna</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Bakalazioa</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Berreskuratu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Instalatu</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Berriztu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Esportatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Driverak xehetasuna</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Driverak desinstalatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Pakatzen duen komputaria egiten</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Gaitu</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Berriztu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Esportatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Desgaitu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Kopiatu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Ez daitez</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Mesmo izeneko karpeta hautsiz</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Kargatzen...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_fa.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_fa.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fa">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>بازگشت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>تائید</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>بیشتر</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>اعلان شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>باز نصب</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>بیشتر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>بستن</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>دسترسی ندارد</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>نام دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>پیچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>قدرت‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>مسیر SysFS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ویرایش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>سیستم مد رانر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>آدرس حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>دسترسی ندارد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>چیپست</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>نام مستعار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>حداکثر قدرت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>نسخه گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>میزان قابلیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات گردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>نام منطقی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>آدرس MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>غیرقابل استفاده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>غیرفعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات گردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>میزان قابلیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>حداکثر قدرت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>غیرقابل استفاده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>غیرفعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>آی دی پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>آی دی هسته</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>نخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بودو میبس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>معماری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>خانواده پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>کری (ها)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>مجازی‌سازی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>پرچم‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>تکمیل‌کننده‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>کش L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>کش L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>کش L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>کش L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>کمپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>حداکثر سرعت</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>تولیدکننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>حافظه گرافیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>شناسه فیزیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>آدرس حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>پورت ورودی/خروجی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات خط انتقال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>حداکثر رزولوشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>حداقل رزولوشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>رزولوشن فعلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>نرم‌افزار کنترل کننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>توضیحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>خروج رقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>خروج نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>قدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>اسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>مصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>نمونه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات کاری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>قدرت حداکثر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>نرم‌افزار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>قدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>اسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>مصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>نمونه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>رابط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات کاری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>جریان حداکثر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>نرم‌افزار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>میزان قابلیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>غیرقابل استفاده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>غیرفعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>نظارت کلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation> процسور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>تعداد پرچیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>پلکار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation> حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>کارت نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>کارت صوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>ذخیره سازی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>دستگاه‌های دیگر PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation> باتری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>کارت شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>ماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>کلیدبord</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>نمایشگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>دوربین</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>دستگاه‌های دیگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>سیستم عامل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>حجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>عرض کلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>محل یاب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>ولتاژ پیکربندی شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>ولتاژ حداکثر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>ولتاژ حداقل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>سرعت پیکربندی شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>عرض داده</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>ورودی نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>نوع واسطه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>rozولوشن پشتیبانی شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>rozولوشن فعلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>نسبت نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>نمایشگر اصلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>اندازه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات خط انتقال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>قدرت و قابلیت ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>نرم افزار کنترل کننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>نسخه نرم افزار کنترل کننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>نرخ حداکثر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>نرخ مذاکره</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>پورت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>کاربرد چندگانه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>پیوند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>میانگین زمان پاسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>نرم‌افزار فیرو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>دوگانه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>پخش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>توصیه خودکار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>آدرس حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>آدرس MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>نام منطقی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>ناپدیدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>تولیدکننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات یک محور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>ورودی/خروجی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>میانگین زمان پاسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>نرم‌افزار کنترل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>میزان قابلیت</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>تولیدکننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>اطلاعات یک محور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>میزان قابلیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>سیستم عامل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>قدرت حداکثر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>غیرقابل استفاده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>غیرفعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>وضعیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>سیمای قابلیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ولتاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation> слات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>سیمای طراحی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>ولتاز طراحی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>نسخه SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>شماره سریال SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاریخ ساخت SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>شیمی SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>دما</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>مدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>اشتراکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>وضعیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>نوع واسطه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>تولید کننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>نوع محیط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>اندازه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>امکانات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>نسخه نرم افزاری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>توضیحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>واسطه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>نرخ چرخش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>غیر قابل دسترسی</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>یک واسطه برای به‌روزرسانی انتخاب کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>هیچ واسطه‌ای در این پوشه پیدا نشد</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>در حال بارگذاری اطلاعات دستگاه صوتی...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>در حال بارگذاری اطلاعات BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>در حال بارگذاری اطلاعات CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>در حال بارگذاری اطلاعات سیستم عامل...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>در حال بارگذاری اطلاعات پردازنده...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>در حال بارگذاری اطلاعات دستگاه‌های دیگر...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>در حال بارگذاری اطلاعات برق...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>در حال بارگذاری اطلاعات چاپگر...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>در حال بارگذاری اطلاعات موس...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>در حال بارگذاری اطلاعات پورت شبکه...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>غیر قابل دسترسی</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>غیر فعال کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>غیر قابل دسترسی</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>اطلاعات دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>نمایش کوتاه‌ترین مسیرها</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>بستن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>کمک</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>کپی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>سیستم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>صادرات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>تازه کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>مدیر دستگاها</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>نرم‌افزار</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>سیستم عامل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>نمایشگر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>نظارت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>کارت گرافیک</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>کارت شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>باتری</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>بیشتر</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>نسخه پلتفرم سیستم عامل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>سیستم عامل قابل پشتیبان‌گیری</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>سیستم عامل پشتیبان‌گیری شده</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>به‌روزرسی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>لغو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>بعدی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>هشدار</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>دستگاه پس از لغو نصب سیستم عامل دسترسی پیدا نخواهد کرد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>لغو نصب</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>لغو نصب</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>به‌روزرسی با موفقیت انجام شد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>لغو نصب با موفقیت انجام شد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>به‌روزرسانی شکست خورد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>نصب نکردن شکست خورد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>تأیید</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>بعدی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>پوشه انتخابی وجود ندارد، لطفاً مجدد انتخاب کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>بروزرسانی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>قبلی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>بسته خراب</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>ساختار بسته مطابق نیست</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>فایل انتخابی وجود ندارد، لطفاً مجدد انتخاب کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>این یک گیرنده نیست</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>نصب نمی‌شود - امضای دیجیتالی وجود ندارد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>خطای ناشناخته</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ماژول گیرنده پیدا نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>فرمت ماژول نامعتبر است</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ماژول گیرنده وابستگی‌هایی دارد</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>نصب گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>پشتیبان‌گیری گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>بازگردانی گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>پیشنهاد</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>هیچ گیرنده‌ای برای بازگردانی ندارید، لطفاً ابتدا پشتیبان‌گیری کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>به پشتیبان‌گیری گیرنده بروید</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>نسخه پشتیبان‌گیری</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>گیرنده‌های بازگردانی‌پذیر</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>بروزرسانی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>صادر کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>نظارت کلی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>نصب گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>پشتیبان‌گیری گیرنده</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>بازگردانی گیرنده</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>نشستن فعال سازی دستگاه با شکست</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>نشستن غیرفعال سازی دستگاه با شکست</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>نشستن غیرفعال سازی آن: نتوانسته ایم سریال دستگاه را دریافت کنیم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>به‌روزرسانی گیره‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>حذف گیره‌ها</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تازه کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>صادرات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کپی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>نظارت کلی</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تازه کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>صادرات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کپی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>فعال کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>به‌روزرسانی گیره‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>حذف گیره‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>اجازه دهید دستگاه را بیدار کند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>غیرفعال کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>نشستن غیرفعال سازی آن: نتوانسته ایم سریال دستگاه را دریافت کنیم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>نشستن غیرفعال سازی دستگاه با شکست</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>نشستن فعال سازی دستگاه با شکست</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>به‌روزرسانی گیره‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>حذف گیره‌ها</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>سازنده فرعی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>دستگاه فرعی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>گیره</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>وضعیت گیره</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>فرمان فعال سازی گیره</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>وضعیت پیکربندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>مقدار تأخیر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>فیزیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>سیسفس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>هاندلرها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>پروپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>اچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>کی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>بُس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>اطلاعات بیوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>اطلاعات پلکار بورد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>اطلاعات سیستم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>اطلاعات چسیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>آرایه حافظه فیزیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>تاریخ انتشار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>آدرس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>اندازه اجرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>اندازه رم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>ویژگی‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ویریون بیوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ویریون نرم‌افزار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>نام محصول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>شماره سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>برچسب دار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>ویژگی‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>موقعیت در چسیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>هاندل چسیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>هاندلرها درج شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>نوع روشن شدن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>شماره SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>خانواده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>قفل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>وضعیت راه‌اندازی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>وضعیت تامین برق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>وضعیت گرما</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>وضعیت امنیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>اطلاعات سازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>قد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>تعداد سیم‌های برق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>عناصر محتوا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>مکان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نوع تصحیح خطا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ظرفیت بیشینه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>هندل اطلاعات خطا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>تعداد دستگاه‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>اندازه BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاریخ انتشار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>نام پلیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>نسخه SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>فرمت توصیف زبان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>زبان‌های قابل نصب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>زبان جاری نصب شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>آدرس BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>نوع بسته</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>سیاست پیوند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>وضعیت پیوند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>کلاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>کلاس‌های خدمات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>کلاس دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>نسخه HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>نسخه LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>فرعی نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>آی دی سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>محصول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>توضیحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>مجهز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>قابل کشف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>قابل جفت‌کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>در حال کشف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>مدول‌های پیش‌راننده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>فایل دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>فایل‌های دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>شماره دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>کاربرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>وضعیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>نام منطقی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>نسخه ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>سازنده پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>آرکیتектور پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>تغییر پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>بخش پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>نسخه پردازنده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>یک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>ننه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>دوازده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>چهارده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>شانزده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>هجده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>بیست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>بیست و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>بیست و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>بیست و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>بیست و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>سی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>سی و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>سی و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>سی و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>سی و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>چهل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>چهل و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>چهل و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>چهل و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>چهل و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>پنجاه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>پنجاه و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>پنجاه و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>پنجاه و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>پنجاه و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>شصت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>شصت و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>شصت و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>شصت و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>شصت و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>هفتاد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>هفتاد و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>هفتاد و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>هفتاد و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>هفتاد و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>هشتاد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>هشتاد و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>هشتاد و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>هشتاد و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>هشتاد و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>نوداد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>نوداد و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>نوداد و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>نوداد و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>نوداد و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>صد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>صد و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>صد و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>صد و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>صد و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>صد و ده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>صد و یاد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>صد و چهارده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>صد و شانزده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>صد و هجده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>صد و بیست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>صد و بیست و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>صد و بیست و چهار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>صدی و دویست و شصت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>صدی و دویست و هشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>صدی و نود و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>دویست و پنجاه و شش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>kapasitet GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>فروشنده GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>نوع GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>نسخه EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API های کلاینت EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>نسخه GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>نسخه GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>ناشناس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>یونیک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>کلاس سخت‌افزار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>منبع تغذیه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>منبع تغذیه یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>حافظه یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>ذخیره‌سازی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>دیسک یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>بازیابی چاپنده با شکست مواجه شد!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>لطفاً دوباره امتحان کنید یا با ما بازخورد ارسال کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>کپی چاپنده با شکست مواجه شد!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>آداپتور نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>نمایشگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>نمایشگر یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>آداپتور شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>هیچ آداپتور شبکه یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>آداپتور صوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>هیچ دستگاه صوتی یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>هیچ دستگاه بلوتوت یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>دیگر دستگاه‌های PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>هیچ دیگر دستگاه PCI یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>انرژی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>هیچ باتری یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>کلیدبان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>هیچ کلیدبان یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>ماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>هیچ ماوس یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>هیچ چاپگر یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>کامرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>هیچ کامرا یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>هیچ CD-ROM یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>دیگر دستگاه‌ها</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>هیچ دیگر دستگاه یافت نشد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>هندل آرای</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>فوم فکتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>مجموعه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>locator بانک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>جزئیات نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>شماره قطعه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>رتبه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>تکنولوژی حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>قابلیت حالت عملیات حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>نسخه نرم‌افزار اصلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>شناسه سازنده ماژول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>شناسه محصول ماژول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>شناسه سازنده کنترل‌کننده سیستم حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>شناسه محصول کنترل‌کننده سیستم حافظه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>حجم غیر قابل پاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>حجم قابل پاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>حجم کش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>حجم منطقی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>اینش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>تاریخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>پورت ورودی/خروجی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>باتری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>مسیر محلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>منبع تامین برق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>به‌روزرسانی شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>تاریخچه دارد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>آمار دارد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>قابل شارژ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>وضعیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>سطح هشدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation> انرژی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation> انرژی خالی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation> انرژی پر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation> انرژی پر (طراحی)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>نرخ انرژی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation> ولتاژ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>درصد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تکنولوژی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>نام ایکون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>آنلاین</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>نسخه دمون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>بر روی باتری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>کاور بسته است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>کاور وجود دارد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>عملیه اساسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>کپی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>کار دریافتی را بعد از</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>کار را تا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>اولویت کار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>زمان تغییر مارکر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>تعداد به بالا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>جایگاه درخواست شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>حالت چاپ رنگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>چاپگر کار دریافتی را پذیرفت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>چاپگر به اشتراک گذاشته شده است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>چاپگر موقت است</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>ساخت و مدل چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>زمان تغییر وضعیت چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>دلایل وضعیت چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>نوع چاپگر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI چاپگر پشتیبانی شده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>طرف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>اطلاعات بوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>اندازه بخش های منطقی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>اندازه بخش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>آیدی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>هندسی (منطقی)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدیر دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدیر دستگاه ابزاری مفید برای مشاهده اطلاعات سخت افزاری و مدیریت دستگاه ها است.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>نگه داری جدید در دسترس است! اینجا نصب یا به روز رسانی کنید.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>پوشه های فرعی را شامل شود</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>جستجو برای نگه داری در این مسیر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 به روز رسانی نگه داری در دسترس است'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'زمان بررسی شده: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>در حال دانلود نگه داری برای %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعت دانلود: %1 دانلود شده %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>در حال نصب نگه داری برای %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 نگه داری نصب شد، %2 نگه داری شکست خورد'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 نگه داری نصب شد'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>نصب نگه داری شکست خورد</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطای شبکه. باز متصل شدن...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعت دانلود: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>نگه داری های شما به روز هستند</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>همه نگه داری ها پشتیبان گرفته شده اند</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 نگه داری وجود دارد، از آن %2 نگه داری پشتیبان گرفته شده است</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>شما %1 نگه داری دارید که می تواند پشتیبان گرفته شود، توصیه می شود فوراً انجام شود</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>شما %1 نگه داری دارید که می تواند پشتیبان گرفته شود</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>در حال پشتیبان گرفتن نگه داری %1، تعداد کل نگه داری ها %2 است</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'در حال پشتیبان گرفتن: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 نگه داری پشتیبان گرفته شد، %2 نگه داری شکست خورد'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>پشتیبان گرفتن نگه داری شکست خورد</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 نگه داری پشتیبان گرفته شد'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>شما %1 نگه داری دارید که می تواند بازیابی شود</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>لطفاً یک نگه داری را برای بازیابی انتخاب کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>سرویس‌دهی گرنت است</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>در حال بازگردانی: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>راه‌اندازی مجدد</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>لطفا %1 را انجام دهید تا گرنت‌های نصب شده به کار بیافت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>مسیر پشتیبان را مشاهده کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>پشتیبان تمام</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>فیدبک ارسال کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>لطفا دوباره امتحان کنید یا %1 به ما ارسال کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>نصب تمام</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>بار دیگر اسکن کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>لغو</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>در حال اسکن گرنت‌های دستگاه سخت‌افزاری، لطفا صبر کنید...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>در حال اسکن %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>اسکن شکست خورد</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>شبکه در دسترس نیست</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>لطفا اتصال شبکه خود را بررسی کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>لطفا دوباره اسکن کنید یا %1 به ما ارسال کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>شما در حال نصب یک گرنت هستید که اگر از برنامه خارج شوید، قطع می‌شود.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>مطمئن هستید که می‌خواهید از برنامه خارج شوید؟</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>خروج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>لغو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>شما در حال ایجاد پشتیبان گرنت‌ها هستید که اگر از برنامه خارج شوید، قطع می‌شود.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>شما در حال بازگردانی گرنت‌ها هستید که اگر از برنامه خارج شوید، قطع می‌شود.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>کارت بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>دستگاه تصویربرداری</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>کارت نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>کارت صدا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>کارت شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>کارت شبکه بی‌سیم</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>نصب با موفقیت انجام شد</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>نصب ناکام شد</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>در حال دانلود</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>در حال نصب</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>نصب نشده</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>قدیمی</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>در انتظار</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>پشتیبانی نشده</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>در حال پشتیبانی</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>پشتیبانی ناکام شد</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>پشتیبانی موفق شد</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>در حال بازیابی</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>خطا ناشناخته</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>خطا در شبکه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>لغو شد</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>دریفر فایل ها به دست نیامد</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>به روز رسانی</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>پشتیبانی</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>بازیابی</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>نصب</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>غیر فعال کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>تازه کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>صادر کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>دریفر را به روز رسانی کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>دریفر را نصب نکنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>مجاز به بیدار کردن راکت کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>فعال کنید</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>تازه کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>صادر کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>کپی کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>غیر فعال کنید</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>غیر قابل دسترسی</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>لطفاً یک پوشه محلی انتخاب کنید</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>در حال بارگذاری...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_fi.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_fi.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Palaute</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Tiivistä</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Lisää</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Tiivistä</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Lisää</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Tiivistä</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Laitteen nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Piiri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Moduulialias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fyysinen tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_polku</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Kuvaus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Muistin osoite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Piirisarja</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Lempinimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Moduulialias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fyysinen tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Suurin teho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Ajurin versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Ajuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Väylän tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Looginen nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Mac osoite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Väylän tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Ajuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Suurin teho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Moduulialias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fyysinen tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>Prosessorin tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Core ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Säikeet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Arkkitehtuuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Prosessorin tuoteperhe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Prosessori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Ytimet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualisointi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Laajennukset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 välimuisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 välimuisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 välimuisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i välimuisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d välimuisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Kerroin</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Maksimi nopeus</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Grafiikkamuisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Moduulialias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fyysinen tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Muistin osoite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO-portti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Väylän tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maksimi tarkkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Minimi tarkkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Nykyinen tarkkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Ajuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Kuvaus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Näytön ulostulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Väylän tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Moduulialias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fyysinen tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Suurin teho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Ajuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Sarjanumero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Malli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Liitäntä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Väylän tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Moduulialias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fyysinen tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Maksimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Ajuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Yleiskuva</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>Prosessori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Suorittimen määrä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Emolevy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Muisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Näytönohjain</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Äänikortti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Levytila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Muut PCI -laitteet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Akku</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Verkkokortti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Hiiri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Näppäimistö</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Näyttö</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Tulostin</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Muut laitteet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Laite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Kokonaisleveys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Kohdistus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Sarjanumero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Määritetty jännite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Suurin jännite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Pienin jännite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Määritetty nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Datan leveys</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Näytön sisääntulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Liitännän tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Tukee tarkkuutta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Nykyinen tarkkuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Näytön taajuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Ensisijainen näyttö</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Sarjanumero</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Median tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Moduulialias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fyysinen tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmware versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Nopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Kuvaus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Sarjanumero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Liitäntä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Pyörimisnopeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Valitse päivitettävä ohjain</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Kansiosta ei löytynyt ohjaimia</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Ladataan äänilaitteen tietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Ladataan BIOS-tietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Ladataan CD-ROM-tietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Ladataan käyttöjärjestelmän tietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Ladataan prosessorin tietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Ladataan muiden laitteiden tietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Ladataan virtatietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Ladataan tulostintietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Ladataan hiiren tietoja...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Ladataan verkkokortin tietoja...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Laiteen tiedot</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Näytä pikakuvakkeet</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Sulje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Apua</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopio</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Järjestelmä</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Laitehallinta</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Laitteisto</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Ajurit</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Näyttö</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Yleiskuva</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Näytönohjain</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Prosessori</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Verkkokortti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Akku</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Lisää</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Nykyinen versio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Ajurialustan versio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Tila</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Toiminta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Varmuuskopioitavat ajurit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Varmistetut ajurit</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Päivittää</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Seuraava</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Laite ei ole käytettävissä ohjaimen poistamisen jälkeen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Poista asennus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Poistetaan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Päivitys onnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Asennuksen poisto onnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Päivitys epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Asennuksen poistaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Seuraava</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Valittua kansiota ei ole, valitse uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Päivitä</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Edellinen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Viallinen paketti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Epäsopiva pakettiarkkitehtuuri</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Valittua tiedostoa ei ole, valitse uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Tämä ei ole ajuri</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Asennus ei onnistu – ei digitaalista allekirjoitusta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Tuntematon virhe</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Ohjainta ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Virheellinen moduulin formaatti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Ohjaimella on riippuvuuksia</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Laitteen nimi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versio saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Tila</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Toiminta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Uusi versio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Nykyinen versio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Puuttuvat ajurit (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Vanhetuneet ajurit (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Ajantasaiset ajurit (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Ajurien asennus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Ajurien varmistus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Ajurien palautus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Palaute</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Sinulla ei ole palautettavia ohjaimia, varmuuskopioi ensin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Siirry kohtaan Ajurien varmistus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Nykyinen versio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Varmistuksen versio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Toiminta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Palautettavat ajurit</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Yleiskuva</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Ajurien asennus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Ajurien varmistus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Ajurien palautus</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Laitteen käyttöönotto epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Laitteen poistaminen käytöstä epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Käytöstä poisto epäonnistui: laitteen SN:n haku epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Päivitä ajurit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Poista ajurit</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Yleiskuva</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Käyttöön</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Salli sen herättää tietokone</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Käytöstä poisto epäonnistui: laitteen SN:n haku epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Laitteen poistaminen käytöstä epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Laitteen käyttöönotto epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Päivitä ajurit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Poista ajurit</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Alihankkija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Alalaite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Ajuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Ajurin tila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Ajurin aktivointi cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Määrityksen tila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>viive</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Käsittelijät</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Väylä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>BIOS-tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Pohjan tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Järjestelmätiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Laitteen tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Fyysisen muistin ryhmä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Julkaisupäivä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Suorituksen kesto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM-koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Ominaisuudet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS-versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware-versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Tuotteen nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Sarjanumero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Sisältökuvaus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Sijainti kotelossa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Laitteen käsittely</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Sisällön käsittely</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Herätys tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>SKU numero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Perhe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Lukko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Käynnistystila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Virtalähteen tila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Lämpötila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Turvallisuuden tila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM-tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Korkeus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Virtajohtojen lukumäärä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Sisältää elementtejä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Paikannin</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Virheenkorjauksen tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maksimi kapasiteetti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Virheilmoitusten käsittely</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Laitteiden määrä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS-muistin koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Julkaisupäivä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Piirilevyn nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS Versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Kieli Kuvaus Formaatti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Asennettavat kielet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Asennettu kieli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD-osoite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Pakettityyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Yhteyskäytäntö</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Linkin tila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Luokka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Palvelun luokat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Laiteluokka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Alaversio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Laite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Sarjan tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>tuote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>kuvaus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Käytössä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Löydettävissä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Liitettävissä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modpeite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Hakemassa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Ajuripaketit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Laitetiedosto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Laiteen tiedostot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Laitenumero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Sovellus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>tila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>looginen nimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ansiversio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU-valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU-arkkitehtuuri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU-variantti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU-osa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU-versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Yksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Kaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Neljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Kuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Kahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Yhdeksän</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Kymmenen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Kaksitoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Viisitoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Kuusitoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Kahdeksantoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Kaksikymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Kaksikymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Kaksikymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Kaksikymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Kaksikymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Kolmekymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Kolmekymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Kolmekymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Kolmekymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Kolmekymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Neljäkymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Neljäkymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Neljäkymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Neljäkymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Neljäkymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Viisikymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Viisikymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Viisikymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Viisikymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Viisikymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Kuusikymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Kuusikymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Kuusikymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Kuusikymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Kuusikymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Seitsemänkymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Seitsemänkymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Seitsemänkymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Seitsemänkymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Seitsemänkymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Kahdeksankymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Kahdeksankymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Kahdeksankymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Kahdeksankymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Kahdeksankymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Yhdeksänkymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Yhdeksänkymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Yhdeksänkymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Yhdeksänkymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Yhdeksänkymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Sata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Satakaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Sataneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Satakuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Satakahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Satakymmenen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Sata kaksitoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Sata neljätoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Sata kuusitoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Sata kahdeksantoista</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Sata kaksikymmentä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Sata kaksikymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Sata kaksikymmentäneljä</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Sata kaksikymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Sata kaksikymmentäkahdeksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Sata yhdeksänkymmentäkaksi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Kaksisataa viisikymmentäkuusi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR-kapasiteetti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU-valmistaja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU-tyyppi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL-versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL-rajapinnat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL-versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL-versio</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Tuntematon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Laitteistoluokka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>Prosessori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Suoritinta ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Emolevy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Emolevyä ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Muisti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Muistia ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Levytila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Levyä ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Ajurien palautus epäonnistui!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Yritä uudelleen tai anna meille palautetta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Ajurien varmistus epäonnistui!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Näytönohjain</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>GPU:ta ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Näyttö</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Näyttöä ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Verkkokortti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Verkkokorttia ei löytynyt</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Äänikortti</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Äänilaitetta ei löytynyt</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Bluetooth ei löytynyt</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Muut PCI -laitteet</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Muita PCI-laitteita ei löytynyt</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Virta</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Akkua ei löytynyt</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Äänikortti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Äänilaitetta ei löytynyt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Bluetooth ei löytynyt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Muut PCI -laitteet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Muita PCI-laitteita ei löytynyt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Virta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Akkua ei löytynyt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Näppäimistö</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Näppäimistöä ei löytynyt</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Hiiri</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Hiirtä ei löytynyt</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Tulostin</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Tulostinta ei löytynyt!</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Kamera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Kameraa ei löytynyt</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>CD-levyä ei löytynyt!</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Hiiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Hiirtä ei löytynyt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Tulostin</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Tulostinta ei löytynyt!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Kameraa ei löytynyt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-levyä ei löytynyt!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Muut laitteet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Muita laitteita ei löytynyt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Matriisin käsittely</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Muotoseikka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Aseta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Muistin sijainti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Tyypin tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Osanumero</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Sijoitus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Muistitekniikka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Muistin käyttötilan ominaisuus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmware versio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Moduulin valmistajan tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Moduulin tuotetunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Muistin alihankkijan tunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Muistin alihankkijan tuotetunnus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Pysyvä koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Kiinteä koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Välimuistin koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Looginen koko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>tuumaa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Päivämäärä</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>sivut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>väylän tiedot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>looginensektorikoko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sektorikoko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometria (looginen)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Laitehallinta</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Laitehallinta on kätevä työkalu laittetietojen tarkastelemiseen ja laitteiden hallintaan.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Uusia ajureita saatavilla! Asenna tai päivitä ne nyt.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Näytä</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Sisällytä alikansiot</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Etsi ajurit tästä polusta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 ajuripäivitystä saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Tarkistettu: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Ajurien lataus %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Latausnopeus: %1 ladattu %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Asennetaan ajureita %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 ajuria asennettu, %2 ajuria epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 ajuria asennettu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Ajurien asentaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Verkkovirhe. Yhdistetään uudelleen...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Latausnopeus: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Ajurit ovat ajan tasalla</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Kaikki ajurit on varmistettu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Yhteensä %1 ajuria, joista %2 on varmuuskopioitu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Sinulla on %1 ajuria, jotka voidaan varmuuskopioida. Suosittelemme, että teet sen heti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Sinulla on %1 ajuria, jotka voidaan varmuuskopioida</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Varmuuskopioidaan %1 ajuria, yhteensä %2</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Varmistetaan: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 ajuria varmuuskopioitu, %2 epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Ajureiden varmuuskopiointi epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 ajuria varmistettu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Sinulla on %1 ajuria, jotka voidaan palauttaa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Valitse palautettava ajuri</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Ajuria palautetaan...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Palautetaan: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>käynnistä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Ole hyvä ja %1, jotta asennetut ajurit tulevat voimaan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Näytä varmuuskopiopolku</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Varmista kaikki</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>anna palautetta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Yritä uudelleen tai %1 meille</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Asenna kaikki</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Tarkista uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Tarkistetaan laitteisto-ajureita, odota...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Tarkistetaan %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Tarkistus epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Verkko ei saatavilla</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Tarkista verkkoyhteytesi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Tarkista uudelleen tai %1 meille</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Olet asentamassa ajuria, joka rikkoutuu, jos poistut.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Oletko varma, että haluat poistua?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Poistu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Varmuuskopioit ajureita, jotka keskeytyvät, jos poistut.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Palautat ajureita, jotka keskeytyvät, jos poistut.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Ajuritiedostoja ei saatu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Päivitä</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Varmista</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Palauta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Asenna</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Päivitä ajurit</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Poista ajurit</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Salli sen herättää tietokone</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Käyttöön</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Vie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopio</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Ei saatavilla</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Valitse paikallinen kansio</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Ladataan...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_fil.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_fil.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fil">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Balik</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Mas</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Abiso sa network</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Ibalik ang pag-install</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Mas</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Bumagsak</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Hindi magagamit</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Pangalan ng Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Kabuuang kakayahan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisions</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Address ng memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Hindi magagamit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Sersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Mga nangunguna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Lumalakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maximum na kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Versyon ng driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Kabatiran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Kasalungat na pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>Address ng MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Hindi magagamit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>I-off</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Mga nangunguna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Kabatiran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maximum na kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Lumalakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Hindi magagamit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>I-off</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Mga nangunguna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Core ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Mga thread</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arkitektura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Pamilya ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Prosesor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Core (s)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Pagmamay-ari</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Bintana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Pangalawang Paggalaw</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Pagsusumikap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Maximum Speed</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Mga tagapagtustos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Graphics Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Address ng Memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon sa Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maximum Resolution</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minimum Resolution</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Kasalukuyang Resolution</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Pangkalahatang Pagsusuri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Digital Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Display Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Kabability</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Hindi available</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Mga tagagawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon sa Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maximum Power</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kabability</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Hindi available</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Mga tagagawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interface</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon sa Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maximum Current</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Kabangat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Sersyong</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Di magagamit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>I-wag</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Panimulang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Bilang ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Adapter ng Pagpapakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Adapter ng Buhay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Pamamahala sa Paggalaw</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Mga Iba Pang PCI Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Bateriya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Adapter ng Network</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Mga Iba Pang Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Laki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Lamang Lapad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Mga Lokasyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serye ng Bilang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Nakasusukat na Boltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Makakalawang Boltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Makakamaliit na Boltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Nakasusukat na Bilis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Lapad ng Datos</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Input ng Pagpapakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Uri ng Interface</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Suportado Resolution</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Kasalukuyang Resolution</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Porsyento ng Pagpapakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Pangunahing Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Laki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Serye ng Bilang</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Kabatiran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Versyon ng Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Makakalawang Taktik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Taktik ng Pag-uusap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto Negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Memory Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logical Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Diwala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Iboto</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Tagapagtustos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon sa Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Input/Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Kabatidang mga kakayahan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Tagapagtustos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon sa Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kabability</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maximum Power</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Speed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Diwala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Iboto</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Kalagayan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kabugtang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Boltahe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Slot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Nasusunod na Kabugtang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Nasusunod na Boltahe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS Bersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS Paggawa ng Araw</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS Chemistry</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Temperature</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Sinamantala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Kalagayan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Uri ng Paggamit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>I-wag</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Mga Tagagawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Uri ng Media</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Laki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Kabatangan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Versyon ng Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Pangalawang Paggawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Numero ng Serisyal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Rate ng Pag-ukit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Hindi na Laruin</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Piliin ang isang driver para i-update</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Walang driver na nakita sa folder na ito</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Naglalagot ng Impormasyon ng Audio Device...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Naglalagot ng Impormasyon ng BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Naglalagot ng Impormasyon ng CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Naglalagot ng Impormasyon ng Sistema ng Pag-operasyon...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Naglalagot ng Impormasyon ng CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Naglalagot ng Impormasyon ng Mga Iba pang Kagamitan...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Naglalagot ng Impormasyon ng Pagkakaroon ng Kuryente...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Naglalagot ng Impormasyon ng Printer...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Naglalagot ng Impormasyon ng Mouse...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Naglalagot ng Impormasyon ng Network Adapter...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>I-wag</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Hindi na Laruin</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>I-wag</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Hindi na Laruin</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Mga Detalye ng Device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Mga shortcut ng display</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>I-close</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Tulong</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopyahin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Manager ng Device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Drivers</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Overview</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Adapter ng Display</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Adapter ng Network</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Bateriya</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Mas</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Version ng Driver Platform</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Drivers na maaaring i-backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Drivers na na-backup</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Nag-uupdate</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Kanselahin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Susunod</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Paalala</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Ang device hindi magagamit na pagkatapos i-uninstall ang driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>I-uninstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Nag-uuninstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Nagawa na ang update</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Nagawa na ang uninstallation</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Nagawa ang update</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Nagawa ang pag-uninstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Susunod</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Wala ang napiling folder, piliin muli</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>I-update</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Maliit</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Nakasira ang package</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Hindi sumasang-ayon ang architecture ng package</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Wala ang napiling file, piliin muli</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Hindi ito isang driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Hindi maaari i-install - walang digital signature</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Di kilalang error</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Wala nang nakita ang driver module</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Invalid na format ng module</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>May mga dependency ang driver module</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>I-install ang Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>I-backup ang Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>I-restore ang Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Mga komento</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Wala kang anumang driver na maaari i-restore, paki-backup muna</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Punta sa Backup Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Versyon ng Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Mga driver na maaari i-restore</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Panimula</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>I-install ang Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>I-backup ang Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>I-restore ang Driver</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Nagawaan ang pag-activate ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Nagawaan ang pag-batay ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Nagawaan ang pag-batay nito: hindi maaaring makuha ang device SN</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>I-update ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>I-copy</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Panimula</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>I-copy</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Paganahin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>I-update ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Pahintuluyan ito upang mag-awit ng computer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>I-batay</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Nagawaan ang pag-batay nito: hindi maaaring makuha ang device SN</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Nagawaan ang pag-batay ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Nagawaan ang pag-activate ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>I-update ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>SubVendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>SubDevice</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Status ng Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Driver Activation Cmd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Status ng Config</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Phys</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Impormasyon ng BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Impormasyon ng Base Board</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Impormasyon ng Sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Impormasyon ng Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Mga Memorya sa Pisikal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Petsa ng Paglalabas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Alamat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Laki sa Runtime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Laki sa ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Mga Katangian</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Revisyon ng BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Revisyon ng Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Pangalan ng Produkto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Numero ng Serisyal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Tag ng Asset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Mga Karapatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Lokasyon sa Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Handle ng Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Mga Handle ng Nakakalap na Obje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Uri ng Wake-up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Numero ng SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Pamilya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Ilok</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Estado ng Pagpapalakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Estado ng Pagbibigay ng Kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Thermal State</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Pangangalaga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Impormasyon ng OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Bilang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Bilang ng mga Kabel ng Kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Mga Elemento na Ikinabibilang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Lokasyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Uri ng Pagwawasto ng Kasalanan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maximum Capacity</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Handle ng Impormasyon ng Kasalanan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Bilang ng mga Kagamitan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Petsa ng Paglilinaw</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Pangalang ng Plaka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Format ng Paggamit ng Wika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Mga Wika na Maaring Iinstall</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Kasalukuyang Wika na Ikinabibilang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Uri ng Packet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Policies ng Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Mode ng Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Mga Klas ng Serbisyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Klas ng Selyunit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Versyon ng HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Versyon ng LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Selyunit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID ng Seriyal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produkto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>pangkabug-osang pagsusulit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Nakapag-ebang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Nakakadiscover</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Nakakapare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Nakakadiscover</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Modyul ng Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Papel ng Selyunit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Mga Papel ng Selyunit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Numero ng Selyunit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Aplikasyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>estado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>pangalan ng logical</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Mga tagapag-implementa ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Arali ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Variante ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Bahagi ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Revisyon ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Isang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Siyam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Labing</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Labing-dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Labing-apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Labing-anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Labing-anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Lusot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Lusot at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Lusot at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Lusot at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Lusot at walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Lusot at sampu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Lusot at sampu at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Lusot at sampu at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Lusot at sampu at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Lusot at sampu at walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Lusot at labing-anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Lusot at labing-anim at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Lusot at labing-anim at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Lusot at labing-anim at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Lusot at labing-anim at walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Lusot at labing-anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Lusot at labing-anim at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Lusot at labing-anim at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Lusot at labing-anim at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Lusot at labing-anim at walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Lusot at labing-anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Siksenta-dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Siksenta-apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Siksitan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Siksampu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Pitumpu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Pitumpu at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Pitumpu at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Pitumpu at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Pitumpu at pito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Walo at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Walo at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Walo at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Walo at pito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Labingwalo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Labingwalo at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Labingwalo at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Labingwalo at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Labingwalo at pito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Isang daan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Isang daan at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Isang daan at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Isang daan at anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Isang daan at pito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Isang daan at walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Isang daan at labingwalo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Isang daan at labindalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Isang daan at labindalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Isang daan at labindalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Isang daan at labimpitu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Isang daan at labimpitu at dalawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Isang daan at labimpitu at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Isang daan at dalawampu-anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Isang daan at dalawampu-walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Isang daan at siyamnapu-pu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Dalawang daan at limampu-anim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kabugtang ng GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Mga nangungunang GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Uri ng GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Versyon ng EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL Client APIs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Versyon ng GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Versyon ng GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Di kilala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Klaseng hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Walang CPU na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Walang motherboard na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Sakop</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Walang memorya na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Pamamahala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Walang disk na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Nagka-error ang pag-ibayon ng driver!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Sana subukan muli o magbigay ng feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Nagka-error ang pag-backup ng driver!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Adapter ng display</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Walang GPU na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Walang monitor na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Network Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Walay network adapter na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Sound Adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Walay audio device na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Walay Bluetooth device na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Mga iba pang PCI Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Walay iba pang PCI device na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Powersupply</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Walay battery na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Walay keyboard na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Walay mouse na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Walay printer na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Walay camera na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Walay CD-ROM na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Mga iba pang mga device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Walay iba pang mga device na nahanap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Form Factor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Set</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bank Locator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Type Detail</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Part Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Memory Technology</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Kababilidad ng Mode ng Pag-Operate sa Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Versyon ng Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ID ng Manufacturer ng Module</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID ng Product ng Module</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ID ng Manufacturer ng Memory Subsystem Controller</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ID ng Product ng Memory Subsystem Controller</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Laki ng Non-Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Laki ng Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Laki ng Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Laki ng Logical</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>inches</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Araw</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>network</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>baterya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>supply ng kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>naimodify</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>may kasaysayan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>may mga estadistika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>mababatay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>estado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>antas ng palakasan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>enerhiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>enerhiya na walay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>enerhiya na puno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>enerhiya na puno ng disenyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>mabilis na enerhiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>voltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>porsyento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknolohiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>pangalan ng icon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>versyon ng daemon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>sa baterya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>lid ay nakabukas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>lid ay nakakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritikal na aksyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>tanggalin ang trabaho pagkatapos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>ipagmamano hanggang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>prioridad ng trabaho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>oras ng pagbabago ng marker</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>bilang sa iba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>pangangalaga sa direksyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>mga kulay sa pag-print</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer ay nagsusumikap sa mga trabaho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer ay nakakonekta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer ay temporal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>gawa at modelo ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>oras ng pagbabago ng estado ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>mga kadahilanan ng estado ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>uri ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>uri ng URI ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>mga gilid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus impormasyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logicalsectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>guid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometriya (Kabug-os)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Mangulo ng mga Selyon</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Ang Device Manager ay isang mapagbubuti na tool para makita ang impormasyon ng hardware at pamahalaan ang mga selyon.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>May mga bagong driver! I-install o i-update ito ngayon.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Pananatiling Pananaw</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Mag-include ng mga subfolder</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Hanapin ang mga driver sa landas na ito</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 driver updates available'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Nakasuri ang oras: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Nagdudownload ng mga driver para sa %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Lamangan: %1 Nakuha: %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Nag-iinstall ng mga driver para sa %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 drivers na inilagay, %2 drivers na nagsawa'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 drivers na inilagay'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Nagsawa ang pag-install ng mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Mga error sa network. Nagrereconnect...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Lamangan: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Ang iyong mga driver ay nakakatagpo na</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Lahat ng mga driver ay naka-back up na</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Isang kabuuang %1 drivers, kung saan ang %2 ay naka-back up na</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Mayroon kang %1 drivers na maaaring i-back up, kinakailangan ito ngayon</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Mayroon kang %1 drivers na maaaring i-back up</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Nag-back up ng %1 driver, isang kabuuang %2 drivers</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Nag-back up: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 drivers na naka-back up, %2 drivers na nagsawa'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Nagsawa ang pag-back up ng mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 drivers na naka-back up'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Mayroon kang %1 drivers na maaaring i-restore</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Siyang piliin ang isang driver para i-restore</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Ang driver ay nagsisimula nang i-backup...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Nag-i-backup: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>pangalawang pag-ugat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Please %1 para ma-epekto ang mga nakainstal na driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Tingnan ang landas ng backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Backup lahat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>mag-submit ng feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Please subukan muli o %1 para sa amin</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Install lahat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>I-scan muli</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Kanselahin</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Nag-scan ng mga driver ng hardware device, please wait...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Nag-scan ng %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Nagkabigo ang scan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Wala pang network</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Please tingnan ang iyong network connection</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Please i-scan muli o %1 para sa amin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Ang iyong nag-i-install ng driver, ang gagawin ay ma-epekto kung i-exit ka.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Sigurado ka ba na gusto mong i-exit?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>I-exit</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Kanselahin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Ang iyong nag-i-backup ng drivers, ang gagawin ay ma-epekto kung i-exit ka.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Ang iyong nag-i-restore ng drivers, ang gagawin ay ma-epekto kung i-exit ka.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Imaging device</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Display adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Sound card</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Wireless network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Ang pag-install ay nabatid</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Nagkabanggit ang pag-install</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Nagdudownload</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Nag-iinstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Hindi nakakatag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Naglalabas na</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Naghihintay</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Hindi nakakatag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Naglalabas ng backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Nagkabanggit ang backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Nagawa ang backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Naglalabas ng pagbawi</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Di-nakakilala na error</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Mga error sa network</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Nakasakop</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Nagkabanggit ang pagkuha ng mga file ng driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>I-update</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Ibawi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>I-install</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>I-update ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Pahintuluyan ito upang mabuo ang computer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>I-enable</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopyahin</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Wala</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Pakipili ng isang lokal na folder, please</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Naglo-load...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_fr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_fr.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Commentaire en retour</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Plus</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Réduire</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Plus</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Plus</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Réduire</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Plus</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Réduire</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nom du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Puce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Révision</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>Pilote de noyau</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Adresse mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias ​​</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Charge maximum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Version du pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Infos du bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nom logique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Adresse MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Infos du bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Charge maximum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Core ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Tâches</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Architecture</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Famille de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Processeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Noyau(x)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualisation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Indicateurs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensions</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>Cache L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Cache L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Cache L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Cache L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Cache L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Étape</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Vitesse max</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Mémoire graphique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Adresse mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Port E/S</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Infos du bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Résolution maximale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Résolution minimale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Résolution actuelle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Sortie numérique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Sortie écran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Infos du bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Charge maximum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Infos du bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Courant maximal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
@@ -762,214 +753,176 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Aperçu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Quantité de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Carte mère</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Carte graphique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Adaptateur audio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Stockage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Autres périphériques PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Batterie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Adaptateur réseau</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Souris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Clavier</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Écran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Imprimante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Caméra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Autres appareils</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Appareil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
-        <translation>Système d&apos;exploitation</translation>
+        <translation>Système d'exploitation</translation>
     </message>
 </context>
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Largeur totale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Localisateur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Tension configurée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Tension maximale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Tension minimale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Vitesse configurée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Largeur des données</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Entrée écran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
-        <translation>Type d&apos;interface</translation>
+        <translation>Type d'interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Résolution de prise en charge</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Résolution actuelle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
-        <translation>Ratio d&apos;affichage</translation>
+        <translation>Ratio d'affichage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Écran principal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Numéro de série</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
@@ -1417,7 +1367,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
         <source>Interface Type</source>
-        <translation>Type d&apos;interface</translation>
+        <translation>Type d'interface</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Vendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Type de support</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Capacités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Version du micrologiciel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Taux de rotation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Sélectionner un pilote pour la mise à jour</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Aucun pilote trouvé dans ce dossier</translation>
     </message>
@@ -1524,67 +1469,65 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Chargement des informations du périphérique audio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Chargement des informations du BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Chargement des informations du lecteur CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
-        <translation>Chargement des informations du système d&apos;exploitation...</translation>
+        <translation>Chargement des informations du système d'exploitation...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Chargement des informations du processeur...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Chargement des informations des autres périphériques...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Chargement des informations de la batterie...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
-        <translation>Chargement des informations de l&apos;imprimante...</translation>
+        <translation>Chargement des informations de l'imprimante...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Chargement des informations de la souris...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
-        <translation>Chargement des informations de l&apos;adaptateur réseau...</translation>
+        <translation>Chargement des informations de l'adaptateur réseau...</translation>
     </message>
 </context>
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
-        <translation>Infos de l&apos;appareil</translation>
+        <translation>Infos de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Afficher les raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Système</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Gestionnaire de périphériques</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Matériel</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Écran</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Aperçu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Carte graphique</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Adaptateur réseau</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Batterie</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Plus</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Version actuelle</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>Version de la plateforme du pilote</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Statut</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Pilotes que vous pouvez sauvegarder</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Pilotes sauvegardés</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Prochain</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Le périphérique sera indisponible après la désinstallation du pilote</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Désinstaller</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Désinstallation</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Mise à jour réussie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Désinstallation réussie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Échec de la mise à jour</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>La désinstallation a échoué</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Suivant</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
-        <translation>Le dossier sélectionné n&apos;existe pas, veuillez sélectionner à nouveau</translation>
+        <translation>Le dossier sélectionné n'existe pas, veuillez sélectionner à nouveau</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Paquet cassé</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Architecture de paquet non correspondante</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
-        <translation>Le fichier sélectionné n&apos;existe pas, veuillez sélectionner à nouveau</translation>
+        <translation>Le fichier sélectionné n'existe pas, veuillez sélectionner à nouveau</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
-        <translation>Ce n&apos;est pas un pilote</translation>
+        <translation>Ce n'est pas un pilote</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
-        <translation>Impossible d&apos;installer - pas de signature numérique</translation>
+        <translation>Impossible d'installer - pas de signature numérique</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
-        <translation>Le module de pilote n&apos;a pas été trouvé</translation>
+        <translation>Le module de pilote n'a pas été trouvé</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Format de module invalide</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Le module de pilote a des dépendances</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Nom du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Version disponible</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Statut</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nouvelle version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Version actuelle</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Pilotes manquants (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Pilotes obsolètes (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Pilotes à jour (%1)</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>Installation de pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>Sauvegarde de pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>Restauration de pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Commentaire en retour</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation>Vous n&apos;avez pas de pilote à restaurer, veuillez faire une sauvegarde au préalable</translation>
+        <translation>Vous n'avez pas de pilote à restaurer, veuillez faire une sauvegarde au préalable</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Aller à la sauvegarde de pilote</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Version actuelle</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Sauvegarder la version</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Pilotes pouvant être restaurés</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Aperçu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Installation de pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Sauvegarde de pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Restauration de pilotes</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
-        <translation>Échec de l&apos;activation de l&apos;appareil</translation>
+        <translation>Échec de l'activation de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
-        <translation>Échec de la désactivation de l&apos;appareil</translation>
+        <translation>Échec de la désactivation de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation>Échec de la désactivation : impossible d&apos;obtenir le numéro de série de l&apos;appareil</translation>
+        <translation>Échec de la désactivation : impossible d'obtenir le numéro de série de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Mettre à jour les pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Désinstaller les pilotes</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Aperçu</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
@@ -2128,36 +2052,35 @@
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
         <source>Allow it to wake the computer</source>
-        <translation>L&apos;autoriser à réveiller l&apos;ordinateur</translation>
+        <translation>L'autoriser à réveiller l'ordinateur</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation>Échec de la désactivation : impossible d&apos;obtenir le numéro de série de l&apos;appareil</translation>
+        <translation>Échec de la désactivation : impossible d'obtenir le numéro de série de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
-        <translation>Échec de la désactivation de l&apos;appareil</translation>
+        <translation>Échec de la désactivation de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
-        <translation>Échec de l&apos;activation de l&apos;appareil</translation>
+        <translation>Échec de l'activation de l'appareil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Mettre à jour les pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Désinstaller les pilotes</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>Revendeur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>Appareil secondaire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Statut du pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
-        <translation>Commande d&apos;activation du pilote</translation>
+        <translation>Commande d'activation du pilote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Statut de la configuration</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>latence</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Sous-routines</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>CLÉ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Informations du BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Informations sur la carte de base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Informations système</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Informations sur le châssis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Tableau de mémoire physique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Date de sortie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
-        <translation>Taille d&apos;exécution</translation>
+        <translation>Taille d'exécution</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Taille de la ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Caractéristiques</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Révision du BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Révision du micrologiciel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Nom du produit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Numéro de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
-        <translation>Numéro d&apos;inventaire</translation>
+        <translation>Numéro d'inventaire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Fonctionnalités</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Emplacement dans le châssis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Poignée du châssis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
-        <translation>Gestionnaires d&apos;objet contenus</translation>
+        <translation>Gestionnaires d'objet contenus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Type de réveil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>Numéro SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Famille</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Verrouiller</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
-        <translation>État d&apos;amorçage</translation>
+        <translation>État d'amorçage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
-        <translation>État de l&apos;alimentation électrique</translation>
+        <translation>État de l'alimentation électrique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>État thermique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>État de sécurité</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Informations OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
-        <translation>Nombre de cordons d&apos;alimentation</translation>
+        <translation>Nombre de cordons d'alimentation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Éléments contenus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Emplacement</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
-        <translation>Type de correction d&apos;erreur</translation>
+        <translation>Type de correction d'erreur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacité maximale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
-        <translation>Traitement des informations d&apos;erreur</translation>
+        <translation>Traitement des informations d'erreur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Nombre de périphériques</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>Taille de la ROM du BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Date de sortie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nom de la carte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Version SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format de description de la langue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Langues disponibles</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Langue actuellement installée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Adresse BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Type de paquet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Politique de liage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Mode de liage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Classe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Classes du service</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Classe du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Version HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Version LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Sous version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Appareil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>ID de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>description</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Alimenté</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Visible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Jumelable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Découvrir</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Modules pilotes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Fichier du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Fichiers du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Numéro du périphérique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Application</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>statut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>nom logique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>version ansi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementeur du CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Architecture du CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variante du CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Partie du CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Révision du CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Un</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Neuf</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dix</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Douze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Quatorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Seize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Dix-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Vingt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Vingt-deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Vingt-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Vingt-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Vingt-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trente</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trente-deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trente-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Trente-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trente-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Quarante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Quarante-deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Quarante-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Quarante-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Quarante-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cinquante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cinquante-deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cinquante-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cinquante-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cinquante-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Soixante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Soixante-deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Soixante-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Soixante-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Soixante-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Soixante-dix</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Soixante-douze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Soixante-quatorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Soixante-seize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Soixante-dix-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Quatre-vingts</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Quatre-vingt-deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Quatre-vingt-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Quatre-vingt-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Quatre-vingt-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Quatre-vingt-dix</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Quatre-vingt-douze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Quatre-vingt-quatorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Quatre-vingt-seize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Quatre-vingt-dix-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Cent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Cent deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Cent quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Cent six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Cent huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Cent dix</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Cent douze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Cent quatorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Cent seize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Cent dix-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Cent vingt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Cent vingt-deux</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Cent vingt-quatre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Cent vingt-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Cent vingt-huit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Cent quatre-vingt-douze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Deux cent cinquante-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacité GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Vendeur du GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Type de GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Version EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>APIs pour les clients EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Version de GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Version de GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Classe de matériel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Aucun CPU trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Carte mère</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Aucune carte mère trouvée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Aucune mémoire trouvée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Stockage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Aucun disque trouvé</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>La restauration du pilote a échoué</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>Essayez à nouveau ou envoyez un commentaire</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Sauvegarde de pilote échouée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Carte graphique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Aucun GPU trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Écran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Aucun écran trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Adaptateur réseau</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Aucune carte réseau trouvée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Adaptateur audio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Aucun appareil audio détecté</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Aucun périphérique Bluetooth trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Autres périphériques PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Aucun autre périphérique PCI trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Alimentation</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Aucune batterie trouvée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Clavier</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Aucun clavier trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Souris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Aucune souris trouvée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Imprimante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Aucune imprimante trouvée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Caméra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Aucune caméra trouvée</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Aucun CD-ROM trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Autres appareils</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Aucun autre appareil trouvé</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Poignée du tableau</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Facteur de forme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Définir</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Localisateur de banque</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Détails du type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Numéro de pièce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Technologie de la mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
-        <translation>Capacité du mode d&apos;opération mémoire</translation>
+        <translation>Capacité du mode d'opération mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Version du micrologiciel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID du manufacturier de module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID de produit du module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID du manufacturier du système de sous contrôle de la mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID de production du sous système de contrôle de la mémoire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Taille non volatile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Taille volatile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Taille du cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Taille logique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>pouce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
@@ -3529,7 +3290,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
         <source>warning-level</source>
-        <translation>niveau d&apos;avertissement</translation>
+        <translation>niveau d'avertissement</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
@@ -3554,7 +3315,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
         <source>energy-rate</source>
-        <translation>taux d&apos;énergie</translation>
+        <translation>taux d'énergie</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
@@ -3574,7 +3335,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
         <source>icon-name</source>
-        <translation>nom d&apos;icône</translation>
+        <translation>nom d'icône</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
@@ -3619,7 +3380,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
         <source>job-hold-until</source>
-        <translation>prend en charge la tâche jusqu&apos;à</translation>
+        <translation>prend en charge la tâche jusqu'à</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
@@ -3639,52 +3400,52 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
         <source>orientation-requested</source>
-        <translation>demande d&apos;orientation</translation>
+        <translation>demande d'orientation</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
         <source>print-color-mode</source>
-        <translation>mode d&apos;impression en couleur</translation>
+        <translation>mode d'impression en couleur</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
         <source>printer-is-accepting-jobs</source>
-        <translation>l&apos;imprimante accepte les impressions</translation>
+        <translation>l'imprimante accepte les impressions</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
         <source>printer-is-shared</source>
-        <translation>l&apos;imprimante est partagée</translation>
+        <translation>l'imprimante est partagée</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
         <source>printer-is-temporary</source>
-        <translation>l&apos;imprimante est temporaire</translation>
+        <translation>l'imprimante est temporaire</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
         <source>printer-make-and-model</source>
-        <translation>marque et modèle de l&apos;imprimante</translation>
+        <translation>marque et modèle de l'imprimante</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
         <source>printer-state-change-time</source>
-        <translation>Heure de changement d&apos;état de l&apos;imprimante</translation>
+        <translation>Heure de changement d'état de l'imprimante</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
         <source>printer-state-reasons</source>
-        <translation>état de l&apos;imprimante</translation>
+        <translation>état de l'imprimante</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
         <source>printer-type</source>
-        <translation>type d&apos;imprimante</translation>
+        <translation>type d'imprimante</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
         <source>printer-uri-supported</source>
-        <translation>l&apos;imprimante supporte les URis</translation>
+        <translation>l'imprimante supporte les URis</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
@@ -3692,313 +3453,294 @@
         <translation>côtés</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>Disque dur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>infos du bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>taille du secteur logique</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>taille du secteur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Géométrie (Logique)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Gestionnaire de périphériques</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Gestionnaire de périphériques est un outil pratique pour afficher les informations sur le matériel et gérer les périphériques.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Nouveaux pilotes disponibles ! Installez-les ou mettez-les à jour maintenant.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Vue</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Inclure les sous-dossiers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Rechercher des pilotes dans ce chemin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 mises à jour de pilotes disponibles</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Heure de vérification : %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Téléchargement des pilotes pour %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Vitesse de téléchargement : %1 Téléchargé %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Installation des pilotes pour %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 pilotes installés, %2 ont échoué</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 pilotes installés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
-        <translation>Échec de l&apos;installation des pilotes</translation>
+        <translation>Échec de l'installation des pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Erreur réseau. Reconnexion...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Vitesse de téléchargement : %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Vos pilotes sont à jour</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Tous les pilotes ont été sauvegardés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Un total de %1 pilotes sur %2 ont été sauvegardés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Vous avez %1 pilotes pouvant être sauvegardés, il est recommandé de le faire immédiatement</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Vous avez %1 pilotes pouvant êtres sauvegardés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Sauvegarde de %1 pilotes sur un total de %2 pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Sauvegarde: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 pilotes sauvegardés, %2 pilotes échoués</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Sauvegarde de pilotes échouée</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 pilotes sauvegardés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Vous avez %1 pilotes pouvant être restaurés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Veuillez sélectionner un pilote à restaurer</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Pilote en cours de restauration...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Restauration: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>redémarrer</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Veuillez %1 pour que les pilotes installés prennent effet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Voir le chemin de la sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Sauvegarder tout</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>soumettre des commentaires</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Veuillez réessayer ou %1 pour nous</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Tout installer</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Rechercher à nouveau</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Analyse des pilotes de périphériques matériels, veuillez patienter...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Recherche de %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
-        <translation>L&apos;analyse a échoué</translation>
+        <translation>L'analyse a échoué</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Réseau indisponible</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Veuillez vérifier votre connexion réseau</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Veuillez rechercher à nouveau ou %1 pour nous</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation>Vous êtes en train d&apos;installer un pilote, ce qui sera interrompu si vous quittez.</translation>
+        <translation>Vous êtes en train d'installer un pilote, ce qui sera interrompu si vous quittez.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Êtes-vous sûr de vouloir quitter ?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Sauvegarde de pilotes, cela sera interrompu si vous quittez</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Restauration de pilotes, cela sera interrompu si vous quittez</translation>
     </message>
@@ -4009,9 +3751,8 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
-        <translation>Dispositif d&apos;imagerie</translation>
+        <translation>Dispositif d'imagerie</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="38"/>
@@ -4041,7 +3782,7 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="67"/>
         <source>Installation failed</source>
-        <translation>L&apos;installation a échoué</translation>
+        <translation>L'installation a échoué</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="68"/>
@@ -4111,25 +3852,25 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Failed to get driver files</source>
-        <translation>Impossible d&apos;obtenir les fichiers du pilote</translation>
+        <translation>Impossible d'obtenir les fichiers du pilote</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Sauvegarde</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Restauration</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Installer</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Mettre à jour les pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Désinstaller les pilotes</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
-        <translation>L&apos;autoriser à réveiller de l&apos;ordinateur</translation>
+        <translation>L'autoriser à réveiller de l'ordinateur</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Actualiser</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Indisponible</translation>
     </message>
@@ -4210,15 +3949,15 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
-        <translation>Sélectionnez un dossier local, s&apos;il vous plaît</translation>
+        <translation>Sélectionnez un dossier local, s'il vous plaît</translation>
     </message>
 </context>
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Chargement...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_gl_ES.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_gl_ES.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Xustifica</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Máis</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Colapsar</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Máis</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Máis</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Colapsar</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Máis</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Colapsar</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nome do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>Caminho de SysFS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Descrición</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>Controlador do modo kernel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Enderezo da memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Poder máximo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versión do controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Información do bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nome lóxico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Enderezo MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Información do bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Poder máximo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID do Núcleo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Fíos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Arquitectura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Familia CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Procesador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Núcleo(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualización</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Bandeiras</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensións</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>Cache L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Caché L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Caché L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Caché L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Caché L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Pisando</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Velocidade máxima</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Memoria gráfica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Enderezo da memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Porto IO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Información do bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Resolución máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Resolución mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Resolución actual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Descrición</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Saída dixital</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Saída a pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Información do bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Poder máximo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Información do bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Corrente máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Visión xeral</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Número de CPUs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Adaptador do son</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Almacenamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Outros dispositivos PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Rato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Impresora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Cámara</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Outros dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>SO</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Ancho total</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Localizador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Tensión configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Tensión máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Tensión mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Velocidade configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Ancho dos datos</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Ancho da visualización</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Tipo de interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Resolución de apoio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Resolución actual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Amosar ratio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor principal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Tipo de media</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Capacidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versión do firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Descrición</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Taxa de rotación</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Seleccione un controlador para actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Non se atoparon controladores neste cartafol</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Cargando a información do dispositivo de audio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Cargando información BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Cargando información CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Cargando información do sistema operativo</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Cargando información da CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Cargando a información doutros dispositivos...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Cargando a información do poder...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Cargando a información da impresora...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Cargando a información do rato</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Cargando a información do adaptador da rede...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Información do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Amosar atallos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Pechar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Axuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Xestor de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Visión xeral</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Máis</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Versión actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Versión de plataforma de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Controladores con copia de seguridade</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Copia de seguranza de controladores</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Actualizando</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>O dispositivo non estará dispoñíbel despois da desinstalación do controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Desinstalando</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Instalación exitosa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Desinstalación exitosa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Erro ao actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Erro ao desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>O cartafol seleccionado non existe, selecciónao de novo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Paquete roto</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Arquitectura de paquetes incomparable</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>O ficheiro seleccionado non existe, selecciónelo de novo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Non é un controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Non se puido instalar - sen sinatura dixital</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Erro descoñecido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Non se atopou o módulo controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>O formato do módulo non é válido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>O módulo controlador ten dependencias</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Nome do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versión dispoñíbel</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nova versión</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Versión actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Faltan controladores (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Controladores obsoletos (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Controladores actualizados (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Instalación de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Copia de seguridade do controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Restauración de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Xustifica</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Non tes ningún controlador para restaurar, primeiro fai unha copia de seguridade</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Vaia ao controlador de copia de seguranza</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Versión actual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Versión de copia de seguranza</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Controladores restaurables</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Visión xeral</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Instalación de controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Copia de seguridade do controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Restauración de controladores</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Fallo ao activar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Fallo ao desactivar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Produciuse un erro ao desactivalo: non se puido obter o SN do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Actualizar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar controladores</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Visión xeral</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Permíteo espertar o ordenador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Produciuse un erro ao desactivalo: non se puido obter o SN do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Fallo ao desactivar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Fallo ao activar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Actualizar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar controladores</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>SubFabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>SubDispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Estado do controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Activación do controlador Cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Configuración do estado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>Latencia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Manipuladores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>CLAVE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Información BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Información da tarxeta base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Información do sistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Información do chasis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Matriz de memoria física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Data de lanzamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Enderezo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Tamaño de tempo de execución</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Tamaño ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Características</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revisión BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revisión do firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Nome do produto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Etiqueta de activos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Características</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Localización en chasis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Manexador do chasis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Tiradores de obxectos contidos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Tipo de erguer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Número de SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Familia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Pechar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Estado do inicio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Estado de subministración de enerxía</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Estado térmico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Estado de seguranza</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Información OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Número de cables de alimentación</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elementos contidos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Localización</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Tipo de corrección de erro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacidade máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Manexo de información de erro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Número de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>TAMAÑO ROM DE BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Data de lanzamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nome da placa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versión SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Formato de descrición do idioma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Idiomas instalables</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Idioma instalado actualmente</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Enderezo BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Tipo de paquete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Política de ligazón</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Modo da ligazón</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Clase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Clases do servidor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Clase do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versión HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versión LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversión</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>ID de serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>descrición</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Impulsado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Descuberto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Pariable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalidades</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Descubrindo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Módulos de controladores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Ficheiro do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Ficheiros do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Número de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplicativos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>estado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>nome lóxico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>versión ansi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementador de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arquitectura de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variante de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Parte de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revisión de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Un</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Nove</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dez</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Doce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Catorce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Dezaseis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Dezaoito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Vinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Vinte e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Vinte e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Vinte e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Vinte e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trinta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trinta e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trinta e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Trinta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trinta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Corenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Corenta e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Corenta e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Corenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Corenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cincuenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cincuenta e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cincuenta e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cincuenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cincuenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sesenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sesenta e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sesenta e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sesenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sesenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Setenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Setenta e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Setenta e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Setenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Setenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Oitenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Oitenta e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Oitenta e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Oitenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Oitenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Noventa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Noventa e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Noventa e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Noventa e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Noventa e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Cen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Cento dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Cento catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Cento seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Cento oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Cento dez</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Cento doce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Cento catorce</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Cento dezaseis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Cento dezaoito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Cento vinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Cento vinte e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Cento vinte e catro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Cento vinte e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Cento vinte e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Cento noventa e dous</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Douscentos cincuenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacidade GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Fabricante da GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Tipo GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versión EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>Cliente APIs EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versión GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versión GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Descoñecido</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Clase de hardware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Non se atopou ningunha CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Non se atopou ningunha placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Non se atopou ningunha memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Almacenamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Non se atopou ningún disco</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Fallou a restauración do controlador!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Por favor, pruba de novo ou dámennos xustifica</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Fallou a copia de seguridade dos conductores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Adaptador de pantalla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Non se atopou ningún GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Non se atopou ningún monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Non se atopou ningún adaptador da rede</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Adaptador do son</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Non se atopou ningún dispositivo de audio</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Non se atopou ningún dispositivo Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Outros dispositivos PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Non se atopou outro dispositivo PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Poder</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Non se atopou ningunha batería</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Adaptador do son</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Non se atopou ningún dispositivo de audio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Non se atopou ningún dispositivo Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Outros dispositivos PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Non se atopou outro dispositivo PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Poder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Non se atopou ningunha batería</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Non se atopou ningún teclado</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Rato</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Non se atopou ningún rato</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Impresora</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Non se atopou ningunha impresora</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Cámara</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Non se atopou ningunha cámara</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>Non se atopou ningún CD-ROM</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Rato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Non se atopou ningún rato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Non se atopou ningunha impresora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Cámara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Non se atopou ningunha cámara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>Non se atopou ningún CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Outros dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Non se atopou outro dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Matriz de manexo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Factor de forma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Establecer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Localizador de bancos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Detalle tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Parte número</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rango</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Memoria tecnolóxica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Modo de funcionamento da memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versión do firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID do fabricante do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID do produto do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID do fabricante do controlador de subsistemas de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID do produto do controlador de subsistemas de memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Tamaño non volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Tamaño volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Tamaño caché</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Tamaño lóxico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>polgada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>lados</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>información do bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>Tamaño do sector lóxico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>Tamaño do sector</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guía</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Xeometría (Lóxico)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Xestor de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Xestor de dispositivos é unha ferramenta útil para ver información de hardware e xestionar os dispositivos.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Conductores novos dispoñibles! Instálalos ou actualíjalos agora.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Include subcarrifos</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Busca conductores neste camiño</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 actualizacións de conductor dispoñibles</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Hora de comprobación: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Descargando conductores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocidade de descarga: %1 Descargado %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Instalando conductores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 conductores instalados, %2 conductores fallaron</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 conductores instalados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Fallou a instalación dos conductores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Erro na rede. Reconectando...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Velocidade de descarga: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Os seus controladores están actualizados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Todos os controladores están copiados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Un total de %1 controladores, de os que %2 están copiados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Tienes %1 controladores que se pueden copiar, é recomendable que o haches inmediatamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Tienes %1 controladores que se pueden copiar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Está copiando o controlador %1, un total de %2 controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Copiando: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 controladores copiados, %2 fallaron</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Fallou a copiar os controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 controladores copiados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Tienes %1 controladores que se pueden restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Por favor, selecciona un controlador para restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>O controlador está a restaurarse...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Restaurando: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Por favor, %1 para que os controladores instalados tenan efecto</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Ver ruta de copia de seguridade</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Copia de todo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>enviar feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Por favor, tenta de novo ou %1 con nós</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Instalar todo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Escanear de novo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Escaneando controladores de dispositivos de hardware, agarde...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Escaneando %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Erro ao escanear</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Rede non dispoñible</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Comproba a túa conexión de rede</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Escanea de novo ou %1 para nós</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Estás a instalar un controlador, que se interromperá se saes.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Estás seguro de que queres saír?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Saír</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Estás facendo unha copia de seguranza dos controladores, que se interromperán se saes.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Estás restaurando controladores, que se interromperán se saes.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Produciuse un erro ao obter os ficheiros do controlador</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Copia de seguranza</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Actualizar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Desinstalar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Permíteo espertar o ordenador</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Recargar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Non dispoñible</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Seleccione un cartafol local, por favor</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Cargando...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_he.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_he.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="he">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>フィードバック</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>אישור</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">יותר</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished"> 접기</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>יותר</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>יותר</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation> 접기</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>יותר</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation> 접기</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>השבת</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>שם המכשיר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>חип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>תפקודים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>כינוי מודול</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID פיזי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>תיאור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>שדרוג</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>מצלצל מצב חומרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>כתובת זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>تعطيل</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>כיסוי</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>מודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID פיזית</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>מהירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>SSIP מקסימלית</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>גרסה של המומץ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>מומץ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>כישורים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>מידע על תחנת חיבור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>שם לוגי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>כתובת MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>غير متوفر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation> Dezaktivieren</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>מודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>מידע על תחנת חיבור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>כישורים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>מפעיל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>הנפילה המаксימלית</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>מהירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>כינוי מודול</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID פיזי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation> Dezaktivieren</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
-        <source>CPU ID</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
-        <source>Core ID</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
-        <source>Threads</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
-        <source>BogoMIPS</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
-        <source>Architecture</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
-        <source>CPU Family</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>מזהה CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>מזהה גרעין</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>תreads</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>בוגו מיפס</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>ארכיטקטורה</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation> משפחת CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>מודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
-        <translation type="unfinished"/>
+        <translation>מעבד</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>כרוס</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation> виртуאליזציה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>פאנלים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>הרחבות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>מגש L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>מגש L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>מגש L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>מגש L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>מגש L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>סיבוב</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>מהירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>מהירות מקסימלית</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>מודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation> זיכרון גרפי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>כינוי מודול</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID פיזי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>כתובת זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>תת תחתי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>מידע שטיח</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>해상도 최대</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>해상도 최소</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>해상도 현재</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>מפעיל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>תיאור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
-        <translation type="unfinished"/>
+        <translation>די פיי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
-        <translation type="unfinished"/>
+        <translation>אי די פיי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
-        <translation type="unfinished"/>
+        <translation>הדי מאי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
-        <translation type="unfinished"/>
+        <translation>ויגע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
-        <translation type="unfinished"/>
+        <translation>די ווי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>יציאה דיגיטלית</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
-        <translation type="unfinished"/>
+        <translation>יציאה תצוגה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>כישורים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>מודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>מידע על תחנת חיבור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>כינוי מודול</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID פיזי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>מהירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>הנפילה המаксימלית</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>מפעיל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>כישורים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>מספר סדר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>השבה</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>מודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>הצורה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>מידע על רשת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>כינוי מודול</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID פיזי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>מהירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation> Strom מקסימלי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>מפעיל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>תכונות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>השבה</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>תקציר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>معالג</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>כמותمعالג</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>.BOARD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>מזהה תצוגה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>מזהה שמע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>ה Hos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>ה Hos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>בATER</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>בליgetPosition</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>ממשק רשת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>הכף</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>כלי כתיבה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>מוניטור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>מ��יק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>קAMERA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>.Devices אחרים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>DEVICE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>oS</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>גודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>סוג</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>מהירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>폭 총합</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>מזהה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>מספר סדר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>מתח מותאם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>מתח מקסימום</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>מתח מינימום</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>מהירות מותאמת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>폭 נתונים</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>מוניטור DEVICE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>סוג</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>הכנסת תצוגה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>סוג חיבור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>תפ=subprocessution פלט поддерживаемое разрешение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>הPHA当前分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>יחס תצוגה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>מוניטורראשי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>גודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>מספר סדרה</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>ספק</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>סוג</translation>
     </message>
@@ -1100,7 +1050,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
         <source>Port</source>
-        <translation>פוג&apos;ט</translation>
+        <translation>פוג'ט</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
@@ -1115,32 +1065,32 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>השהייה</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
         <source>IP</source>
-        <translation type="unfinished"/>
+        <translation>אי פי</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
         <source>Firmware</source>
-        <translation type="unfinished"/>
+        <translation>סופט웨어 מותנה</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
         <source>Duplex</source>
-        <translation type="unfinished"/>
+        <translation>דופלקס</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
         <source>Broadcast</source>
-        <translation type="unfinished"/>
+        <translation>רמקול</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
         <source>Auto Negotiation</source>
-        <translation type="unfinished"/>
+        <translation>ת约 אוטומטית</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
@@ -1203,7 +1153,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
         <source>Input/Output</source>
-        <translation type="unfinished"/>
+        <translation>קלט/פלט</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
@@ -1218,7 +1168,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>השהייה</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>מוצר של</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>סוג מסמך</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>גודל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>הופכים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>מ Oaks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID פיזית</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>גרסה של תוכנת המטאור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>מהירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>תיאור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>מספר סדרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>אינטראקציה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>קצב סיבוב</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>בחר דריבר לעדVerdana</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>לא נמצאו דריברים ב thưרה זו</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>טועמת מידע על Gerät음향장치...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>טועמת מידע על BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>טועמת מידע על CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>טועמת מידע על מערכת ההפעלה...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>טועמת מידע על процессור...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>טועמת מידע על איברים אחרים...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>טועמת מידע על מומנט...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>טועמת מידע על מדפסת...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>טועמת מידע על מ.getCount...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>טועמת מידע על מונחן רשת...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation> Dezactivה</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation> Dezactivה</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>מידע על Gerätה kako</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>הצג מקצרים</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>עזרה</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>העתק</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>מערכת</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>יצא</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>�新鲜</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>מנהל Gerätה kako</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>הARDWARE</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>דיפרזים</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>מונטור</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>תלויון</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>מזהה מסך</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>מזהה רשת</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>בטריה</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>יותר</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>הגרסה הנוכחית</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>הגרסה של המפלטפורמה של הדיפרזים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>מצב</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>פעולה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>דיפרזים ניידים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>דיפרזים שהושקעו</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>עדכון</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>בטל</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>הבא</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>אזהרה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>הDEVICE יהיה זמין לאחר ביטול ההתקנה של הדיפרזים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>הסר</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>הסרת</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>עדכון מוצלח</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>הסרת מוצלחת</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>עדכון נכשל</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>הסרה נכשלה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>הבא</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>התיקייה שנבחרה לא קיימת, אנא בחר שוב</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>עדכון</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>הקודם</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>חבילה שבורתית</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>מגפת חבילת תוכנה לא תואמת</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Dos not exist, please select again</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>זה לא מודול תרשים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>לא ניתן להתקין - אין חתימה דיגיטלית</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>שגיאה לא ידועה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>לא נמצא המודול של המודול</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>פורמט המודול לא תקין</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>מודול המודול תלוי</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>שם המכשיר</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>גרסה זמינה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>גודל</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>סטטוס</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>פעולה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>גרסה חדשה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>גרסה נוכחית</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>מגפת תרשים חסרת (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>מגפת תרשים ישנה (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>ič.getCurrentUser()了好多更新的驱动程序 (%1</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>התקנה של המהנדסים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>העתקת המהנדסים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>חזרה של המהנדסים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>הערות</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>אין לך מEHgetCurrentUser()了好多程需要恢复，请先进行备份</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>לך אל העתקת המהנדסים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>הגרסה הנוכחית</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>הגרסה העתיקה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>פעולה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>מEHgetCurrentUser()了好多נדראגים זזים</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>איפוס</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>אקס포וט</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>סקירה כללית</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>התקנה של המהנדסים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>העתקת המהנדסים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>חזרה של המהנדסים</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>הפעלה של המכשיר נכשלה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>כישלון ב Dunking of the device</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>כישלון ב Dunking of it: לא ניתן להשיג את מספר הסדרה של המכשיר</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>עדכון המהנדסים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>הסרת המהנדסים</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>איפוס</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>ייצוא</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>העתקה</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>תקציר</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>הפעלת</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>อนוסה让他醒来</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation> Dezactivare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>לא ניתן לה Dezactivare את המכשיר: לא ניתן לקבל את מספר סידור המכשיר</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>לא ניתן לה Dezactivare את המכשיר</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>לא ניתן לה פעיל את המכשיר</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>עדכן את המוטרים</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>הסר את המוטרים</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation> תת מ Vendור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation> תת מ תי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>מוטר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>מצב המוטר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation> comamnd להפעיל את המוטר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>מצב ההקצנה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>איטיות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>פיזי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>מארחים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation> PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>כפתור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>בוס</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>מידע על BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>מידע על מסגרת בסיס</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>מידע על מערכת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>מידע על חassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>מערך זיכרון פיזי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>תאריך שחרור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>גודל ביצוע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>גודל ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>מאפיינים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>ה עדכון BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>ה עדכון תוכנה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>שם מוצר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>מספר סדרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>תג אSETS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>מאפיינים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>מיקום בחassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>-handle בחassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>סוג</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>_HANDLES_[]{</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>סוג пробуждения</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>מספר SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>משפחת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation> låm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>מצב הפעלה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>מצב תזונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>מצב תרמOMETRIC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>מצב בטיחות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>מידע על OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>גובה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>מספר חותכי תזונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>عناصر נמצאות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>מיקום</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>סוג תיקון טעויות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>�能达到的最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>מקרה של מידע על טעויות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>מספר חלופות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>גודל BIOS ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>תאריך יצירה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>שם הלוח</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>גרסה של SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>פורמט תיאור שפה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>שפות נחסמות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>השפה הנصبיתปัจจุบัน</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>כתובת BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>סוג פקט</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>מדיניות החיבור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>modo החיבור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>קטגוריה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>קטגוריות שירות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>קטגוריה של מכשיר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>גרסה של HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>גרסה של LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>שFU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>מכשיר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>ID סדרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>מוצר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>תיאור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation> päוע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>נוכחי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>נוכחי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>נוכחי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>מודולים של ידיד</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>קובץ מכשיר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>קבצים מכשיר</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>מספרcadeשvice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>יישום</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>מצב</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>שם לוגי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>מימוש CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>(WIN) תכנית arquiteCDATA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>היבריד CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>חלק CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>העריכה CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>אחת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>שתיים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>ארבע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>שש</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>שמונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>תשע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>שתים עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>ארבעה עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>שישה עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>שמונה עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>עשרים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>עשרים ושתיים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>עשרים וארבע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>עשרים ושש</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Twenty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Thirty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Thirty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Thirty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Thirty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Thirty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Forty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Forty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Forty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Forty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Forty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Fifty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Fifty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Fifty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Fifty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Fifty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sixty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sixty-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sixty-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sixty-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sixty-eight</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Seventy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Seventy-two</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Seventy-four</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Seventy-six</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>שמונים ושמונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>שמונים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>שמונים ושנים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>שמונים וארבע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>שמונים ושש</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>שמונים ושמונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation> תשעים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>תשעים ושנים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>תשעים וארבע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>תשעים ושש</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>תשעים ושמונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>מאה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>מאה ושנים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>מאה וארבע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>מאה ושש</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>מאה ושמונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>מאה עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>מאה ושנים עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>מאה וארבע עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>מאה ושש עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>מאה ושמונה עשרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>מאה עשרים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>מאה עשרים ושנים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>מאה עשרים וארבע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>מאה עשרים ושש</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>מאה ושמונים ושמונה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>מאה תשעים ויב</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>מאת וחמישים ושש</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation> dungDDR�存量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>ספקטור של GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>סוג GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>גרסה של EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>APIים ללקוח של EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>גרסה של GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>גרסה של GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>לא ידוע</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>יחיד</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>קטגוריה של חומרה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>הגה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>לא נמצאה הגה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>.BOARD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>לא נמצאה .BOARD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>לא נמצאה זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>מגנ生产能力</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>לא נמצאה דיסק</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>השחזור של המדריך נכשל</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>נסה שוב או תן לנו חזרה</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>האחסון של המדריך נכשל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>מגש מסך</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>לא נמצאה מפץ גרפי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>מוניטור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>לא נמצא מוניטור</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>מגש רשת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>לא נמצא מגש רשת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>מגש תופעה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>לא נמצאה מכשיר תופעה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>בluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>לא נמצא מכשיר bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>מגשים PCI אחרים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>לא נמצאו מגשים PCI נוספים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>חשמל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>לא נמצאה ניידת חשמל</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>מקלדת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>לא נמצאה מקלדת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>מOUSE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>לא נמצא מOUSE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>מ��פס</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>לא נמצא מ��פס</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>מצלמה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>לא נמצאה מצלמה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>לא נמצא CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>.Devices אחרים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>לא נמצאו מכשירים נוספים</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>מגש מערך</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>צורה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>קבוצה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>מזהה בנק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>פרטים של סוג</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>מספר חלק</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>rang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>טכנולוגיה זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>כapaציה של מצב عمل זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>גרסה של תוכנת─מערכת</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID של ספק סופרמום</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID של מוצר סופרמום</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID של ספק של מנהל מערכת זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID של מוצר של מנהל מערכת זיכרון</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>גודל לא─ממשטי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>גודל משטי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>גודל 缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>גודל לוגי</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>היקף</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
@@ -3692,314 +3453,295 @@
         <translation>גבה</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>מידע על בUSES</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>גודל סCTORיות לוגיות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>גודל סCTORיות</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>GUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>גיאומטריה (לוגית)
 </translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>מנהל מכשירים</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>מנהל מכשירים הוא כלי שימושי להצגת מידע על המחשבות והניהול שלהן.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>ממשקי מארחים חדשים זמינים! התקן או עדכן אותם עכשיו.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>הצג</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
-        <translation type="unfinished"/>
+        <translation>הכלוא תיקיות משנה</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
-        <translation type="unfinished"/>
+        <translation>לחפש דרייברים בمسלול זה</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
-        <translation type="unfinished"/>
+        <translation>יש %1 עדכונים לדרייברים זמינים</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
-        <translation type="unfinished"/>
+        <translation>זמן בדיקה: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>מורידים דרייברים עבור %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation type="unfinished"/>
+        <translation>מהירות הורדה: %1 הורדה %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>מתקינים דרייברים עבור %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>הותקנו %1 דרייברים, %2 דרייברים נכשלו</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
-        <translation type="unfinished"/>
+        <translation>%1 נראשים מותקנים</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
-        <translation type="unfinished"/>
+        <translation>התקנת נראשים נכשלה</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
-        <translation type="unfinished"/>
+        <translation>שגיאה בתקשורת. מנסה להתחבר מחדש...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
-        <translation type="unfinished"/>
+        <translation>מהירות הורדה: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
-        <translation type="unfinished"/>
+        <translation>הנראשים שלך עדכניים</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>הנראשים הוחזרו כולם</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>בסך הכל %1 נראשים, מהם %2 הוחזרו</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>יש לך %1 נראשים שניתן להחזיר, מומלץ לבצע את זה즉시</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>יש לך %1 נראשים שניתן להחזיר</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>הכנת ההחזר של הנראה %1, בסך הכל %2 נראשים</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>החזר: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>%1 נראשים הוחזרו, %2 נראשים נכשלו</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>החזר נראשים נכשל</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 נראשים הוחזרו</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>יש לך %1 נראשים שניתן להחזיר</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>אנא בחר נראה להחזר</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>הנראה מוחזר...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>החזרה: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>אנא %1 כדי שהדрайVERS המותקנים יופעלו</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>הצג נתיב ה备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>הצג נתיב ה备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>הצג נתיב ה备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>אנא נסה שוב או %1 אלינו</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>הצג נתיב ה备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>סרוק שוב</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>בטל</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>סרוק דרایVERS של מכשירי האורח, אנא המתן...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>סרוק %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>סרוק נכשל</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>רשת לא זמינה</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>אנא בדוק את פלטפורמת התקשורת שלך</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>אנא סרוק שוב או %1 אלינו</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>אתה מותקן דרایVER, אם תסגר את התוכנה ייפסק התהליך.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>אתה בטוח שאתה רוצה להתנתק?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>הצג נתיב ה备份</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>בטל</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>אתה מ kopierer דרایVERS, אם תסגר את התוכנה ייפסק התהליך.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>אתה מ kopierer דרایVERS, אם תסגר את התוכנה ייפסק התהליך.</translation>
     </message>
@@ -4010,7 +3752,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>מכשיר ציור</translation>
     </message>
@@ -4022,77 +3763,77 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="40"/>
         <source>Sound card</source>
-        <translation type="unfinished"/>
+        <translation>카드 של קול</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="42"/>
         <source>Network adapter</source>
-        <translation type="unfinished"/>
+        <translation>מתאפשת רשת</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="46"/>
         <source>Wireless network adapter</source>
-        <translation type="unfinished"/>
+        <translation>מתאפשת רשת痰</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="66"/>
         <source>Installation successful</source>
-        <translation type="unfinished"/>
+        <translation>התקנת מצליחה</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="67"/>
         <source>Installation failed</source>
-        <translation type="unfinished"/>
+        <translation>התקנת נכשלה</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="68"/>
         <source>Downloading</source>
-        <translation type="unfinished"/>
+        <translation>מוריד</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="69"/>
         <source>Installing</source>
-        <translation type="unfinished"/>
+        <translation>מתקין</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="70"/>
         <source>Not installed</source>
-        <translation type="unfinished"/>
+        <translation>לא מותקן</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="71"/>
         <source>Out-of-date</source>
-        <translation type="unfinished"/>
+        <translation>לא עדכני</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="72"/>
         <source>Waiting</source>
-        <translation type="unfinished"/>
+        <translation>ממתין</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>לא הוחזר</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>הכנת החזר</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>החזר נכשל</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>איחוי מוצלח</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>שחזור</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4102,37 +3843,37 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Network error</source>
-        <translation type="unfinished"/>
+        <translation>שגיאה רשת</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Canceled</source>
-        <translation type="unfinished"/>
+        <translation>מבוטל</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Failed to get driver files</source>
-        <translation type="unfinished"/>
+        <translation>לא ניתן לקבל קבצי שדרים</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>עדכון</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>איחוי</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>שחזור</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation>התקנה</translation>
     </message>
     <message>
         <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
@@ -4143,39 +3884,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation> Dezaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>רענן</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>יצא</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>עדכן-drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>הסר-drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>אפשר לו לה réveiller את המחשב</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>הפעל</translation>
     </message>
@@ -4183,27 +3922,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>רענן</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>יצא</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>-League of Legends</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation> Dezaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>לא זמין</translation>
     </message>
@@ -4211,7 +3950,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>בחר תיקייה מקומיות, בבקשה</translation>
     </message>
@@ -4219,7 +3958,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>טוען...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_hi_IN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_hi_IN.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>प्रतिक्रिया</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ओके</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>अधिक</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>नेटवर्क नोटिफिकेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>पुन: आवर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>अधिक</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>संकुचित करें</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>उपकरण का नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>चिप</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>सिसएफएस_पथ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>कर्नेल मोड ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>मेमोरी पता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>आईआरक्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>चिपसेट</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>एलियास</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>अधिकतम शक्ति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ड्राइवर संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>तार्किक नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>एमएएच पता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>अधिकतम शक्ति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>सीपीयू आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>कोर आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>थ्रेड्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>बोगोमिप्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>आर्किटेक्चर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>सीपीयू परिवार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>प्रोसेसर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>कोर (एस)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>वर्चुअलाइजेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>फ़्लैग्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>एक्सटेंशन्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>एल 3 कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>एल 2 कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>एल 1आई कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>एल 1डी कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>स्टेपिंग</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>स्पीड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>मैक्स स्पीड</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ग्राफिक्स मेमोरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>फिजिकल आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>मेमोरी एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>आईओ पोर्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>अधिकतम रेज़ोल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>न्यूनतम रेज़ोल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>वर्तमान रेज़ोल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>विवरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>डीपी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>ईडीपी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>एचडीएमआई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>वीजीए</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>डीवीआई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>डिजिटल आउटपुट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>डिस्प्ले आउटपुट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>आईआरक्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>वैंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>अधिकतम शक्ति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>वैंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>संस्थान</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>अधिकतम वर्तमान</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>सारांश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>सीपीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>सीपीयू की मात्रा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>मदरबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>स्मृति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>दिखाव के अनुकूलक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>ध्वनि अनुकूलक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>संग्रह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>अन्य पीसीआई उपकरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>बैटरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>ब्लूटूथ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>नेटवर्क अनुकूलक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>माउस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>कीबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>मॉनिटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>सी-डी रोम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>प्रिंटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>कैमरा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>अन्य उपकरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>उपकरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ओएस</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>कुल चौड़ाई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>संरचित वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>अधिकतम वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>न्यूनतम वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>संरचित गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>डेटा चौड़ाई</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>डिस्प्ले इनपुट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>इंटरफेस प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>समर्थन रेज़ोलूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>वर्तमान रेज़ोलूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>डिस्प्ले अनुपात</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>मुख्य डिस्प्ले</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ड्राइवर संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>अधिकतम दर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>सौदाजोग दर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>पोर्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>मल्टीकास्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>लिंक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>लेटेंसी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>आईपी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>फर्मवेयर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ड्यूपलेक्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>ब्रॉडकास्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ऑटो नेगोशिएशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>मेमरी एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>आईआरक्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>मैक एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>लॉजिकल नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>इनपुट/आउटपुट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>मेमरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>आईआरक्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>लेटेंसी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>कैपेबिलिटीज</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>अधिकतम शक्ति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>निषेध करें</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>सॉट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>डिज़ाइन क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>डिज़ाइन वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>एसबीडीएस संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>एसबीडीएस सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>एसबीडीएस निर्माण तारीख</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>एसबीडीएस रसायन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>तापमान</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>साझा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>यूआरआई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>संचार प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>मीडिया प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>क्षमताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>फ़र्मवेयर संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>गति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>विवरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>संचार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>घूर्णन दर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>अपडेट के लिए एक ड्राइवर चुनें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>इस फ़ोल्डर में कोई ड्राइवर नहीं मिला</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ऑडियो डिवाइस जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>बायोस जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>सी-डी रॉम जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ऑपरेटिंग सिस्टम जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>सीपीयू जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>अन्य डिवाइस जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ऊर्जा जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>प्रिंटर जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>माउस जानकारी लोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>नेटवर्क एडप्टर जानकारी लोड कर रहे हैं...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>उपकरण जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>दिखाएं शॉर्टकट</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>बंद करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>सहायता</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>कॉपी करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>सिस्टम</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>अपोर्ट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>उपकरण प्रबंधक</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>हार्डवेयर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>मॉनिटर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>ओवरव्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>दिखाएं एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>सीपीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>नेटवर्क एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>बैटरी</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>अधिक</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ड्राइवर प्लेटफॉर्म संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>बैकअप करने योग्य ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>बैकअप किए गए ड्राइवर</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>अपडेट कर रहे हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>रद्द करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>अगला</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>चेतावनी</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ड्राइवर अनइंस्टॉल करने के बाद उपकरण उपलब्ध नहीं होगा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>अनइंस्टॉल करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>अनइंस्टॉल कर रहे हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>अपडेट सफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>अनइंस्टॉल सफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>अपडेट असफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>अनस्थापन असफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ओके</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>अगला</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>चयनित फोल्डर नहीं मिल रहा है, कृपया फिर से चयन करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>पिछला</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>टूटा पैकेज</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>असदस्य पैकेज आर्किटेक्चर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>चयनित फ़ाइल नहीं मिल रही है, कृपया फिर से चयन करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>यह एक ड्राइवर नहीं है</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>इंस्टॉल करना संभव नहीं है - कोई डिजिटल साइनेचर नहीं है</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>अज्ञात तर्क</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ड्राइवर मॉड्यूल नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>अमान्य मॉड्यूल प्रारूप</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ड्राइवर मॉड्यूल में निर्भरताएं है</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ड्राइवर इंस्टॉल करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ड्राइवर बैकअप करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ड्राइवर बहाल करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>प्रतिक्रिया</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>आपके पास कोई ड्राइवर बहाल करने के लिए नहीं है, कृपया पहले बैकअप करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>बैकअप ड्राइवर जाएं</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>बैकअप संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>बहाल करने योग्य ड्राइवर</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>निर्यात करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>ओवरव्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ड्राइ वर इंस्टॉल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ड्राइ वर बैकअप</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ड्राइ वर रिस्टोर</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>उपकरण को सक्षम करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>उपकरण को अक्षम करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>इसे अक्षम करने में विफल: उपकरण के SN को प्राप्त करने में असमर्थ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ड्राइवर अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ड्राइवर अनस्थापित करें</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>पुनः चलाएं</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>निर्यात करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>कॉपी करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ओवरव्यू</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>पुनः चलाएं</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>निर्यात करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>कॉपी करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>सक्षम करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ड्राइवर अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ड्राइवर अनस्थापित करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>यह कंप्यूटर को जगाने की अनुमति दें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>अक्षम करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>इसे अक्षम करने में विफल: उपकरण के SN को प्राप्त करने में असमर्थ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>उपकरण को अक्षम करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>उपकरण को सक्षम करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ड्राइवर अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ड्राइवर अनस्थापित करें</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>उप-वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>उप-उपकरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ड्राइवर स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ड्राइवर सक्रियण कमांड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>कॉन्फ़िग स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>लेटेंसी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>फिज़िकल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>सिसएफएस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>हैंडलर्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>प्रॉप</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ईवी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>की</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>बस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>बायोस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>आधार पै plat जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>सिस्टम जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>चेसिस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>फिजिकल मेमोरी एरे</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>मुक्ति तारीख</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>पता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>रनटाइं आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>आरओएम आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>विशेषताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>बायोस पुनर्व्यवस्था</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>फर्मवेयर पुनर्व्यवस्था</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>उत्पाद नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>सीरियल संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>संपत्ति टैग</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>विशेषताएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>चेसिस में स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>चेसिस हैंडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>सामग्री वाले ऑब्जेक्ट हैंडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>यूआईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>वेक-अप प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>एसकू संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>परिवार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>लॉक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>स्टार्टअप स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>बिजली सнैप स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>थर्मल स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>सुरक्षा स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ओईएम जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ऊंचाई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>बिजली केबल की संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>सामग्री तत्व</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>स्थान</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>त्रुटि संशोधन प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>अधिकतम क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>त्रुटि जानकारी हैंडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>उपकरणों की संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>बिस रोमसाइज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>जारी करने की तारीख</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>बोर्ड नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>एसएमबीआईओस वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>भाषा वर्णन प्रारूप</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>इंस्टॉल करने योग्य भाषाएं</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>वर्तमान इंस्टॉल की गई भाषा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>बीडी पता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>एसएल सीएमटीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>एससीओ सीएमटीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>पैकेट प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>लिंक नीति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>लिंक मोड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>क्लास</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>सेवा क्लासेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>उपकरण क्लास</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>एचसीआई संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>एलएमपी संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>उप-संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>उपकरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>सीरियल आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>उत्पाद</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>विवरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>चालू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>खोजी लिए उपलब्ध</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>युग्मन करे उपलब्ध</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>मोडिलियास</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>खोजी कर रहा है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>ड्राइवर मॉड्यूल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>उपकरण फ़ाइल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>उपकरण फ़ाइलें</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>उपकरण संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>अनुप्रयोग</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>स्थिति</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>तार्किक नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>एनएसआई संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>सीपीयू विवर्तक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>सीपीयू विवर्तक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>सीपीयू वैरिएंट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>सीपीयू हिस्सा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>सीपीयू संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>एक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>नौ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>दस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>बारह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>चौदह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>सोलह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>अठारह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>बीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>बीस-दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>बीस-चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>बीस-छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>बीस-आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>तीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>तीस-दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>तीस-चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>तीस-छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>तीस-आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>चौंतीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>चौंतीस-दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>चौंतीस-चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>चौंतीस-छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>चौंतीस-आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>पच्चीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>पच्चीस-दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>पच्चीस-चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>पच्चीस-छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>पच्चीस-आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>छप्पीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>छप्पीस-दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>छप्पीस-चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>छप्पर छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>छप्पर आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>सत्तर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>सत्तर दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>सत्तर चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>सत्तर छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>सत्तर आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>अठारह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>अठारह दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>अठारह चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>अठारह छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>अठारह आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>नब्बर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>नब्बर दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>नब्बर चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>नब्बर छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>नब्बर आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>एक सौ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>एक सौ दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>एक सौ चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>एक सौ छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>एक सौ आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>एक सौ दस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>एक सौ बारह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>एक सौ बारह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>एक सौ सोलह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>एक सौ अठारह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>एक सौ बीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>एक सौ बीस दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>एक सौ बीस चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>एक सौ बाईंतीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>एक सौ बाईंतीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>एक सौ उनतीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>दो सौ पचपन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL ग्राहक एपीआई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>अज्ञात</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>अद्वितीय</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>एमएससी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>हार्डवेयर क्लास</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>सीपीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>कोई सीपीयू नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>मदरबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>कोई मदरबोर्ड नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>मेमोरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>कोई मेमोरी नहीं मिली</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>स्टोरेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>कोई डिस्क नहीं मिली</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ड्राइवर बहाली असफल रही!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>कृपया फिर से प्रयास करें या हमें फीडबैक दें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ड्राइवर बैकअप असफल रही!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>दिस्प्ले एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>कोई GPU नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>मॉनिटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>कोई मॉनिटर नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>नेटवर्क एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>कोई नेटवर्क एडाप्टर नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>साउंड एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>कोई ऑडियो डिवाइस नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>ब्लूटूथ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>कोई ब्लूटूथ डिवाइस नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>अन्य PCI डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>कोई अन्य PCI डिवाइस नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>ऊर्जा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>कोई बैटरी नहीं मिली</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>कीबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>कोई कीबोर्ड नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>माउस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>कोई माउस नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>प्रिंटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>कोई प्रिंटर नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>कैमरा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>कोई कैमरा नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>सी-डी रॉम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>कोई सी-डी रॉम नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>अन्य डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>कोई अन्य डिवाइस नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>एरे हैंडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>फॉर्म फैक्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>सेट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>बैंक लोकेटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>टाइप डिटेल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>पार्ट नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>रैंक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>मेमरी टेक्नोलॉजी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>मेमोरी ऑपरेटिंग मोड क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>फर्मवेयर संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>मॉड्यूल मैन्युफैक्चरर आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>मॉड्यूल प्रोडक्ट आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>मेमोरी सबसिस्टम कंट्रोलर मैन्युफैक्चरर आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>मेमोरी सबसिस्टम कंट्रोलर प्रोडक्ट आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>अस्थायी आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>स्थायी आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>कैच आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>तार्किक आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>इंच</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>तारीख</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>आईओपोर्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>नेटवर्क</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>बैटरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>नेटिव-पैथ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>पावर सप्लाई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>अपडेट किया गया</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>इतिहास है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>सांख्यिकी है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>पुनः चार्ज करने योग्य</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>अवस्था</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>चेतावनी स्तर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ऊर्जा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ऊर्जा खाली</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ऊर्जा भरा हुआ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ऊर्जा भरा हुआ डिज़ाइन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ऊर्जा दर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>प्रतिशत</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>तकनीक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>आइकन का नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ऑनलाइन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>डेमॉन संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>बैटरी पर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>कवर बंद है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>कवर उपलब्ध है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>गंभीर कार्य</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>कॉपी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>कार्य रद्द करें</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>कार्य रोकें</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>कार्य प्राथमिकता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>मार्कर बदलने का समय</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>पृष्ठ पर संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>अभिविन्यास अनुरोधित</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>प्रिंट कलर मोड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>प्रिंटर जॉब के स्वीकृति के लिए तैयार है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>प्रिंटर साझा है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>प्रिंटर अस्थाई है</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>प्रिंटर बनाने वाला और मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>प्रिंटर स्थिति बदलने का समय</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>प्रिंटर स्थिति कारण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>प्रिंटर प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>प्रिंटर URI समर्थित</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>पक्ष</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>बस जानकारी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>तार्किक सेक्टर आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>सेक्टर आकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>GUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>ज्योमेट्री (तार्किक)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>डिवाइस मैनेजर</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>डिवाइस मैनेजर हार्डवेयर जानकारी देखने और डिवाइस के प्रबंधन के लिए एक उपयोгी टूल है।</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>नए ड्राइवर उपलब्ध हैं! अब इन्स्टॉल या अपडेट करें।</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>देखें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>उप-फोल्डर शामिल करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>इस पथ में ड्राइवर खोजें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>%1 ड्राइवर अपडेट उपलब्ध हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>समय चेक किया गया: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 के लिए ड्राइवर डाउनलोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>डाउनलोड गति: %1 डाउनलोड किया %2/%3</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 के लिए ड्राइवर इंस्टॉल कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>%1 ड्राइवर इंस्टॉल किया गया, %2 ड्राइवर विफल रहे</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>%1 ड्राइवर इंस्टॉल किया गया</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ड्राइवर इंस्टॉल करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>नेटवर्क त्रुटि। पुनः सं连接 कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>डाउनलोड गति: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>आपके ड्राइवर अद्यतन हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>सभी ड्राइवर बैकअप कर लिए गए हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 ड्राइवर कुल, जिनमें से %2 बैकअप कर लिए गए हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 ड्राइवर बैकअप कर सकते हैं, इसे तुरंत करने की सलाह दी जाती है</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 ड्राइवर बैकअप कर सकते हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 ड्राइवर के बैकअप, कुल %2 ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>बैकअप कर रहे हैं: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>%1 ड्राइवर बैकअप किया गया, %2 ड्राइवर विफल रहे</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ड्राइवर बैकअप करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 ड्राइवर बैकअप किया गया</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 ड्राइवर बहाल कर सकते हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>कृपया एक ड्राइवर चुनें जिसे बहाल करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ड्राइवर बहाल कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>बहाल कर रहे हैं: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>रीबूट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>कृपया %1 करें ताकि स्थापित ड्राइवर कार्य कर सकें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>बैकअप पथ देखें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>सभी के लिए बैकअप</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>प्रतिक्रिया भेजें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>कृपया फिर से प्रयास करें या %1 हमें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>सभी के लिए स्थापित करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>फिर से स्कैन करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>रद्द करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>हार्डवेयर डिवाइस ड्राइवर स्कैन कर रहे हैं, कृपया इंतजार करें...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>स्कैन कर रहे हैं %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>स्कैन विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>नेटवर्क उपलब्ध नहीं है</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>कृपया अपना नेटवर्क कनेक्शन चेक करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>कृपया फिर से स्कैन करें या %1 हमें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>आप एक ड्राइवर स्थापित कर रहे हैं, जो आप बाहर निकले तो बाधित हो जाएगा।</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>क्या आप वास्तव में बाहर निकलना चाहते हैं?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>बाहर निकलें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>रद्द करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>आप ड्राइवर बैकअप कर रहे हैं, जो आप बाहर निकले तो बाधित हो जाएगा।</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>आप ड्राइवर बहाल कर रहे हैं, जो आप बाहर निकले तो बाधित हो जाएगा।</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>ब्लूटूथ एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>छवि डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>डिस्प्ले एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>साउंड कार्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>नेटवर्क एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>वायरलेस नेटवर्क एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>स्थापना सफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>स्थापना असफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>डाउनलोड कर रहे हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>स्थापित कर रहे हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>स्थापित नहीं है</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>पुराना है</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>इंतजार कर रहे हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>बैकअप नहीं किया गया</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>बैकअप कर रहे हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>बैकअप असफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>बैकअप सफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>पुनः स्थापित कर रहे हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>अज्ञात त्रुटि</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>जाल त्रुटि</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>रद्द कर दिया गया</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ड्राइवर फ़ाइलें प्राप्त करने में असफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>बैकअप करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>पुनः स्थापित करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>स्थापित करें</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>निष्क्रिय करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>निर्यात करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>ड्राइवर अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ड्राइवर हटाएं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>कंप्यूटर को जागे देने की अनुमति दें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>सक्षम करें</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>अपडेट करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>निर्यात करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>कॉपी करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>निष्क्रिय करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नहीं</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>कृपया एक स्थानीय फ़ोल्डर चुनें</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>लोड हो रहा है...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_hr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_hr.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Povratne informacije</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>U redu</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Više</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Obavijestite mrežu</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Ponovno instalirajte</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Više</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Skrivite</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Onemogućite</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Nedostupno</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Naziv uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Naziv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Čip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>Put do SysFS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revizija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Adresa memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Nedostupno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Onemogućite</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Naziv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Pseudonim</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Naziv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maksimalna snaga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Verzija vozača</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Vozač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Informacije o upravljaču</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logičko ime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Nije dostupan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Ime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Informacije o upravljaču</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Vozač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maksimalna snaga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Nije dostupan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Ime</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Ime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ID procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>ID jezgra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Nitovi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arhitektura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Porodica procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Procesor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Jezgra(š)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualizacija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Zastavice</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Proširenja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Step</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Maksimalna brzina</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Naziv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Prodavač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Grafička memorija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Fizički ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Adresa memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Podaci o upravljaču</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maksimalna rezolucija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minimalna rezolucija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Trenutna rezolucija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Vodič</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Opis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Digital Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Izlaz za prikaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Nije dostupan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Ime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Podaci o busu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maksimalna snaga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Vodič</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Broj serijske karte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Nije dostupan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Ime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Sustav</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Podaci o busu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maksimalni strujni protok</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Vodič</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Nije dostupan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Pregled</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>Procesor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Broj procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Maternička ploča</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Pamet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Adapter za prikaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Adapter za zvuk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Spremnik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Drugi PCI uređaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Baterija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Mrežni adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Miš</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Tastatura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Štampala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Drugi uređaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>Sustav</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Ime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Veličina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Tip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation> Ukupna širina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation> Lokator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation> Serijski broj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation> Postavljena napetost</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation> Maksimalna napetost</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation> Minimalna napetost</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation> Postavljena brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation> Širina podataka</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation> Naziv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation> Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation> Tip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation> Ulaz za prikaz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation> Tip sučelja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation> Podržana rezolucija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation> Trenutna rezolucija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation> Omjer prikaza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation> Glavni monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation> Veličina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation> Serijski broj</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation> Naziv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation> Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation> Tip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation> Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation> Informacije o magistrali</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation> Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation> Vodič</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation> Verzija vodiča</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation> Maksimalna brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation> Ugovorna brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation> Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Мултикаст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Веза</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Задирка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Фирвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Дуплекс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Бродкаст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Аутономни преговор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Адреса памети</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ИРК</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>МАК адреса</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Логичко име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Недоступно</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Онемогући</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Произвођач</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Информације о бусу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Верзија</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Улаз/Излаз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Памет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ИРК</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Задирка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Водач</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Могућности</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Произвођач</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Верзија</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Информације о бусу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Могућности</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Водич</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Максимална моћ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Брзина</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Сериски број</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Недоступан</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Онемогући</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Произвођач</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Сериски број</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Статус</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Капацитет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Напон</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Слот</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Дизајн капацитет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Дизајн напон</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>Верзија SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>Сериски број SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>Датум произвођања SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>Хемија SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation> Температура</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Име</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Произвођач</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Сериски број</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Дељено</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Статус</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Tip interfejsa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Proizvođač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Vrsta medija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Veličina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Mogućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Verzija firmware-a</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Brzina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Opis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Serijski broj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Interfejs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Brzina rotacije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Nedostupno</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Odaberite vodič za ažuriranje</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Nema vodiča u ovom folderu</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Učitavanje informacija o audio uređaju...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Učitavanje informacija o BIOS-u...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Učitavanje informacija o CD-ROM-u...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Učitavanje informacija o operativnom sistemu...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Učitavanje informacija o procesoru...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Učitavanje informacija o drugim uređajima...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Učitavanje informacija o napajanju...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Učitavanje informacija o štampaci...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Učitavanje informacija o mišu...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Učitavanje informacija o mrežnom adapteru...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Nedostupno</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Nedostupno</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation> информација о уреđају</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation> приказ кратких позивница</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation> Затвори</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation> Помоћ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation> Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation> Систем</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation> Извози</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation> Освежи</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation> Уреđајски управљач</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation> Хардвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation> Драйвери</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation> Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation> Увод</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation> Прикључник за приказ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation> ЦПУ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation> Прикључник за мрежу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation> Батерија</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation> Više</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation> Верзија платформе драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation> Драйвери који могу бити наизменичено зачувани</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation> Зачувани драйвери</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation> Ажурирање</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation> Откажи</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation> Следеће</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation> Упозорење</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation> Уреđај ће бити недоступан након деинсталације драйвера</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation> Деинсталација</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation> Деинсталација</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation> Ажурирање је успешно</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation> Деинсталација је успешно</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Ažuriranje je neuspiješno</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Deinstalacija je neuspiješna</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Sljedeće</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Odabrana mapa ne postoji, odaberite ponovno</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Ažuriraj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Prije</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Oštećen paket</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Paket ne pristupa arhitekturi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Odabrani fajl ne postoji, odaberite ponovno</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>To nije voznja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Nije moguće instalirati - nema digitalne potpise</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Nepoznata greška</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Modul voznja nije pronađen</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Neispravni format modula</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Modul voznja ima ovisnosti</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Instalacija voznja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Nadogradnja voznja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Ponovna instalacija voznja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Povratne informacije</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Nemate voznja za ponovnu instalaciju, prvo nadogradite</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Idite na Nadogradnju voznja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Verzija sa rezervom</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Voznja za ponovnu instalaciju</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Osveži</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Izvoz</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Pregled</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Instalacija voznja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Nadogradnja voznja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Ponovna instalacija voznja</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Nije moguće uključiti uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Nije moguće isključiti uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Nije moguće isključiti: ne moguće je dobiti serijski broj uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Ažurirajte vođere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Uklonite vođere</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Osveži</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Izvoz</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopirajte</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Pregled</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Osveži</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Izvoz</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopirajte</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Uključiti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Ažurirajte vođere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Uklonite vođere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Omogućite da probuđe računalo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Isključiti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Nije moguće isključiti: ne moguće je dobiti serijski broj uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Nije moguće isključiti uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Nije moguće uključiti uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Ažurirajte vođere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Uklonite vođere</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Podprodavač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Poduređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Vođer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Status vođera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Naredba za aktivaciju vođera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Status konfiguracije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>Latencija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Fizički</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Obradači</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Verzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Informacije o BIOS-u</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Informacije o osnovnoj ploči</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Informacije o sistemu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Informacije o korpama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fizički niz memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Datum izdavanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Veličina u toku izvršavanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Veličina ROM-a</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Značajke</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Revisionsija BIOS-a</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Revisionsija firmware-a</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Naziv proizvoda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Broj serijske oznake</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Oznaka imovine</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Značajke</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Lokacija u korpi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Rukohvat korpe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Tip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Sadržani objekti rukohvata</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Tip budućnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Broj SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Porodica</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Zaključi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Stanje pri pokretanju</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Stanje napajanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Termičko stanje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Sigurnosno stanje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Informacije o OEM-u</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Visina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Broj kabela za napajanje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Sadržani elementi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Lokacija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Vrsta ispravljanja pogrešaka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maksimalna kapacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Rukohvat informacija o pogrešci</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Broj uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>Veličina BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Datum izdavanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Naziv ploče</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>Verzija SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Format opisa jezika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Instalirani jezici</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Trenutno instalirani jezik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD Adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Vrsta paketa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Politika veze</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Način veze</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klasa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Klase usluga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Klasa uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Verzija HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Verzija LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Podverzija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Serijalni ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>proizvod</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>opis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Uključen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Otkrivljiv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Poveziv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Otkrivanje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Moduli vodiča</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Datoteka uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Datoteke uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Broj uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Aplikacija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logičko ime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Implementer procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Arhitektura procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Varijanta procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Dijel procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Rezim procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Jedan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Devet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Deset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Dvanaest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Sedamnaest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Sedamdeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Osamnaest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Dvadeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Dvadeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Dvadeset četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Dvadeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Dvadeset osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Trijest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Trijest dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Trijest četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Trijest šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Trijest osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Četrdeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Četrdeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Četrdeset četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Četrdeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Četrdeset osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Petdeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Petdeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Petdeset četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Petdeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Petdeset osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Sedamdeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Sedamdeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Sedamdeset četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Šezdeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Šezdeset osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Sedamdeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Sedamdeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Sedamdeset četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Sedamdeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Sedamdeset osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Osamdeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Osamdeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Osamdeset četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Osamdeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Osamdeset osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Dva stotina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Dva stotina dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Dva stotina četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Dva stotina šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Dva stotina osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Jedan stotina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Jedan stotina i dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Jedan stotina i četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Jedan stotina i šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Jedan stotina i osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Jedan stotina i deset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Jedan stotina i dvanaest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Jedan stotina i četrnaest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Jedan stotina i sedamnaest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Jedan stotina i osamnaest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Jedan stotina i dvadeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Jedan stotina i dvadeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Jedan stotina i dvadeset četiri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Sto dvadeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Sto dvadeset osam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Sto devetdeset dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Dva stotina i pedeset šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapacitet GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Prodavač GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Vrsta GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Verzija EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL klijentske API-je</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Verzija GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Verzija GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Nepoznat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Unik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Klasa hardvera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Nije pronađen CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Maternička ploča</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Nije pronađena maternička ploča</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Pamet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Nije pronađena pamet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Spremni prostor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Nije pronađen disk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Povratak drivera nije uspješan!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Molimo pokušajte ponovno ili nam pošaljite povratne informacije</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Spremanje drivera nije uspješno!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Prikazni adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Nije pronađen GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Nije pronađen monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Mrežni adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Nema pronađenog mrežnog adaptera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Zvučni adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Nema pronađenog audio uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Nema pronađenog Bluetooth uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Drugi PCI uređaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Nema pronađenih drugih PCI uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Snaga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Nema pronađenog baterije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Tipkovnica</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Nema pronaĎene tipkovnice</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Miš</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Nema pronađenog miša</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Štampalo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Nema pronađenog štampala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Nema pronađene kamere</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Nema pronađenog CD-ROM-a</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Drugi uređaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Nema pronađenih drugih uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Niz rukovodioca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Oblik faktora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Skup</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Lokator banke</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Detalji tipa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Broj komponente</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Teknologija memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Kapacitet operativnog načina rada memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Verzija firmware-a</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ID proizvođača modula</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID proizvoda modula</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ID proizvođača kontrolera memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ID proizvoda kontrolera memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Veličina nevolatile memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Veličina volatile memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Veličina cache memorije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logička veličina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>inč</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>IOPORT</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>Mreža</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>Baterija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>Nativni put</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>Izvor napajanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>Ažurirano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>Ima povijest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>Ima statistiku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>Ponovno punjivo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>Stanje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>Nivo upozorenja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>Energija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>Energija prazna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>Energija puna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>Energija puna u dizajnu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>Stopa energije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>Napon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>Procenat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>tehnologija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ime ikone</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>verzija demonja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>na bateriji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ključ je zatvoren</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ključ je prisutan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritična akcija</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopije</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>odustajanje posla nakon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>zadržavanje posla do</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>prioritet posla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>vrijeme promjene označenja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>broj na stranici</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orijentacija zahtjevana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>rezim boja tiskanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>tiskalo prihvaća poslove</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>tiskalo je podijeljeno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>tiskalo je privremeno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>proizvođač i model tiskala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>vrijeme promjene stanja tiskala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>razlozi stanja tiskala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>tip tiskala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI tiskala podržan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>strane</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>informacije o upravljaču</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>veličina logičkog sektora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>veličina sektora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometrija (Logička)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Upravljač uređaja</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Upravljač uređaja je korisna alatka za pregled informacija o hardveru i upravljanje uređajima.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Nove uređajne vježbe dostupne! Instalirajte ih ili ažurirajte ih sada.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Pregled</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Uključi potpovršine</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Traži uređajne vježbe u ovom putu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 ažuriranje uređajne vježbe dostupno'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Vrijeme provjerenog: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Preuzimanje uređajnih vježbi za %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Brzina preuzimanja: %1 Preuzeto %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Instalacija uređajnih vježbi za %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 uređajnih vježbi instalirano, %2 uređajnih vježbi neuspješno'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 uređajnih vježbi instalirano'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Nije uspješno instalirano uređajnih vježbi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Mrežna greška. Povezivanje ponovno...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Brzina preuzimanja: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Vaše uređajne vježbe su ažurirane</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Sve uređajne vježbe su sigurno kopirane</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Ukupno %1 uređajnih vježbi, od kojih je %2 sigurno kopirano</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Imate %1 uređajnih vježbi koje mogu biti sigurno kopirane, preporučuje se da to učinite odmah</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Imate %1 uređajnih vježbi koje mogu biti sigurno kopirane</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Sigurno kopiranje %1 uređajne vježbe, ukupno %2 uređajnih vježbi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Sigurno kopiranje: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 uređajnih vježbi sigurno kopirano, %2 uređajnih vježbi neuspješno'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Nije uspješno kopirano uređajnih vježbi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 uređajnih vježbi sigurno kopirano'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Imate %1 uređajnih vježbi koje možete vratiti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Molimo vas odaberite uređajnu vježbu za vraćanje</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Vodič se vraća...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Vraćanje: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>ponovno pokretanje</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Molimo vas %1 da bi se promjene ugrađenih vodiča pojavile</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Pogledajte put do sigurnosne kopije</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Sigurnosna kopija svih</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>pošaljite povratne informacije</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Molimo vas pokušajte ponovno ili %1 nam</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Instaliraj sve</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Ponovno skeniranje</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Odustani</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Pregled vodiča hardverskih uređaja, molimo pričekajte...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Skeniranje %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Skeniranje je neuspješno</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Mreža nije dostupna</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Molimo vas provjerite vašu mrežnu vežu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Molimo vas pokušajte ponovno skeniranje ili %1 nam</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Instalirate vodič, koji će biti prekinut ako izađete.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Zaista želite izći?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Izlaz</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Odustani</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Kopirate vodiče, koji će biti prekinuti ako izađete.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Vraćate vodiče, koji će biti prekinuti ako izađete.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Uređaj za slikanje</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Adapter za prikaz</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Zvučna kartica</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Mrežni adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Bežični mrežni adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Instalacija je uspješna</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Instalacija je neuspješna</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Preuzimanje</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Instalacija</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Nije instalirano</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Zastarjelo</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Čekanje</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Nije sigurno kopirano</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Sigurno kopiranje</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Sigurno kopiranje je neuspješno</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Sigurno kopiranje je uspješno</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Vraćanje</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Nepoznata pogreška</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Mrežna pogreška</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Odustano</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Nije moguće dobiti datoteke za uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Ažuriraj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Sigurno kopiranje</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Vraćanje</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Instaliraj</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Osveži</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Izvoz</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Ažuriraj uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Deinstaliraj uređaj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Dozvoli da probuđe računalo</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Omogući</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Osveži</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Izvoz</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopiraj</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Onemogući</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Nije dostupno</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Odaberite lokalnu mapu, molim</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Učitavanje...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_hu.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_hu.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Visszajelzés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Több</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Összecsukás</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Több</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Több</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Összecsukás</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Több</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Összecsukás</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Eszköz neve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Becenév modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fizikai azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Útvonal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Leírás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Felülvizsgálat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>Kernel módú illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Memóriacím</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Lapkakészlet</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
-        <translation type="unfinished"/>
+        <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Becenév modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fizikai azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Legnagyobb teljesítmény</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Illesztőprogram verziója</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Busz adatok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logikai név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC cím</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Busz adatok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Legnagyobb teljesítmény</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Becenév modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fizikai azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>Processzor azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Mag azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Szálak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Architektúra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Processzorcsalád</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Processzor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Mag(ok)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualizáció</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Zászlók</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Kiterjesztések</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 gyorsítótár</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 gyorsítótár</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i gyorsítótár</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d gyorsítótár</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Lépés</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Maximális sebesség</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Grafikus memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Becenév modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fizikai azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Memóriacím</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Busz adatok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Legnagyobb felbontás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Legkisebb felbontás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Aktuális felbontás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Leírás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Digitális Kimenet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Kijelző kimenete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Busz adatok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Becenév modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fizikai azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Legnagyobb teljesítmény</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Sorozatszám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modell</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interfész</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Busz adatok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Becenév modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fizikai azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Legnagyobb áram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Áttekintés</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>Processzor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Processzorok száma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Alaplap</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Kijelző feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Hang feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Tárhely</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Egyéb PCI-eszközök</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Akkumulátor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Hálózati feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Egér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Billentyűzet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Nyomtató</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Egyéb eszközök</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Eszköz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>Operációs rendszer</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Teljes szélesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Helykereső</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Sorozatszám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Beállított feszültség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Legnagyobb feszültség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Legkisebb feszültség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Beállított sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Adat szélesség</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Kijelző bemenete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Interfész típusa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Támogatott felbontás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Aktuális felbontás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Kijelző képarány</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Elsődleges megjelenítő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Sorozatszám</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Adathordozó típusa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Képességek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Becenév modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fizikai azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmware verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Leírás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Sorozatszám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interfész</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Forgási sebesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Válasszon illesztőprogramot a frissítéshez</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Ebben a mappában nem található illesztőprogram</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Hangeszköz információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS információk betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Operációs rendszer információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Processzor információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Egyéb eszközök információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Tápellátás információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Nyomtató információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Egér információinak betöltése...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Hálózati csatoló információinak betöltése...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Eszköz információ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Parancsikonok megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Bezárás</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Rendszer</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Eszközkezelő</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardver</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Illesztőprogramok</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Áttekintés</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Kijelző feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Processzor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Hálózati feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Akkumulátor</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Több</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Jelenlegi verzió</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>Illesztőprogram-platform verzió</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Állapot</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Művelet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Biztonsági mentésre alkalmas illesztőprogramok</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Mentett illesztőprogramok</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Frissítés...</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Figyelmeztetés</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Az eszköz nem lesz elérhető az illesztőprogram eltávolítása után</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Eltávolítás</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Eltávolítás....</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>A frissítés sikeres</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Az eltávolítás sikeres</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>A frissítés sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Az eltávolítás sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Következő</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>A kiválasztott mappa nem létezik, kérjük válasszon ki egy másikat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Előző</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Törött csomag</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Páratlan csomagarchitektúra </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>A kiválasztott fájl nem létezik, kérjük válasszon ki egy másikat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Ez nem egy illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>A telepítés nem lehetséges – nincs digitális aláírás</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Ismeretlen hiba</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Az illesztőprogram modul nem található</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Érvénytelen modul formátum</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Az illesztőprogram modulnak függőségei vannak</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Eszköz neve</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Elérhető verzió</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Méret</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Állapot</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Művelet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Új verzió</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Jelenlegi verzió</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Hiányzó illesztőprogramok (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Elavult illesztőprogramok (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Naprakész illesztőprogramok (%1)</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>Illesztőprogram telepítése</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>Illesztőprogram biztonsági mentése</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>Illesztőprogram helyreállítása</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Visszajelzés</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Nincsenek helyreállítandó illesztőprogramjai, kérjük először készítsen biztonsági mentést</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Ugrás az illesztőprogramok biztonsági mentéséhez</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Jelenlegi verzió</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Biztonsági mentés verziója</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Művelet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Helyreállítható illesztőprogramok</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Áttekintés</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Illesztőprogram telepítése</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Illesztőprogram biztonsági mentése</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Illesztőprogram helyreállítása</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Nem sikerült engedélyezni az eszközt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Nem sikerült letiltani az eszközt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>A letiltás sikertelen: nem sikerült lekérni az eszköz sorozatszámát</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Illesztőprogramok frissítése</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Illesztőprogramok eltávolítása</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Áttekintés</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Engedélyezés</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Engedélyezze számára, hogy felébressze a számítógépet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>A letiltás sikertelen: nem sikerült lekérni az eszköz sorozatszámát</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Nem sikerült letiltani az eszközt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Nem sikerült engedélyezni az eszközt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Illesztőprogramok frissítése</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Illesztőprogramok eltávolítása</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>Alszállító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>Aleszköz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Illesztőprogram</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Illesztőprogram állapot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Illesztőprogram aktiválási parancs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Konfigurációs állapot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>késleltetés</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fizikai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Kezelők</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>Kulcs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Busz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS információ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Alaplapi információk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Rendszerinformációk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Alváz információ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Fizikai memória tömb</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Megjelenési dátum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Futásidő méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM mérete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Karakterisztika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS felülvizsgálat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware felülvizsgálat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Terméknév</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Sorozatszám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Eszközcímke</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Jellemzők</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Elhelyezkedés az alvázon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Alváz kezelő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Tartalmazott objektum kezelők</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Felébresztés típusa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU szám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Család</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Zárolás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Bootolási állapot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Tápellátási állapot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Hőmérséklet állapot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Biztonsági állapot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM információ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Magasság</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Tápkábelek száma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Tartalmazott elemek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Hely</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Hibajavítás típusa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Legnagyobb kapacitás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Hibainformáció kezelő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Eszközök száma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM-mérete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Kiadás dátuma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Tábla neve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Nyelvi leírás formátuma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Telepíthető nyelvek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>A jelenleg telepített nyelvek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD címek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Csomagtípus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Hivatkozási szabályok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Hivatkozási mód</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Osztály</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Szolgáltatási osztályok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Eszköz osztályok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP Verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Alverzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Eszköz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Sorozat azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>termék</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>leírás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Gyártó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Felfedezhető</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Párosítható</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Becenév módosítása</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Felfedezés</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Illesztőprogram modulok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Eszköz fájl</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Eszköz fájlok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Eszköz szám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Alkalmazás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>állapot</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>logikai név</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansi verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Processzor megvalósító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Processzor acrhitektúra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Processzor variáció</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Processzor rész</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Processzor felülvizsgálat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Egy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Kettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Négy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Hat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Nyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Kilenc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Tíz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Tizenkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Tizennégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Tizenhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Tizennyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Húsz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Huszonkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Huszonnégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Huszonhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Huszonnyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Harminc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Harminckettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Harmincnégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Harminchat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Harmincnyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Negyven</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Negyvenkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Negyvennégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Negyvenhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Negyvennyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Ötven</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Ötvenkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Ötvennégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Ötvenhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Ötvennyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Hatvan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Hatvankettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Hatvannégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Hatvanhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Hatvannyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Hetven</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Hetvenkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Hetvennégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Hetvenhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Hetvennyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Nyolcvan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Nyolcvankettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Nyolcvannégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Nyolcvanhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Nyolcvannyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Kilencven</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Kilencvenkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Kilencvennégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Kilencvenhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Kilencvennyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Száz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Százkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Száznégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Százhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Száznyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Száztíz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Száztizenkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Száztizennégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Száztizenhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Száztizennyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Százhúsz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Százhuszonkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Százhuszonnégy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Százhuszonhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Százhuszonnyolc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Százkilencvenkettő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Kétszázötvenhat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR kapacitás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU szállító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU típus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL kliens API-k</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL verzió</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Ismeretlen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Egyedi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Hardver osztályok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>Processzor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Processzor nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Alaplap</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Alaplap nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Memória nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Tárhely</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Lemez nem található</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Az illesztőprogram helyreállítása sikertelen!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>Kérjük próbálja újra, vagy küldjön visszajelzést felénk</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Az illesztőprogram biztonsági mentése sikertelen!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Kijelző feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Grafikus processzor nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Monitor nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Hálózati feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Hálózati feldolgozó nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Hang feldolgozó</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Hang eszköz nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Bluetooth eszköz nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Egyéb PCI-eszközök</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Egyéb PCI-eszközök nem találhatóak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Akkumulátor nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Billentyűzet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Billentyűzet nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Egér</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Egér nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Nyomtató</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Nyomtató nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Kamera nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>CD-ROM nem található</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Egyéb eszközök</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Egyéb eszközök nem találhatóak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Tömb kezelő</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Űrlap tényező</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Beállít</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Töltés kereső</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Típus részletek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Rész szám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Besorolás</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Memória technológia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Memória üzemmód képesség</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmware verzió</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Modul gyártói azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Termék modul azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Memória alrendszer vezérlő gyártói azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Memória alrendszer vezérlő termék azonosító</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Nem illékony méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Illékony méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Gyorsítótár méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logikai méret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>incs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
@@ -3692,313 +3453,294 @@
         <translation>oldalak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>busz adatok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>logikai szektorméret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>szektorméret</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometria (Logikai)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Eszközkezelő</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Az Eszközkezelő egy praktikus eszköz a hardverinformációk megtekintéséhez és az eszközök kezeléséhez.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Új illesztőprogramok érhetőek el! Telepítse, vagy frissítse őket most.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Nézet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Tartalmazza az almappákat is</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Keressen illesztőprogramokat ezen az útvonalon</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 illesztőprogram frissítése érhető el</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Ellenőrzési idő: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>A %1 illesztőprogramjának letöltése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>letöltési sebesség: %1 Letöltve %2 / %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>A %1 illesztőprogramjának telepítése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 illesztőprogram telepítve, %2 illesztőprogram meghiúsult</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 illesztőprogram telepítve</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Az illesztőprogramok telepítése sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Hálózati hiba. Újra csatlakozás...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Letöltési sebesség: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Az illesztőprogramok naprakészek</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Az összes illesztőprogram biztonsági mentése megtörtént</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Összesen %1 illesztőprogram, amelyből %2 biztonsági mentése megtörtént</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Önnek %1 illesztőprogramja van, amelyről biztonsági mentést készíthet, javasoljuk, hogy azonnal tegye meg </translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Önnek %1 illesztőprogramja van, amelyről biztonsági mentést készíthet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>A %1 illesztőprogram biztonsági mentése, összesen %2 illesztőprogram​</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Biztonsági mentés: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 illesztőprogrambiztonsági mentése megtörtént, %2 illesztőprogram mentése meghiúsult</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Az illesztőprogramok biztonsági mentése sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 illesztőprogram biztonsági mentése megtörtént</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Önnek %1 illesztőprogramja van, amely helyreállítható</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Kérjük válassza ki a helyreállítandó illesztőprogramot</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Illesztőprogram helyreállítása...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Helyreállítás: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>Újraindítás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Kérjük %1, hogy a telepített illesztőprogramok érvénybe lépjenek</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Biztonsági mentés elérési útvonalának megtekintése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Összes biztonsági mentése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>Visszajelzés küldése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Kérjük próbálja újra, vagy küldje el nekünk %1-et</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Összes telepítése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Újra ellenőrzés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Hardvereszköz illesztőprogramok ellenőrzése, kérjük várjon...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Ellenőrzés %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Az ellenőrzés sikertelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>A hálózat nem érhető el</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Kérjük ellenőrizze a hálózati kapcsolatot</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Kérjük ellenőrizze újra, vagy küldje be nekünk a %1-et</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Az illesztőprogramok telepítése folyamatban, kilépés esetén a folyamat megszakad.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Valóban ki szeretne lépni? </translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Kilépés</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Az illesztőprogramok biztonsági mentése folyamatban, kilépés esetén a folyamat megszakad.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Az illesztőprogramok helyreállítása folyamatban, kilépés esetén a folyamat megszakad.</translation>
     </message>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Képalkotó eszköz</translation>
     </message>
@@ -4114,22 +3855,22 @@
         <translation>Nem sikerült beolvasni az illesztőprogram fájljait</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Biztonsági mentés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Helyreállítás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Telepítés</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Illesztőprogramok frissítése</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Illesztőprogramok eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Engedélyezze számára, hogy felébressze a számítógépet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Engedélyezés</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportálás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Letiltás</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Nem elérhető</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Kérjük válasszon egy helyi mappát</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Betöltés...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_hy.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_hy.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hy">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Գանձարան</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Այո</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Ավելի շատ</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Ինտերնետի հաղորդակցություն</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Վերահաստատում</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Ավելի շատ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Փակել</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Նիւթի անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Վարձակալ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Չիպ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Արտահայտություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS ճանապարհ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Վերանորոշում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Կենտրոնական ռեժիմի դրայվեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Հիշողության հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Վարձակալ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Վարձակալ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Չիպսեթ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Հանրային</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Ամենամեծ հզորություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Բացահայտողի տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Բացահայտող</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Կարողություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Ընթացիկ անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Հասանելի չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Հանրային</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Կարողություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Բացահայտող</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Ամենամեծ հզորություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Հասանելի չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Անուն</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Հանրային</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Կորե համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Թրեդեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>ԲոգոՄԻՊՍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Արխիտեկտուրա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>CPU ընտանիք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Ծրագիր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Կորիներ (ընտանիք)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Վիրտուալիզացիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Ֆլագներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Էքստենսիոներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 կորիներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 կորիներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i կորիներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d կորիներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Քայլահարում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Ամենամեծ արագություն</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Հանրապետ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Գրաֆիկական հիշողություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Ֆիզիկական ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Հիշողության հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO փոխանցում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Ամենամեծ լուծություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Ամենափոքր լուծություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Ընթացիկ լուծություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Բացարձակում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Ամբողջականում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>ԴՊ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>էԴՊ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>ՀԴՄԻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>ՎԳԱ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>ԴՎԻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Տվալ արտածանք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Դիսպլե արտածանք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Կարողություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>ԻՐԿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Վենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Վերսունք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Ամենամեծ էներգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Ռեժիմավոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Սերիալ համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Չափահասակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Շինարար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Ինտերֆեյս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Ամենամեծ հաստատուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Օպերատոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>հնարավորություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>անհասանելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>անակտիվացնել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>ընդհանուր տեսակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>կորպուս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>կորպուսի քանակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>մայրային տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>հիշողություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>ցուցադրման ադապտեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>ձայնի ադապտեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>պահեստարան</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>այլ ՊԻՍ սարքեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>ակումբ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>բլուետոութ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>ցանցի ադապտեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>մուսոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>կոմպյուտերի կողմնային կոճակներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>կոմպյուտերի էկրան</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>ԿԴ-ՌՕՄ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>տպագիր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>կամերա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>այլ սարքեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>սարք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ՕՍ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>տուրքավոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>տեսակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ընդհանուր լայնություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>գտնում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>համարը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>կարգավորված լարում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>առավելագույն լարում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>նվազագույն լարում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>կարգավորված արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>տվյալների լայնություն</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Վարիանտը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Տիպը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Ցուցադրման մուտք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Ինտերֆեյսի տիպը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Աջակցություն լուծումների</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Ընթացիկ լուծումների</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Ցուցադրման հարաբերությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Հիմնական ցուցադրողը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Չափը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>համարը</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Վարիանտը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Տիպը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Բուս տվյալները</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Կարողությունները</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Շարունակությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Շարունակության տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Առավելագույն արագությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Բանակցության արագությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Փոխանցումը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Մուլտիկաստ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Լինք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Կամայականություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>ԻՊ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Ֆիրմվար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Դուպլեքս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Բրոդկաստ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Ավտոմատ կոնվենցիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Հիշողության հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ԻՐՔ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>ՄԱԿ հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Լոգիկական անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Անջատել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Վենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Վերսանդ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Մուտք/Ելք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Հիշողություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ԻՐՔ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Կամայականություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Դրայվեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Կարողություններ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Վենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Վերսանդ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Կարողություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Բացահայտող</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Առավելագույն կուտակումը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Սերիայի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Անվանումը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Մոդելը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Վենդորը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Սերիայի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Տիպը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Կարգավիճակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Տարողությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Լիցքային տարածությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Նիշանը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Նախագծված տարողությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Նախագծված լիցքային տարածությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>ՍԲԴՍ տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>ՍԲԴՍ սերիայի համարը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>ՍԲԴՍ արտադրության ամսաթիվը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>ՍԲԴՍ քիմիական բարդությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Ջերմաստիճանը</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Անվանումը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Մոդելը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Վենդորը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Սերիայի համարը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Ընդհանուր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>ՈւՐԻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Կարգավիճակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Տիպ ինտերֆեյս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Կառուցվածքի մատակարար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Մեդիա տիպ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Կարողություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Ֆիրմվերս տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Նկարագրություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Սերիալ համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Ինտերֆեյս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Շարժման արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Ընտրեք թարմացման համար դրայվեր</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Այս պանելում դրայվերներ չեն գտնվում</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Բացահայտում է ձայնային սարքի տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Բացահայտում է BIOS տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Բացահայտում է CD-ROM տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Բացահայտում է օպերացիոն համակարգի տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Բացահայտում է CPU տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Բացահայտում է այլ սարքերի տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Բացահայտում է էներգիայի տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Բացահայտում է տպագիրային սարքի տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Բացահայտում է մակարդակի տեղեկությունը...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Բացահայտում է ցանցի ադապտերի տեղեկությունը...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Անհասանելի</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Տեղեկատվություն սարքի մասին</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Ցուցադրել կրճատականները</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Փակել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Օգնություն</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Կապել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Համակարգ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Արտահան</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Ընթացիկ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Սարքերի համակարգիչը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Ուղեկցող սարքեր</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Բացակայություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Հետադարձ կապ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Ընդհանուր տեսանկյուն</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Դիսփլեի ադապտերը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Ծառայության ադապտերը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Բատարեյա</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Ավելին</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Բացակայող սարքի համար պլատֆորմի տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Արտահանվող բացակայողներ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Արտահանված բացակայողներ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Թարմացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Չեղարկել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Հաջորդը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Ուշադրություն</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Սարքը կարող է դառնալ անհասանելի բացակայողների հեռացման հետևանքով</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Հեռացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Հեռացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Թարմացումը հաջողությամբ ավարտվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Հեռացումը հաջողությամբ ավարտվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Թարմացումը հնարավոր չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Ընթացիկ հանումը հնարավոր չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ՕԿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Առաջ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Ընտրված պայումանը գոյություն չունի, խնդրում ենք վերստացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Թարմացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Նախագահություն</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Չափահաս փաթեթ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Անհամապատասխան փաթեթի կառուցվածք</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Ընտրված անձնականը գոյություն չունի, խնդրում ենք վերստացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Այն դրայվեր չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Ընթացիկ հանումը հնարավոր չէ - առանց դիգիտալ ստուգում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Անհայտ սխալ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Դրայվերի մոդուլը գտնված չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Անվավեր մոդուլի ձևաչափ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Դրայվերի մոդուլը ունի կախվածություններ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Դրայվերի նախագիծ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Դրայվերի պատկերացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Դրայվերի վերականգնում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Վերաբերմունք</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Դրայվերներ չունեք վերականգնելու համար, խնդրում ենք առաջին պատկերացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Գնալ պատկերացված դրայվերի կողմը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Պատկերացված տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Վերականգնվող դրայվերներ</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Ընթացիկ հանում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Արտահանում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Ընդհանուր տեսարան</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Դրայվերի նախագիծ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Դրայվերի պատկերացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Դրայվերի վերականգնում</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Չի հնարավոր ստեղծել սարքը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Չի հնարավոր անակտիվացնել սարքը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Չի հնարավոր անակտիվացնել սարքը: հնարավոր չէ ստանալ սարքի SN</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Ապարանքների թարմացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Ընթարսանքների հանում</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Թարմացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Արտահանել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Կապել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Ընդամենը</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Թարմացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Արտահանել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Կապել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Ակտիվացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Ապարանքների թարմացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Ընթարսանքների հանում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>թույլ տրվի համայնքին արագացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Անակտիվացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Չի հնարավոր անակտիվացնել սարքը: հնարավոր չէ ստանալ սարքի SN</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Չի հնարավոր անակտիվացնել սարքը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Չի հնարավոր ստեղծել սարքը</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Ապարանքների թարմացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Ընթարսանքների հանում</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Սուբվենդոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Սուբդեվիս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Ապարանք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Ապարանքի վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Ապարանքի ակտիվացման հրահանգ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Կարգավորման վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>հանգստացում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Ֆիզիկական</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Սիսֆս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Հանդիսացողներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>ՊՐՈՊ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ԵՎ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>ԿԵՅ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Բուս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ԲԻՕՍ տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Հիմնական սանդուղքի տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Համակարգի տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Կառուցվածքի տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Ֆիզիկական հիշողության առանցք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Շրջանակային ամսաթիվ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Աշխատանքային չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ՌՈՄ չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Հատկություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ԲԻՕՍ վերանայում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Ֆիրմվար վերանայում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Ապրանքի անվանում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Սերիային համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Ակտիվ սագա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Ֆունկցիաներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Կառուցվածքում տեղադրում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Կառուցվածքի ձեռնարկում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Տիպ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Ընդգրած օբյեկտների ձեռնարկումներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Շարունակող տիպ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>ՍԿՈՒ համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>ընտանիք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>փակել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>սկիզբ վերադրման վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>էլեկտրական մատակարարության վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>ջերմային վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>անվտանգության վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM տեղեկություններ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>բարձրություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>էլեկտրական հաղորդալարերի քանակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>պարունակող տարրեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>տեղաբաշխում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>սխալների վերացման տեսակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>առավելագույն տարածությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>սխալների տեղեկության ձևաչափը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>սարքերի քանակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>արտադրության ամսաթիվը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>կառավարման սարքի անվանումը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>լեզվի արտադրությունից հետո նկարագրության ձևաչափը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>տեղակայելի լեզուներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>այս պահին տեղակայված լեզուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>տվյալների տեսակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>հղումի քանդակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>հղումի ռեժիմը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>կատեգորիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>ծառայության կատեգորիաներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Դասընթացը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>ՀԻ տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>ԼՄՊ տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Սուբվերսիոնը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Ապարատը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Սերիալ ԻԴ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>ապարատը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>ապարատի նկարագրությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Ակտիվացված</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Որոշակի արտադրությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Կապված է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Մոդալիաս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Որոշակի արտադրությունը կատարվում է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Բացահայտող մոդուլները</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Ապարատի ֆայլը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Ապարատի ֆայլերը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Ապարատի թիվը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Ծրագիրը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>կարգավիճակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>տոպոլոգիական անվանումը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ANSI տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU իմպլեմենտատորը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU արխիտեկտուրան</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU մասը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU վերաբերությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>մեկը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>երկուսը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>չորսը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>վեցը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Ութ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Ինը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Տաս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Երեսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Չորսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Վասնեսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Ութսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Երկուսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Երկուսուն երկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Երկուսուն չորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Երկուսուն վեց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Երկուսուն ութ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Երեսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Երեսուն երկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Երեսուն չորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Երեսուն վեց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Երեսուն ութ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Չորսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Չորսուն երկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Չորսուն չորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Չորսուն վեց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Չորսուն ութ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Վասնեսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Վասնեսուն երկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Վասնեսուն չորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Վասնեսուն վեց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Վասնեսուն ութ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Վասնեսուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Վասնեսուն երկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Վասնեսուն չորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Յոթանասունվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Յոթանասունություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Յոթանասուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Յոթանասուներկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Յոթանասունչորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Յոթանասունվերս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Յոթանասունություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Ութանասուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Ութանասուներկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Ութանասունչորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Ութանասունվերս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Ութանասունություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Իննանասուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Իննանասուներկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Իննանասունչորս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Իննանասունվերս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Իննանասունություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Մեկ հարյուր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Մեկ հարյուր և երկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>сто четыре</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>сто шесть</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>сто восемь</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>сто десять</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>сто двенадцать</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>сто четырнадцать</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>сто шестнадцать</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>сто восемнадцать</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>сто двадцать</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>сто двадцать два</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>сто двадцать четыре</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>հարյուր ու քսանվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>հարյուր ու քսանութ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>հարյուր ու իննսուներկու</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>երկու հարյուր ու հինգսունվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>ԳԴԴ հիշատակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU մասնակից</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU տեսակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL հաճախորդ API-ները</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Անհայտ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Ունիկ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>ՄՍԿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Ծրագրային դասը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>Կոմպյուտերային ստուդիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Կոմպյուտերային ստուդիա չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Մայրային տարբերակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Մայրային տարբերակ չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Հիշողությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Հիշողություն չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Պահեստարանը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Դիսկ չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Բացահայտումը ստուգելու փորձը հնարավոր չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Խնդրում ենք փորձեք նորից կամ տրամադրեք մեզ մեկնաբանություն</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Բացահայտումը պահպանելու փորձը հնարավոր չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Ցուցադրման հարթակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Հետադարձ հարթակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Հետադարձ հարթակ չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Ադապտեր ցանցի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Ցանցի ադապտեր չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Ադապտեր ձայնի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Ձայնային սարք չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Բլուտուայտ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Բլուտուայտ սարք չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Այլ PCI սարքեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Այլ PCI սարքեր չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Ծախս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Բատարեյ չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Կոմպյուտերային կոճակներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Կոմպյուտերային կոճակներ չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Մուսի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Մուսի չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Տպագրիչ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Տպագրիչ չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Կամերա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Կամերա չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Այլ սարքեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Այլ սարքեր չի գտնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Արանգի հանդիպակաց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Ֆորմատ ամբողջական</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Կառուցվածք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Բանկի տեղանշան</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Տիպի մանրամասներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Բաժինի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Հարադրություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Հիշողության տեխնոլոգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>հնարավորություն հիշողության աշխատանքային ռեժիմի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Ֆիրմվերի տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Մոդուլի մանուֆակտուրայի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Մոդուլի ապրանքի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Հիշողության ենթակառուցվածքի կառավարիչի մանուֆակտուրայի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ՀիշոՂության ենթակառուցվածքի կառավարիչի ապրանքի համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Անփոփոխական չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Փոփոխական չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Կաշ չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Лոգիկական չափ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>մատանի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Ամսաթիվ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>IOport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>ցանց</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>ակումբային սարք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>նատիվ ճանապարհ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>էլեկտրական աղբյուր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>թարմացված</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>ունի պատմություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>ունի վերլուծություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>վերալիցքավորելի</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>վիճակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>անվտանգության մակարդակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>էներգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>էներգիա դատարկ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>էներգիա լիքը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>լիքը նախատեսված էներգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>էներգիայի արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>լարում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>տոգական</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>տեխնոլոգիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>նշանակալի անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>օնլայն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>դեմոնի տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>բատերիայով</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>կուրսուն փակված է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>կուրսուն առկա է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>կարևոր գործողություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>անգամեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>աշխատանքի անվավերացում հետո</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>աշխատանքի կարգավորում մինչև</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>աշխատանքի առաջադրանք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>նշանակալի փոխարինման ժամանակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>թիվը վերադարձնելու համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ուղղությունը պահանջվում է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>տպման գույնային ռեժիմը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>տպագիրը աշխատանքներ ընդունում է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>տպագիրը բաժանված է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>տպագի՛րը ժամանակավոր է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>տպագիրի կազմը և մոդելը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>տպագիրի վիճակի փոփոխման ժամանակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>տպագիրի վիճակի պատճառները</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>տպագիրի տեսակը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>տպագիրի հարթակը աջակցվում է</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>կողմերը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>բուս տեղեկատվությունը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>տունական սեկտորի չափը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>սեկտորի չափը</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>հանրապետական համար</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>երկրաչափություն (տրանսֆորմացիոն)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>սարքերի կառավարիչ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Սարքերի կառավարիչը հարմար գործիք է սարքերի տեхնիկական տեղեկությունները տեսնելու և կառավ արավարկելու համար</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Նոր կառավարիչներ առաջարկված են! Ընդամենը հայտնի կառավարիչները համարի համար կատարեք թարմացումը կամ վերահսկումը այժմ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Դիտել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Ամբողջ ներապատկառները ներառել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Այս ճանապարհով կառավարիչները փնտրել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 կառավարիչների թարմացումներ առաջարկված են'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Ժամանակակից ստուգված է: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Կառավարիչները բերում ենք %1-ի համար...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Բերման արագությունը: %1 Բերված է %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Կառավարիչները համարի համար հայտնի են...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 կառավարիչները հայտնի են, %2 կառավարիչները հանդեպ են'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 կառավարիչները հայտնի են'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Կառավարիչները հայտնի չեն ապահովվել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Ցանցի սխալ է տեղի ունեցել, կրկին կապ հաստատվում է...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Բերման արագությունը: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Ձեր կառավարիչները ամենավերջին տարբերակն են</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>բոլոր դрайվերն արդեն պատրաստակամ են</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>ընդամենը %1 դրայվերներ, որից %2 արդեն պատրաստակամ են</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Դուք ունեք %1 դրայվերներ, որոնք կարող են պատրաստակամ վերցնել, այն անելը առաջարկվում է անմիջապես</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Դուք ունեք %1 դրայվերներ, որոնք կարող են պատրաստակամ վերցնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Պատրաստակամ վերցնելու համար %1 դրայվերը, ընդամենը %2 դրայվերներ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>Պատրաստակամ վերցնելու մեջ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>%1 դրայվերներ պատրաստակամ վերցվել են, %2 դրայվերներ չեն վերցվել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Դրայվերները հնարավոր չէ պատրաստակամ վերցնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 դրայվերներ պատրաստակամ վերցվել են</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Դուք ունեք %1 դրայվերներ, որոնք կարող են վերականգնվել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Խնդրում ենք վերականգնելու համար ընտրեք դրայվերը</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Դրայվերը վերականգնվում է...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Վերականգնելու մեջ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>կրկին սկսել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Խնդրում ենք մի %1 անել, որպեսզի ստացվեն կացարկված դրայվերները</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Դիտել պատրաստակամ վերցված համար</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Բոլորը պատրաստակամ վերցնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>հաղորդագրություն ներս առնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Խնդրում ենք փորձեք նորից կամ %1 մեզ առնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Բոլորը կացարկել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Նորից սկանավերցնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Չեղարկել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Սկանավերցնելու մեջ են համարիչները, խնդրում ենք սպասեք...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Սկանավերցնելու մեջ է %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Սկանավերցումը հնարավոր չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Շրջապատային ցանցը հասանելի չէ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Խնդրում ենք ստուգեք ձեր ցանցի կապը</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Խնդրում ենք նորից սկանավերցնել կամ %1 մեզ առնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Դուք դրայվեր կացարկում եք, որը կարող է անհանգստացնել, եթե դուք դուրս գալիք եք</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Դուք իմաստուն եք դուրս գ来լու համար?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Դուրս գալ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Չեղարկել</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Դու դрайվերներ աներ, որը կարող է ավարտվել, եթե դու դուրս գայ։</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Դու դրայվերներ վերականգնում ես, որը կարող է ավարտվել, եթե դու դուրս գայ։</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Բլուետուչ ադապտեր</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Նկարագրող սարք</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Ցուցադրման ադապտեր</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Ձայնային կարտ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Շրջանակային ադապտեր</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Անսարք ցանցային ադապտեր</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Ինստալյացիան հաջողությամբ ավարտվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Ինստալյացիան հանգիստ ավարտվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Բեռնում է</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Ինստալացվում է</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Չինստալացված է</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Փոխարինված է</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Սպասում է</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Չէ պատրաստված</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Պատրաստում է</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Պատրաստումը հանգիստ ավարտվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Պատրաստումը հաջողությամբ ավարտվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Վերականգնում է</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Անհայտ սխալ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Ցանցային սխալ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Չեղարկվեց</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Չի հաջողվել ստանալ դրայվերների ֆայլերը</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Թարմացում</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Պատրաստում</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Վերականգնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Ինստալացնել</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>հանգստացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>թարմացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>արտահանել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>ձևափոխել մոդուլները</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>հանել մոդուլները</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>թույլատրել համակարգչի ականատեսակը</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>կանգնած լինել</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>թարմացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>արտահանել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>անցնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>հանգստացնել</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>հասանելի չէ</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>ընտրեք տեղական պարունակություն խնդրում ենք</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Բեռնում է...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_id.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_id.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Umpan balik</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Lebih banyak</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Notifikasi jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Reinstalasi</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Lebih banyak</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Kerut</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Tidak tersedia</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Nama perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Pengembang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Driver Mode Kernel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Alamat memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Tidak tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Pengembang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Pengembang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Set chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Pabrikan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Daya Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Versi Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Nama Logis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>Alamat MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Pabrikan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Daya Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Pabrikan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ID CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>ID Core</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Thread</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arsitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Keluarga CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Prosesor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Core</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualisasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Flags</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Ekstensi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>Cache L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>Cache L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>Cache L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>Cache L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Stepping</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Kecepatan Maksimum</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Memori Grafis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ID Fisik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Alamat Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>Port IO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Resolusi Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Resolusi Minimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Resolusi Saat Ini</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Deskripsi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Output Digital</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Output Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Pengembang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Daya Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Pengembang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Antarmuka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Arus Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Overview</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Jumlah CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Adapter Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Adapter Suara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Penyimpanan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Perangkat PCI Lainnya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Baterai</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Adapter Jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Perangkat Lainnya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Ukuran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Jenis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Lebar Total</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Penunjuk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Voltage Terkonfigurasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Voltage Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Voltage Minimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Kecepatan Terkonfigurasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Lebar Data</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Pengembang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Jenis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Input Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Jenis Antarmuka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Resolusi yang Didukung</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Resolusi Saat Ini</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Rasio Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Monitor Utama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Ukuran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Pengembang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Jenis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Versi Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Laju Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Laju Negosiasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latensi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto Negotiasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Alamat Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>Alamat MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Nama Logis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Input/Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latensi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Informasi Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Daya Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Jenis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kapasitas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Voltase</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Slot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Kapasitas Desain</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Voltase Desain</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>Versi SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>Nomor Seri SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>Tanggal Pembuatan SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>Kimia SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Suhu</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Nama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Berbagi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Tipe Antarmuka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Pemasok</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Tipe Media</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Ukuran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Kemampuan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Versi Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Kecepatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Deskripsi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Antarmuka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Laju Putar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Pilih pengemudi untuk pembaruan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Tidak ada pengemudi yang ditemukan dalam folder ini</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Memuat Informasi Perangkat Audio...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Memuat Informasi BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Memuat Informasi CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Memuat Informasi Sistem Operasi...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Memuat Informasi CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Memuat Informasi Perangkat Lain...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Memuat Informasi Daya...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Memuat Informasi Printer...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Memuat Informasi Mouse...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Memuat Informasi Adapter Jaringan...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Informasi Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Tampilkan Pintasan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Tutup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Bantuan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Salin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Perbarui</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Manajer Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Perangkat Keras</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Pandangan Umum</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Adapter Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Adapter Jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Baterai</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Lebih Banyak</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Versi Platform Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Driver yang Dapat Disimpan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Driver yang Telah Disimpan</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Mengupdate</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Batal</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Selanjutnya</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Peringatan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Perangkat akan tidak tersedia setelah penghapusan driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Hapus</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Menghapus</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Pembaruan berhasil</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Penghapusan berhasil</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Pembaruan gagal</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Penghapusan gagal</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Selanjutnya</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Folder yang dipilih tidak ada, silakan pilih ulang</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Perbarui</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Sebelumnya</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Paket rusak</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Arsitektur paket tidak sesuai</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>File yang dipilih tidak ada, silakan pilih ulang</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Ini bukan driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Tidak dapat menginstal - tidak ada tanda tangan digital</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Kesalahan tidak dikenal</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Modul driver tidak ditemukan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Format modul tidak valid</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Modul driver memiliki dependensi</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Instal Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Simpan Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Pulihkan Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Umpan Balik</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Anda tidak memiliki driver apa pun untuk dipulihkan, silakan simpan terlebih dahulu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Pergi ke Simpan Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Versi Simpan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Driver yang Dapat Dipulihkan</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Perbarui</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Pandangan Umum</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Instal Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Simpan Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Pulihkan Driver</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Gagal mengaktifkan perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Gagal menonaktifkan perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Gagal menonaktifkannya: tidak dapat mendapatkan nomor seri perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Perbarui Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Uninstall Driver</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Segarkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Salin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Ringkasan</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Segarkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Salin</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Aktifkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Perbarui driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Uninstall driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Izinkan untuk membangun kembali komputer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Gagal menonaktifkannya: tidak dapat mendapatkan nomor seri perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Gagal menonaktifkan perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Gagal mengaktifkan perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Perbarui Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Uninstall Driver</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>SubVendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>SubDevice</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Status Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Perintah Aktivasi Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Status Konfigurasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Phys</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Pengelola</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Informasi BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Informasi Papan Dasar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Informasi Sistem</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Informasi Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Array Memori Fisik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Tanggal Rilis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Alamat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Ukuran Runtime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Ukuran ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Ciri Khas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Revisi BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Revisi Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Nama Produk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Nomor Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Tag Aset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Fitur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Lokasi Di Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Handle Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Jenis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Handle Objek Terkandung</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Jenis Wake-up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Nomor SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Keluarga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Kunci</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Kondisi Boot-up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Kondisi Pasokan Daya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Kondisi Termal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Status Keamanan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Informasi OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Tinggi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Jumlah Kabel Daya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Elemen yang Dikandung</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Lokasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Jenis Koreksi Kesalahan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Kapasitas Maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Tangani Informasi Kesalahan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Jumlah Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>Ukuran BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Tanggal Rilis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Nama Papan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>Versi SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Format Deskripsi Bahasa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Bahasa yang Dapat Diinstal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Bahasa yang Sedang Terinstal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>Alamat BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Jenis Paket</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Kebijakan Tautan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Mode Tautan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Kelas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Kelas Layanan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Kelas Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Versi HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Versi LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subversi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>deskripsi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Dinyalakan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Dapat Ditemukan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Dapat Dipedu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Mendeteksi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Modul Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>File Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>File Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Nomor Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Aplikasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>nama logis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>versi ansi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Pengembang CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Arsitektur CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Variasi CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Bagian CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Revisi CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Satu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Sembilan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Sepuluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Duabelas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Empatbelas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Enambelas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Delapanbelas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Dua puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Dua puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Dua puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Dua puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Dua puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Tiga puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Tiga puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Tiga puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Tiga puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Tiga puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Empat puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Empat puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Empat puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Emat puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Empat puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Lima puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Lima puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Lima puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Lima puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Lima puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Enam puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Enam puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Enam puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Enam puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Enam puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Tujuh puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Tujuh puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Tujuh puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Tujuh puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Tujuh puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Delapan puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Delapan puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Delapan puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Delapan puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Delapan puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Sembilan puluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Sembilan puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Sembilan puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Sembilan puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Sembilan puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Seratus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Seratus dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Seratus empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Seratus enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Seratus delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Seratus sepuluh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Seratus dua belas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Seratus empat belas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Seratus enam belas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Seratus delapan belas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Seratus dua puluhan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Seratus dua puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Seratus dua puluh empat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Seratus dua puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Seratus dua puluh delapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Seratus sembilan puluh dua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Dua ratus lima puluh enam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapasitas GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Vendor GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Tipe GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Versi EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API EGL klien</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Versi GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Versi GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Tidak diketahui</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Kelas Perangkat Keras</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Tidak menemukan CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Tidak menemukan motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Tidak menemukan memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Penyimpanan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Tidak menemukan disk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Pemulihan driver gagal!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Silakan coba lagi atau beri kami umpan balik</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Pengarsipan driver gagal!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Adapter Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Tidak menemukan GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Tidak menemukan monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Adapter Jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Tidak ditemukan adapter jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Adapter Suara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Tidak ditemukan perangkat audio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Tidak ditemukan perangkat Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Perangkat PCI Lainnya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Tidak ditemukan perangkat PCI lainnya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Daya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Tidak ditemukan baterai</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Tidak ditemukan keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Tidak ditemukan mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Tidak ditemukan printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Tidak ditemukan kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Tidak ditemukan CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Perangkat Lainnya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Tidak ditemukan perangkat lainnya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Form Factor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Set</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bank Locator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Type Detail</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Nomor Part</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Teknologi Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Kemampuan Mode Operasi Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Versi Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ID Pabrikan Modul</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID Produk Modul</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ID Pabrikan Pengendali Subsistem Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ID Produk Pengendali Subsistem Memori</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Ukuran Tidak Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Ukuran Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Ukuran Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Ukuran Logis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>inci</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Tanggal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>baterai</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>sumber daya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>diperbarui</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>memiliki riwayat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>memiliki statistik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>dapat diisi ulang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>tingkat peringatan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energi kosong</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energi penuh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>desain energi penuh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>tingkat energi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>tegangan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>persentase</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>nama ikon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>versi daemon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>di baterai</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>lid tertutup</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>lid tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>tindakan kritis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>salinan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>batalkan pekerjaan setelah</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>tahan pekerjaan sampai</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>prioritas pekerjaan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>waktu perubahan marker</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>jumlah per halaman</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientasi yang diminta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>mode cetak warna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer menerima pekerjaan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer berbagi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer sementara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>merk dan model printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>waktu perubahan status printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>alasan status printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>tipe printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>uri printer yang didukung</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>sisi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>informasi bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ukuran sektor logis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>ukuran sektor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>guid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometri (Logis)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Manajer Perangkat</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Manajer Perangkat adalah alat yang berguna untuk melihat informasi perangkat keras dan mengelola perangkat.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Driver baru tersedia! Pasang atau perbarui sekarang.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Lihat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Termasuk subfolder</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Cari driver di jalur ini</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 pembaruan driver tersedia'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Waktu diperiksa: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Mengunduh driver untuk %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Kecepatan unduh: %1 Terunduh %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Menginstal driver untuk %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 driver terinstal, %2 driver gagal'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 driver terinstal'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Gagal menginstal driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Kesalahan jaringan. Menghubungkan kembali...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Kecepatan unduh: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Driver Anda sudah diperbarui</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Semua driver telah disimpan cadangan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Total %1 driver, dari mana %2 telah disimpan cadangan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Anda memiliki %1 driver yang dapat disimpan cadangan, disarankan untuk melakukan hal tersebut segera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Anda memiliki %1 driver yang dapat disimpan cadangan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Menyimpan cadangan driver %1, total %2 driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Menyimpan cadangan: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 driver disimpan cadangan, %2 driver gagal'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Gagal menyimpan cadangan driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 driver disimpan cadangan'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Anda memiliki %1 driver yang dapat dipulihkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Silakan pilih driver untuk dipulihkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver sedang direstor...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Restoring: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>restart</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Silakan %1 agar penginstalan driver berjalan lancar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Lihat jalur cadangan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Backup Semua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>kirimkan umpan balik</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Silakan coba lagi atau %1 kepada kami</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Install Semua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Scan Lagi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Batal</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Mengikuti driver perangkat keras, silakan tunggu...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Scanning %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Scan gagal</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Jaringan tidak tersedia</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Silakan periksa koneksi jaringan Anda</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Silakan scan lagi atau %1 kepada kami</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Anda sedang menginstal driver, yang akan terganggu jika Anda keluar.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Apakah Anda yakin ingin keluar?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Keluar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Batal</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Anda sedang mencadangkan driver, yang akan terganggu jika Anda keluar.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Anda sedang merestor driver, yang akan terganggu jika Anda keluar.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Adapter Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Perangkat imaging</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Adapter tampilan</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Kartu suara</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Adapter jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Adapter jaringan nirkabel</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Instalasi berhasil</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Instalasi gagal</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Unduh</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Menginstal</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Belum terinstal</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Ketinggalan zaman</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Menunggu</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Belum dibackup</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Membackup</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Backup gagal</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Backup berhasil</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Mengembalikan</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Kesalahan tidak diketahui</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Kesalahan jaringan</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Dibatalkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Gagal mendapatkan file driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Perbarui</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Mengembalikan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Instal</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Segarkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Perbarui driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Menginstal ulang driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Izinkan untuk membangun komputer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Aktifkan</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Segarkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Ekspor</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Salin</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Nonaktifkan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Tidak Tersedia</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Silakan pilih folder lokal</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Memuat...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_it.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_it.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Di più</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collassa</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Di più</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Di più</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Collassa</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Di più</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Collassa</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nome dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID Fisico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Indirizzo di memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID Fisico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Potenza massima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versione driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Info BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nome logico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Indirizzo MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Info BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Potenza massima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID Fisico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID Core</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Thread</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Architettura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Famiglia CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation> Thread</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation> Core(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualizzazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Flag</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Estensioni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Cache L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Cache L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Cache L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Cache L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Velocità massima</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Memoria grafica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID Fisico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Indirizzo di memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Porta IO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Info BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Risoluzione massima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Risoluzione minima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Risoluzione corrente</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Uscita video</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Info BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID Fisico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Potenza massima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modello</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interfaccia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Info BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID Fisico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Corrente massima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Panoramica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Quantità CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Scheda Madre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Adattatore video</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Adattatore audio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Archiviazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Altri Dispositivi PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Batteria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Adattatore di Rete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Tastiera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Stampante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Altri dispositivi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Dimensioni totali</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Locazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Voltaggio configurato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Voltaggio Massimo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Voltaggio minimo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Velocita configurata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Dimensione dei dati</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Ingresso video</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Tipo interfaccia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Risoluzione supportata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Risoluzione corrente</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Frequenza di aggiornamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor primario</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Numero di serie</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Tipo Media</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID Fisico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versione firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interfaccia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Velocità rotazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Seleziona un driver per l&apos;aggiornamento</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Nessun driver rilevato nel percorso selezionato</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Caricamento info dispositivi audio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Caricamento info BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Caricamento info CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Caricamento info Sistema Operativo...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Caricamento info CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Caricamento info degli altri dispositivi...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Caricamento info alimentazione...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Caricamento info stampanti...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Caricamento info mouse...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Caricamento info adattatore di rete...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Info dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Visualizza scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Gestore dispositivi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Panoramica</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Adattatore video</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Adattatore di Rete</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Batteria</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Di più</translation>
     </message>
@@ -1702,178 +1704,178 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Versione corrente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Azione</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Aggiornamento in corso</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Avanti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Il dispositivo non sarà disponibile dopo la disinstallazione del driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Disinstalla</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Disinstallazione in corso</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Aggiornamento riuscito</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Disinstallazione riuscita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Aggiornamento fallito</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Disinstallazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Avanti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Il percorso selezionato non esiste, riprova</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Precedente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Pacchetto danneggiato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Architettura pacchetto non compatibile</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Il file selezionato non esiste, riprova</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Non è un driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Installazione interrotta - Nessuna firma digitale</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Errore sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Il modulo driver non è stato trovato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Formato modulo non valido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Il driver del modulo ha delle dipendenze</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Nome dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versioni disponibili</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Azione</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nuova versione</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Versione corrente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Driver mancanti (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Driver obsoleti (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Driver aggiornati (%1)</translation>
     </message>
@@ -1939,132 +1941,132 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
-        <source>Driver Install</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
-        <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
+        <source>Driver Install</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
-        <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
+        <source>Driver Backup</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
+        <source>Driver Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Versione corrente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Azione</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Panoramica</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Attivazione dispositivo fallita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Attivazione dispositivo fallita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Disabilitazione fallita: impossibile ottenere il SN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Aggiornamento driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Disinstallazione driver</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Panoramica</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Abilita</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Consenti il risveglio del computer</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Disabilitazione fallita: impossibile ottenere il SN del dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Attivazione dispositivo fallita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Attivazione dispositivo fallita</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Aggiornamento driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Disinstallazione driver</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Vendor secondario</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Dispositivo secondario</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Stato driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Comandi di attivazione driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Stato configurazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>latenza</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Handlers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Info BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Info base scheda</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Info Sistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Info Chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Matrice di memoria fisica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Data di rilascio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Indirizzi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Dimensione Runtime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Dimensione ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Caratteristiche</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revisione BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revisione Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Nome Prodotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Etichetta risorsa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Funzionalità</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Locazione nello Chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Chassis Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Contenuto dello Chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Tempo di attività</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Numero SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Famiglia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Blocco</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Stato Boot-up</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Stato dell&apos;alimentazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Stato termico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Stato sicurezza</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Info OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Altezza</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Numero di cavi di alimentazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elementi contenuti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Locazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Tipo di correzione errori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacità massima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Gestione delle informazioni sull&apos;errore</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Numero di dispositivi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>Dimensione ROM del BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Data di rilascio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nome scheda</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versione SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Formato linguaggi supportato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Linguaggi installabili</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Linguaggi attualmente installati</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Indirizzo BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Tipo pacchetto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Link policy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Link mode</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Classe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Classi Servizio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Classe Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versione HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versione LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Sottoversione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>ID Seriale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>prodotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>descrizione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Alimentato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Identificabile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Associabile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Mostra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Moduli driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>File dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>File dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Numero dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Applicazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>stato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>Nome logico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>versione ANSI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU implementer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Architettura CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variante CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Parte CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revisione CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Uno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Due</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Quattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Sei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Otto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dieci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dodici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Quattordici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Sedici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Diciotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Venti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Ventidue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Ventiquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Ventisei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Ventotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trentadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trentaquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Tentasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trentotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Quaranta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Quarantadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Quarantaquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Quarantasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Quarantotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cinquanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cinquantadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cinquataquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cinquantasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cinquantotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sessanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sessantadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sessantaquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sessantasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sessantotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Settanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Settandadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Settantaquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Settantasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Sessantotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Ottanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Ottantadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Ottantaquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Ottantasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Ottantotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Novanta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Novantadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Novantaquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Novantasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Novantotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Cento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Centodue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Centoquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Centosei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Centootto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Centodieci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Centododici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Centoquattordici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Centosedici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Centodiciotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Centoventi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Centoventidue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Centoventiquattro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Centoventisei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Centoventotto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Centonovantadue</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Duecentocinquantasei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacità GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Marca CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Tipo CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versione EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>API Client EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versione GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versione GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Classe hardware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Nessuna CPU rilevata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Scheda Madre</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Nessuna scheda madre rilevata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Nessuna memoria rilevata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Archiviazione</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Nessun disco rilevato</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Adattatore video</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Nessuna GPU rilevata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Nessuno schermo rilevato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Adattatore di Rete</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Nessun adattatore di rete rilevato</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Adattatore audio</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Nessun dispositivo audio rilevato</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Nessun adattatore Bluetooth rilevato</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Altri Dispositivi PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Nessun altro dispositivo rilevato</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Alimentazione</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Nessuna batteria rilevata</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Adattatore audio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Nessun dispositivo audio rilevato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Nessun adattatore Bluetooth rilevato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Altri Dispositivi PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Nessun altro dispositivo rilevato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Alimentazione</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Nessuna batteria rilevata</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Tastiera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Nessuna tastiera rilevata</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Mouse</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Nessun mouse rilevato</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Stampante</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Nessuna stampante rilevata</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Camera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Nessuna Camera rilevata</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>Nessun CD-ROM rilevato</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Nessun mouse rilevato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Stampante</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Nessuna stampante rilevata</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Nessuna Camera rilevata</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>Nessun CD-ROM rilevato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Altri dispositivi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Nessun altro dispositivo rilevato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Array Handle</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Fattore forma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Imposta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Locazione Banco</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Dettagli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Numero componente</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Classifica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Tecnologia della memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Capacità modalità operativa della memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versione firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID modulo fabbricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID Prodotti del modulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID produttore controller sottosistema memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID prodotto controller sottosistema memoria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Dimensione Non-Volatile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Dimensione Volatile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Dimensioni Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Dimensione logica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>pollici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -3692,316 +3694,316 @@
         <translation>sides</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>Info BUS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>dimensione settore logico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>dimensioni settore</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometria (logica)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Gestore dispositivi</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Il Gestore Dispositivi è uno strumento utile per visualizzare informazioni sull&apos;hardware e gestire i dispositivi.
 Localizzazione italiana a cura di Massimo A. Carofano.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Nuovi driver disponibili! Installali o aggiornali ora.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Visualizza</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Includi sottocartelle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Ricerca driver in questo percorso</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 aggiornamenti driver disponibili</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Ora verifica: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Download dei driver per %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Valicità download: %1 Scaricati %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Installazione driver per %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 driver installati, %2 installazione driver fallita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 driver installati</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Installazione driver fallita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Errore rete. Riconnessione in corso...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Valocità Download: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>I tuoi driver sono aggiornati</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>riavvia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Per cortesia %1 per rendere effettive le modifiche ai driver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>invia un feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Per cortesia riprova oppure %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Installa tutti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Analizza nuovamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Analisi dei driver dei dispositivi hardware, attendi...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Analisi %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Analisi fallita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Rete non disponibile</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Controlla la configurazione della rete</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Analizza nuovamente oppure %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Stai installando un driver, così facendo rischi di interrompere l&apos;operazione.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Desideri veramente proseguire?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
@@ -4072,27 +4074,27 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4115,22 +4117,22 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
         <translation>Ottenimento driver fallito</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
         <translation>Installa</translation>
     </message>
@@ -4143,39 +4145,40 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Aggiornamento driver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Disinstallazione driver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Consenti il risveglio del computer</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Abilita</translation>
     </message>
@@ -4183,27 +4186,27 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Disabilita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Non disponibile</translation>
     </message>
@@ -4211,7 +4214,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Seleziona un percorso locale</translation>
     </message>
@@ -4219,7 +4222,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Caricamento...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ja.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ja.ts
@@ -1,0 +1,4229 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
+        <source>Processor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Max Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
+        <source>CPU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
+        <source>CPU quantity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <source>Motherboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <source>Memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <source>Display Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <source>Sound Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <source>Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <source>Other PCI Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <source>Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <source>Network Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <source>Keyboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <source>Monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
+        <source>CD-ROM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
+        <source>Printer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
+        <source>Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
+        <source>OS</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <source>Configured Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
+        <source>Media Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
+        <source>Select a driver for update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file&apos;s name</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+        <source>Driver Platform Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
+        <source>Updating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
+        <source>Driver Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
+        <source>Driver Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
+        <source>Driver Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
+        <source>Enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <source>SubVendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
+        <source>SubDevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
+        <source>Config Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <source>latency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
+        <source>PROP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
+        <source>EV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <source>KEY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <source>Bus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <source>BIOS Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
+        <source>Base Board Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
+        <source>System Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
+        <source>Chassis Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
+        <source>Physical Memory Array</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <source>Product Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <source>Serial Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <source>Asset Tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
+        <source>Features</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <source>UUID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <source>SKU Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <source>Family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <source>Error Information Handle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
+        <source>Class</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
+        <source>Serial ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
+        <source>Driver Modules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
+        <source>Device File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <source>Device Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
+        <source>logical name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
+        <source>ansiversion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
+        <source>Hardware Class</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <source>CPU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <source>No CPU found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <source>Motherboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <source>No motherboard found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <source>Memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <source>No memory found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <source>Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <source>No disk found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
+        <source>Please try again or give us feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <source>Display Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <source>No GPU found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <source>Monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <source>No monitor found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
+        <source>Network Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <source>No network adapter found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <source>Keyboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <source>No keyboard found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
+        <location filename="../src/Tool/commontools.cpp" line="45"/>
+        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <source>Other Devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
+        <source>No other devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
+        <source>inch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
+        <source>SSD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
+        <source>HDD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
+        <source>bus info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
+        <source>Device Manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
+        <source>Time checked: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
+        <source>submit feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
+        <source>Scan Again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
+        <source>Scanning %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
+        <source>Are you sure you want to exit?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <location filename="../src/Tool/commontools.cpp" line="44"/>
+        <source>Imaging device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
+        <source>Enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ka.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ka.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ka">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>შემოწმება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>კარგი</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>მეტი</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ქსელის შეტყობინება</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>ხელახლობით დაყენება</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>მეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>შეკრება</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>გააქტიურება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>აპარატის სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ჩიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>შესაძლებლობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>რევიზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>კერნელის რეჟიმის დრივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>მეხსიერების მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>გააქტიურება</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ცვlanი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ჩიპსეტი</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>მწარმოებელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>მაქსიმალური მასშტაბი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>დრაივერის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>უნარები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>ლოგიკური სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>მეიკ მასივი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>გააქტივირება</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>სხვა სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>მწარმოებელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>უნარები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>მაქს. მასშტაბი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>გააქტივირება</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>ვენდორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>ბეჭდის იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>თრედები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>ბოგომიფს</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>არქიტექტურა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>პროცესორის გარდამავალი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>პროცესორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>ბირთვი (ერთ-ერთი)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ვირტუალიზაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>ფლაგი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>გაფართოებები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 კეში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 კეში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i კეში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d კეში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>სტეპინგი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>მაქსიმალური სიჩქარე</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>მომწე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>გრაფიკული მეხსიერება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ფიზიკური იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>მეხსიერების მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO პორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>მაქსიმალური გადამხდელობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>მინიმალური გადá მხდელობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>მიმდინარე გადამხდელობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>დрайвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>აღწერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>გამომავალი დიზაინი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>გამომავალ ღ indicating</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>შესაძლებლობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>მაქსიმალური მასა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>შესაძლებლობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>გამორთვა</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>ინტერფეისი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>სიჩქäრე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>მაქსიმალური სადგენი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>შესაძლებლობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომია არა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>გააქტიურე</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>სავსება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>პროცესორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>პროცესორის რაოდენობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>მამაკაცი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>მეხსიერება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>გამოყოფის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>სუნის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>სინამდვილე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>სხვ種 PCI მანქანები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>ბატარეია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>ბლუტუზი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>ქსელის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>მაუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>კლავიატურა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>მონიტოরი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>პრინტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>კამერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>სხვა მანქანები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>მანქანა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ოპერაციული სისტემა</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>საერთო სიგანე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>მოთხოვნილების მონაცემი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>განსაზღვრული ტენზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>მაქსიმალური ტენზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>მინიმალური ტენზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>განსაზღვრული სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>მონაცემთა სიგანე</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>გამოყოფის შეყვანა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ინტერფეისის ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>მხარდაჭერილი გადანაწილება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>მიმდინარე გადანაწილება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>გამოყოფის კოეფიციენტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>მთავარი გამოყოფა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>მწარმელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>საშინაო შესაძლებლობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>დრაივერის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>მაქსიმალური სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>შეთანხმების სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>პორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>მარიმედირისტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>დაკავშირება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>დროის დახურვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>იპ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>ფირმვერს</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>დუპლექსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>ბროდკასტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ავტო ნეგოციაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>მეხსიერების მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ირკ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>მაკ მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ლოგიკური სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>გამართვა</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>საწყობი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>შესატანი/გამართვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>მეხსიერება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ირკ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>დროის დახურვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>შესაძლებლობები</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>საწყობი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>საშენი უნარები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>მაქსიმალური ძალა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არაა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>გააკრძნავე</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>მომწე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>სტატუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>კაპაციტეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ტენზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>სლოტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>დიზაინის კაპაციტეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>დიზაინის ტენზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS საშენი დრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS ქიმია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>ტემპერატურა</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>მოდელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>მომწე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>გააზიარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>სტატუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>შემოსა leading ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>გამორთვა</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>გამომმწე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>მედია ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>შესაძლებლობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>ფირმვერსიის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>აღწერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>შემოსა leading</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>მობრუნების სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>განახლებისთვის აირჩიეთ დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>ამ კატალოგში არ არის დრაივერები</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>აუდიო მოწყობილობის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>ბიოს ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>CD-ROM ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ოპერაციის სისტემის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>პირდაპირი ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>სხვა მოწყობილობების ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ენერგიის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>პრინტერის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>მაუსის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>ქსელის ადაპტერის ინფორმაცი‐ის ჩხართვა...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>გამორთვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>გამორთვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ხელმისაწვდომი არ არის</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>მოწყობილობის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>კლავიატურის მართვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>დახურვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>დახმარება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>კოპირება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>სისტემა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ექსპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>მოწყობილობის მართვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>ჰარდვერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>დრაივერები</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>მონიტორი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>საერთო ხიდი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>დისპლეის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>პროცესორი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>ქსელის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>ბატარეია</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>მეტი</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>დრაივერის პლატფორმის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>შენახული დრაივერები</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>შენახული დრაივერები</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>გაუქმება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>შემდეგი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>გაფრთხილება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>დრაივერის გაუმჯობესების შემდეგ მოწყობილობა ხელმისაწვდომი არ იქნება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>გაუმჯობესება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>გაუმჯობესება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>განახლება წარმატებულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>გაუმჯობესება წარმატებულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>განახლება ვერ გამართულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>გამოყენების გაუქმება ვერ გამართულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>კარგი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>შემდეგი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>არჩეული საქაღალდე არ არსებობს, გთხოვთ არჩიოთ ხელსაწყობით</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>წინა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>გაწყობილი პაკეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>უთამაშე პაკეტის არქიტექტურა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>არჩეული ფაილი არ არსებობს, გთხოვთ არჩიოთ ხელსაწყობით</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ეს არ არის დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>დაყენება ვერ გამოიყოს - არ არსებობს ელექტრონული ხსნარი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>უცნობი შეცდომა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>დრაივერის მოდული არ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>უნარიანი მოდულის ფორმატი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>დრაივერის მოდულს აქვს დამოკიდებულებები</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>დრაივერის დაყენება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>დრაივერის დასაცულობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>დრაივერის აღდგენა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>შეფასება</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>თქვენ არ არსებობს არჩეული დრაივერების აღდგენასთან დაკავშირებით, გთხოვთ დასაცულობის შემდეგ აღდგინოთ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>დასაცულობაზე გადასვლა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>დასაცულობის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>აღდგენად შესაძლებელი დრაივერები</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ექსპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>საშინაო ხედი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>დრაივერის დაყენება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>დრაივერის დასაცულობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>დრაივერის აღდგენა</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>დევისის ჩართვა ვერ განხორციელდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>დევისის გამორთვა ვერ განხორციელდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>დევისის გამორთვა ვერ განხორციელდა: დევისის SN მიღება შეუძლებელია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>დრაივერების განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>დრაივერების წაშლა</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>იმპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>კოპირება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>საშინააღლისი</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>იმპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>კოპირება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>ჩართვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>დრაივერების განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>დრაივერების წაშლა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>სათანადოდ ჩართოთ კომპიუტერის გასამატებლად</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>გამორთვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>დევისის გამორთვა ვერ განხორციელდა: დევისის SN მიღება შეუძლებელია</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>დევისის გამორთვა ვერ განხორციელდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>დევისის ჩართვა ვერ განხორციელდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>დრაივერების განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>დრაივერების წაშლა</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>ქვემწარმე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>ქვემანქანა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>დრაივერის მდგომარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>დრაივერის ჩართვის კომანდა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>კონფიგურაციის მდგომარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>დახურვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>ფიზიკური</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>სისფსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>ჰენდლერები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>პროპრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ევი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>კიუ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>ბუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ბიოსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ბაზის პლატფორმის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>სისტემის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ჩეისის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ფიზიკური მეხსიერების მასივი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>გამოცემის დაate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>მისამართი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>რუნტაიმის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>რომის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>თვისებები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ბიოსის რევიზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ფირმვერის რევიზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>პროდუქტის სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ასეტის მარკერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>ფუნქციები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ჩეისის მდებარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>ჩეისის ჰენდლი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>შემცვლელი სისტემის ჰენდლერები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>უუიდი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>გამოსვლის ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>სკუ ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>სილაში</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ჩაკეტვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>გაშენების მდებარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>ელექტროენერგიის მოწყობილობის მდებარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>თემპერატურიდან მდებარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>უსაფრთხოების სტატუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ოემის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>სიმაღლე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>ელექტროენაიშნის რაოდენობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>შემცველი ელემენტები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ადგილი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>შეცდომის სამართალის ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>მაქსიმალური მარტივობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>შეცდომის ინფორმაციის ხელსაწყო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>მოწყობილობის რაოდენო მოწყობილობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ბიუს რომსაიზი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>გამოცემის თარიღი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>პლატფორმის სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>სმბიოს ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ენაიშნის აღწერის ფორმატი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>ჩამოყალიბებული ენერგიები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>ამჟამად ჩამოყალიბებული ენაიშნი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>ბდ მისaddress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>აცლ მტუ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>სკო მტუ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>პაკეტის ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>ბმუს პოლიტიკა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>ბმუს რეჟიმი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>კლასი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>სერვისის კლასები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>მოწყობილობის კლასი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>ქვევერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>მოწყობილობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>სერიალური იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>პროდუქტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>აღწერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>მუშაობს</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>გამოსაძიებელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>გამოსათავისუფლებელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>მოდალიას</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>გამოსაძიებელია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>დრაივერის მოდულები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>მოწყობილობის ფაილი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>მოწყობილობის ფაილები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>მოწყობილობის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>გამოყენება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>სტატუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ლოგიკური სახელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ანსი ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>პროცესორის შემსრულებელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>პროცესორის არქიტექტურა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>პროცესორის ვარიანტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>პროცესორის ნაწილი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>პროცესორის რევიზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>ერთი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>ოთხი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>ცხრა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ათი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>თეგზე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>თოთხე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>თეგვე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>თეგვე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>მეორე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>მეორე და სამი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>მეორე და თოხმე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>მეორე და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>მეორე და რვ.მე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>სამე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>სამე და სამი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>სამე და თოხმე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>სამე და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>სამე და რვ.მე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>ოთხი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>ოთხი და სამი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>ოთხი და თოხმე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>ოთხი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>ოთხი და რვ.მე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>ხუთი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>ხუთი და სამი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>ხუთი და თოხმე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ხუთი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ხუთი და რვ.მე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>გარდა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>გარდა და სამი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>გაরდა და თოხმე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ოქტორცი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ოქტორმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>შვიდმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>შვიდმეტი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>შვიდმეტი და მოთა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>შვიდმეტი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>შვიდმეტი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ათმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ათმეტი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ათმეტი და მოთა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ათმეტი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ათმეტი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>ცხრამეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>ცხრამეტი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>ცხრამეტი და მოთა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>ცხრამეტი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>ცხრამეტი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>ერთი ასეთი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>ერთი ასეთი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>ერთი ასეთი და მოთხუ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>ერთი ასეთი და ექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>ერთი ასეთი და რვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>ერთი ასეთი და ათი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>ერთი ასეთი და ათმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>ერთი ასეთი და ათმოთხუ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>ერთი ასეთი და ათექვსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>ერთი ასეთი და ათრვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>ერთი ასეთი და ათორცი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>ერთი ასეთი და ათორცი და ორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>ერთი ასეთი და ათორცი და მოთა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>ასეული და ორმოცდისეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>ასეული და ორმოცდისრი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>ასეული და ცხათორმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>ორი ასეული და ასეული ხუთმეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>გDDR მიმდებარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU პროდუსენტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL კლიენტის API-ები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>უცნობი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>უნიკალური</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ჰარდვერის კლასი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>პროცესორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>პროცესორი არ იმოძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>მამალისი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>მამალისი არ იმოძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>მეხადისი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>მოხადისი არ იმოძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>სტორაჟი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>დისკი არ იმოძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>დრაივერის აღდგენა ვერ მოხდა!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>გთხოვთ სცადოთ ხელახლა ან გამოიყენეთ ჩვენთვის ფედბექსი</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>დრაივერის ბექაპი ვერ მოხდა!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>დისპლეის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU არ იმოძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>მონიტორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>მონიტორი არ იმოძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>ქსელის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>ქსელის ადაპტერი ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>ხმის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>აუდიო მოწყობილობა ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>ბლუტუნსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>ბლუტუნსის მოწყობილობა ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>სხვა PCI მოწყობილობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>სხვა PCI მოწყობილობები ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>ძალა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>ბატარეი ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>კლავიატურა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>კლავიატურა ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>მაუსი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>მაუსი ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>პრინტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>პრინტერში ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>კამერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>კამერა ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>სხვა მოწყობილობები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>სხვა მოწყობილობები ვერ მოიძებნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>მასივის მართვა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>ფორმატი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>სეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>ბანკის მდებარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>ტიპის დეტალები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>ნაწილის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>რანკი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>მეხსიერების ტექნოლოგია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>მეხატის მუშაობის რეჟიმის უნარი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ფირმვერსიის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>მოდულის ფაბრიკაციის იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>მოდულის პროდუქტის იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>მეხატის ქვესისტემის კონტროლერის ფაბრიკაციის იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>მეხატის ქვესისტემის კონტროლერის პროდუქტი იდენტიფიკატორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>უარყოფითი ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>საცვლო ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>კეშის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ლოგიკური ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>ინჩი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>თარიღი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>იოპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>ქსელი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>ბატარეია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>ნატიური გზა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>ელექტროენერგიის წყარო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>განახლდა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>იქნა ისტორია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>აქვს სტატისტიკა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ჩამწვავი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>მდგომარეობა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>გაფრთხილების დონე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ენერგია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ენერგიის უკან</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ენერგიის სასრული</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ენერგიის სასრული დიზაინი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ენერგიის სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>ტენზია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>პერცენტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>ტექნოლოგია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>იკონის სახე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ონლაინ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>დემონის ვერსია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>ბატარიაზე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>კარი დახურულია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>კარი არსებობს</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>კრიტიკული მოქმედება</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>კოპიები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>სამუშაოს გაუქმება შემდეგ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>სამუშაოს დამატება მდე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>სამუშაოს პრიორიტეტი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>მარკერის ცვლილების დრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>რიცხვი ზემოთ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>მიმართულების მოთხოვნა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>პრინტის ფერის რეჟიმი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>პრინტერი სამუშაოს მიღებს</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>პრინტერი გააზარდილია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>პრინტერი სამართალია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>პრინტერის მოდელი და მარკი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>პრინტერის სტატუსის ცვლილების დრო</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>პრინტერის სტატუსის მიზეზები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>პრინტერის ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>პრინტერის ური მხარდაჭერილია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>გვერდები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>ბუსის ინფორმაცია</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ლოგიკური სექტორის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>სექტორის ზომა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>გუიდი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>გეომეტრია (ლოგიკური)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>მასწავლებელი მოწყობილოები</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>მასწავლებელი მოწყობილოები საშიშროების მოწყობილოების ინფორმაციის ნახვას და მოწყობილოებების მართვას მიუთითებს საშიშრო ინსტრუმენტი</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>ახალი დრაივერები ხელმისაწვდომია! დააყენეთ ან განახოთ ამას ახლავე</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>ნახვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>შემატავებული ქალაქების შესატანად</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ძებნა ამ გზაზე დრაივერებისთვის</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 დრაივერის განახვა ხელმისაწვდომია'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'დრო შემოწმდა: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>დრაივერებზე მიმდინარე ჩამოტვირთვა %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'ჩამოტვირთვის სიჩქარე: %1 ჩამოტვირთულია %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>დრაივერებზე მიმდინარე დაყენება %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 დრაივერი დაყენდა, %2 დრაივერი ვერ დაყენდა'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 დრაივერი დაყენდა'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>დრაივერების დაყენება ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>ქსელის შეცდომა. კავშირის აღდგენა...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'ჩამოტვირთვის სიჩქარე: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>თქვენი დრაივერები განახლდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>ყველა დრაივერი შენახულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 დრაივერის საერთო რაოდენობა, სადაც %2 შენახულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>თქვენ გაქს %1 დრაივერი, რომლებიც შენახულია, როდესაც სასარგებლოა ამას ახლავე გააკეთოთ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>თქვენ გაქს %1 დრაივერი, რომლებიც შენახულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 დრაივერის შენახვა, საერთო რაოდენობა %2 დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'შენახვა: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 დრაივერი შენახულია, %2 დრაივერი ვერ შენახულია'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>დრაივერების შენახვა ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 დრაივერი შენახულია'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>თქვენ გაქს %1 დრაივერი, რომლებიც შესამჩნევია</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>გთხოვთ აირჩიოთ დრაივერი, რომელსაც განახლება საჭიროა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>დრაივერი აღდგენაშია...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>აღდგენა: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>გასატვირთად</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>გთხოვთ %1 დრაივერების აღდგენას სახიფათად გამოყენებისთვის</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>დახილეთ აღდგენის გზა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>ყველას აღდგენის</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>გადმოგზაურების მოწყობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>გთხოვთ მოიცადოთ ან %1 და დაგვიკავშირდეთ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>ყველას გადმოწყობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>გადმოწყობა ახალი სცანის სახით</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>გაუქმება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>მასალის მოწყობის საშინაო დრაივერების მოწყობა, გთხოვთ დაელოდოთ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>მასალის მოწყობა %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>გადმოწყობა ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>ქსელი ხელმისაწვდომი არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>გთხოვთ შეამოწმოთ თქვენი ქსელის შეერთება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>გთხოვთ გადმოწყობა ახალი სცანის სახით ან მომხმარებლის მიეშვებას მზად გადმოგზაურების მოწყობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>თქვენ დრაივერის მოწყობა მოხდება, რომელიც შეიწიდება თქვენი გასვლის შემთხვე შემთხვევაში.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>თქვენ გასვლას გსურთ?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>გასვლა</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>გაუქმება</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>თქვენ დრაივერების აღდგენა მოხდება, რომელიც შეიწიდება თქვენი გასვლის შემთხვევაში.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>თქვენ დრაივერების აღდგენა მოხდება, რომელიც შეიწიდება თვენი გასვლის შემთხვევაში.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>ბლუტუზის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>სურათის მოწყობის მანქანა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>გამოყოფის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>ხმის კარტა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>ქსელის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>სატელეკომუნიკაციო ქსელის ადაპტერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>მოწყობა წარმატებულია</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ჩამოყალიბება ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>ჩატვირთვა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>ჩამოყალიბება</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>არ არის ჩამოყალიბებული</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>განახლებული არ არის</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>მიმდინარეობს</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>არ არის დასაცავი</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>დასაცავის პროცესში</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>დასაცავი ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>დასაცავი წარმატებული გახდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>დაბრუნება</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>უცნობი შეცდომა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>ქსელის შეცდომა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>გაუქმდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>დრაივერების ფაილების მიღება ვერ მოხდა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>დასაცავი</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>დაბრუნება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ჩამოყალიბება</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>გააქრობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>იმპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>დრაივერების განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>დრაივერების გამოყოფა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>საშინა კომპიუტერს დააკიდება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>ჩართება</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>განახლება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>იმპორტი</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>კოპირება</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>გააქრობა</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>არ ხედავა</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>გთხოვთ აირჩიო ლოკალური ფოლდერი</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>ჩატვირთვა...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_km_KH.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_km_KH.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="km_KH">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ការតំណាងចំណូល</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>បាទ/អunt</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>បន្ថែម</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ការแจ้งเตือนសម្តេច</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>ការដំឡើងឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>បន្ថែម</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>ប្រមាញ់</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>មិនមានសម្រាប់ប្រើប្រាស់</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ឈ្មោះឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ប្រអប់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>សមត្ថភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>ផ្លូវ SysFS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ការកែប្រែ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>ប្រអប់កែប្រែប្រព័ន្ធដោយ Kernel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>អាស័យដ្ឋានផ្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>មិនមានសម្រាប់ប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ទំរង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ប្រអប់កែប្រែ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>អារីយ៉ាស៊ី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>អំពីវែង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>មុខងារ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>ល្បឿន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>ថាមពលអតិបរមា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>អំពីវែងនៃកម្មវិធីបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>កម្មវិធីបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>មុខងារ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ព័ត៌មានប្រព័ន្ធបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>ឈ្មោះសំខាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>អាស៊ីដ្រី MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>មិនមានន័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>មុខងារ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>អំពីវែង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ព័ត៌មានប្រព័ន្ធបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>មុខងារ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>កម្មវិធីបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>ថាមពលអតិបរមា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>ល្បឿន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>មិនមានន័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>លេខអេស៊ីអេ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>លេខផ្នែកសំខាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>បន្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>ԲոգոՄԻՊՍ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>համակարգչային կառուցվածք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>CPU ընտանիք</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>գործիչ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>միավորներ (ընտրություն)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>վիրտուալիզացիա</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>հանգամանքներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>ընդարձակումներ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 կորպուս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 կորպուս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i կորպուս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d կորպուս</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>քայլեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>արագություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>ամենամեծ արագություն</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>անուն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>տրանսլատոր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>մոդել</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>տարբերակ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>գրաֆիկական հիշողություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ֆիզիկական ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>հիշողության հասցե</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO փոխանցում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>բուս տեղեկատվություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>ամենամեծ լուծում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>ամենափոքր լուծում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>այժմյան լուծում</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>դրայվեր</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>նկարագրություն</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>ប្រភេទ DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>ប្រភេទ eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>ប្រភេទ HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>ប្រភេទ VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>ប្រភេទ DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>ប្រភេទបញ្ចេញឌីជីថល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>ប្រភេទបញ្ចេញកម្រិត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>សមត្ថភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>ប្រភេទ IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>មិនមានប្រភេទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្តល់សេវា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>ទម្ងន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>ព័ត៌មានប៊ូស</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>ល្បឿន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>ថាមពលអតិបរមា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>កម្មវិធីបម្រើ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>សមត្ថភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>លេខសំគាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>មិនមានប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្តល់សេវា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>ប៊ូតិក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>ព័ត៌មានប៊ូស</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>ល្បឿន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>ចំនួនអតិបរមា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>កម្មវិធីបម្រើ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>ប្រតិបត្តិកម្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>ទំរង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>មិនមានប្រតិបត្តិកម្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>សង្ខែមួល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>ប្រព័ន្ធគ្រប់គ្រង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>ចំនួនប្រព័ន្ធគ្រប់គ្រង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>ម៉ាតេរ៉ូប៉០រ៉ាត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>កម្មវិធីផ្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>កម្មវិធីបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>កម្មវិធីសំឡេង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>ការរក្សាទុក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>ឧបករណ៍ផ្សេងៗ PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>ថ្លាមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>ប្រព័ន្ធប្រតិបត្តិកម្ម Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>កម្មវិធីបណ្តាលទូរសព្ទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>មូស</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>កុងស៊ី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>ដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>ម៉ាស៊ីនបោះពុម្ភ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>កាមេរ៉ា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>ឧបករណ៍ផ្សេងៗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>ឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ប្រព័ន្ធតំណាត់ទំនេរ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>ទំហំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>ល្បឿន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ផ្ទះទំហំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>កន្លែងស្ថិត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>លេខសម្ងាត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>តម្លៃថាមពលដែលកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>តម្លៃថាមពលអតិផល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>តម្លៃថាមពលអាចតិច</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>ល្បឿនដែលត្រូវកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ផ្ទះទំហំទិន្នន័យ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>បញ្ចូលការបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ប្រភេទប្រតិបត្តិការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>ការដំណើរការដំណើរការលំហូត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>ការដំណើរការបច្ចុប្បន្ន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>អត្រាការបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>ម៉ូនីទ័រសំខាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ទំហំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>លេខសម្ងាត់</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>ទំនើប</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ព័ត៌មានប្រព័ន្ធរថភ្លើង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>សមត្ថភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>កម្មវិធីបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ទំនើបកម្មវិធីបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>អត្រាអតិផល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>អត្រាការសម្រេចចិត្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>បំពាក់ការតភ្ជាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>ការបញ្ជូនច្រើន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>តម្លៃទំនាក់ទំនង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>ការវះកាត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>អ៊ីភី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>សំណួរកិច្ចប្រតិបត្តិការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ប្រតិបត្តិការពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>ការបញ្ជូនទៅគ្រប់កន្លែង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>សម្ភាសន៍ដោយស្វ័យប្រវត្តិ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>អាស័យដ្ឋានផ្ទះនៃការផ្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>អាស័យដ្ឋានរបស់ប្រតិបត្តិការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>អាស័យដ្ឋាន MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ឈ្មោះសំខាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>មិនមានសម្ភារៈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្តល់សេវា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>ព័ត៌មានការផ្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>ទំនាក់ទំនង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>បញ្ចូល/ចែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>ផ្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>អាស័យដ្ឋានរបស់ប្រតិបត្តិការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>ការវះកាត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>ការបើកប្រើ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>លក្ខណៈ​និង​សមត្ថភាព</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្តល់សេវា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>ម៉ូដែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>ទំនាក់ទំនង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>ព័ត៌មានការផ្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>សមត្ថភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ប្រភេទ​ប្រើ​ប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>ថាមពល​បំផុត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>ល្បឿន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>លេខ​សូដី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>មិន​មាន​នៅ​ក្នុង​ប្រភេទ​ប្រើ​ប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>ម៉ូឌែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>លេខ​សូដី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>ស្ថានភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>កំណត់​ត្រាម៉ាក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ថាមពល​អគ្គិសនី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>ស្លុត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>កំណត់​ត្រាម៉ាក​នៃ​ការ​សាង​សង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>ថាមពល​អគ្គិសនី​នៃ​ការ​សាង​សង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>ទំរង់​នៃ​SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>លេខ​សូដី​នៃ​SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>ថ្ងៃ​ផលិត​នៃ​SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>គីមី​នៃ​SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>អាកាសធាតុ</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>ម៉ូឌែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>លេខ​សូដី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>ចែក​ចិត្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>ស្ថានភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>ប្រភេទអ៊ីនធឺណែត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>ប្រភេទអ៊ីនធឺណែត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>ទំហំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>ទំរង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>សមត្ថភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>ទំរង់ប្រព័ន្ធមូលដ្ឋាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>ល្បឿន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>ការពិពណ៌នា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>លេខសម្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>ប្រភេទអ៊ីនធឺណែត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>អាកាសធាតុកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>មិនមានន័យ</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>ជ្រើសរើសប្រភេទប្រព័ន្ធមូលដ្ឋានសម្រាប់កំណត់ត្រា</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>គ្មានប្រព័ន្ធមូលដ្ឋានណាមួយត្រូវបានរកឃើញនៅក្នុងតំបន់នេះ</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់សំលេង...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ប្រព័ន្ធបើកដំណើរការ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ឧបករណ៍ផ្សេងៗ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ថាមពល...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ប្រព័ន្ធមូលដ្ឋានសម្រាប់ម៉ាស៊ីនសរសេរ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់ម៉ាស៊ីនសរសេរ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>កំពុងផ្ទះប្រព័ន្ធមូលដ្ឋានសម្រាប់អ៊ីនធឺណែត...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>មិនមានន័យ</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>មិនមានន័យ</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ព័ត៌មានឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>បញ្ជីប្រតិបត្តិការបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>ជួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>ចំណ bóng</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>ប្រព័ន្ធមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>កោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>ប្រថុយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>អ្នកគ្រប់គ្រងឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>សំណង់មួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ប្រតិបត្តិការបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>មើល</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>សង្ខេប</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>អាកាសធាតុអាកាសធាតុ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>អេស៊ីអេ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>ប្រតិបត្តិការបង្ហាញមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>ថ្ម</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>ច្រើន</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>អេស៊ីអេប៊ីវ៉េន ប្រព័ន្ធមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>ប្រតិបត្តិការបង្ហាញដែលអាចកោះបាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>ប្រតិបត្តិការបង្ហាញដែលបានកោះរួច</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>កំពុងបម្លែង</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>បោះបង់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>បន្ទាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>ការប្រកាស</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ឧបករណ៍នឹងមិនមានប្រសិទ្ធភាពនៅពេលបោះបង់ប្រតិបត្តិការបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>បោះបង់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>កំពុងបោះបង់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>ការបម្លែងបានជោគជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>ការបោះបង់បានជោគជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>ការផ្លាស់ប្ដូរបានបំពុងបានបំពុៗ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>ការដកដង់បានបំពុៗ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>បញ្ចប់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>បន្ទាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>ថតបំប៉នដែលបានជ្រើសរើសមិនមានទេ សូមជ្រើសរើសឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>ផ្លាស់ប្ដូរ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>មុន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>តុក្រូមមិនបានប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>ការសម្ពាធតុក្រូមមិនតម្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>ឯកសារដែលបានជ្រើសរើសមិនមានទេ សូមជ្រើសរើសឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>នោះមិនមែនជាតុក្រូមប្រើប្រាស់ទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>មិនអាចដំឡើងបាន - គ្មានចំនួនសញ្ញាបត្រឌីជីថល</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>កំហុសមិនស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>មូឌុលតុក្រូមប្រើប្រាស់មិនមានទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>រាងមូឌុលមិនត្រឹមត្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>មូឌុលតុក្រូមប្រើប្រាស់មានការអាចដំណើរការបាន</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ដំឡើងតុក្រូមប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ការបន្ទាប់តុក្រូមប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ការស្នើសុំតុក្រូមប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>សំណូមពរ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>អ្នកគ្មានតុក្រូមប្រើប្រាស់ណាមួយដែលអាចស្នើសុំបាន សូមបន្ទាប់តុក្រូមប្រើប្រាស់ដែលបានទុកដាក់ជាមុនសិន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>ទៅកាន់ការបន្ទាប់តុក្រូមប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>ទម្រង់ការបន្ទាប់តុក្រូមប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>តុក្រូមប្រើប្រាស់ដែលអាចស្នើសុំបាន</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>ផ្ដល់ថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ចែកចាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>សង្ខេប</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ការបម្លើកប្រព័ន្ធទំនេរ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ការកែប្រែប្រព័ន្ធទំនេរ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ការស្តារប្រព័ន្ធទំនេរ</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>មិនអាចបើកឧបករណ៍បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>មិនអាចបិទឧបករណ៍បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>មិនអាចបិទវាបាន៖ មិនអាចទទួលបានលេខសម្គាល់ឧបករណ៍បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>កែសម្រួលកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ដោះដើមកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>ប្រសើរឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ស្នើសុំ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ចម្លាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>តារាងសក្តានុពល</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>ប្រសើរឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ស្នើសុំ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ចម្លាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>បើក</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>កែសម្រួលកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ដោះដើមកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>អនុញ្ញាតឱ្យវាត្រូវបានបើកកុំព្យូទ័រឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>មិនអាចបិទវាបាន៖ មិនអាចទទួលបានលេខសម្គាល់ឧបករណ៍បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>មិនអាចបិទឧបករណ៍បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>មិនអាចបើកឧបករណ៍បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>កែសម្រួលកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ដោះដើមកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់កណ្ដាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>ឧបករណ៍កណ្ដាល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>កម្មវិធីបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ស្ថានភាពកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ការស្នើសុំបើកកម្មវិធីបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>ស្ថានភាពការកំណត់ត្រាមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>កំហុសសម្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>បច្ចេកទេស</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ទំរង់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>ប្រព័ន្ធថ្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ព័ត៌មាន BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ព័ត៌មានតំបន់ផ្តាច់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>ព័ត៌មានប្រព័ន្ធមូលដ្ឋាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ព័ត៌មានប្រព័ន្ធមូលដ្ឋាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>អារេនៃការផ្ទុកផ្នែករាវ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>ថ្ងៃបោះផ្សាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>អាស៊ីត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>ទំហំដែលកំពុងដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ទំហំ ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>លក្ខណៈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>កំណែ BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>កំណែប្រព័ន្ធនៃកម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ឈ្មោះផលិតផល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>លេខសម្គាល់សាកល្បង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>សំណួលសម្គាល់សម្បព្វ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>គ្រោះថ្នាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ទីតាំងនៅក្នុងប្រព័ន្ធមូលដ្ឋាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>ប្រព័ន្ធមូលដ្ឋានដែលគ្រប់គ្រង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>ដៃគូអង្គធាតុដែលបញ្ចូល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>ប្រភេទនៃការកើតឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>លេខសម្គាល់សម្បព្វ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>ក្រុម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>ស្ថានភាពបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>ស្ថានភាពផ្តល់ថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>ស្ថានភាពត្រជាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>ស្ថានៈសុខភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ព័ត៌មាន OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>កម្ពស់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>ចំនួនខ្ទង់ដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>ធាតុផ្សេងៗដែលបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ទីតាំង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>ប្រភេទការកែលំអើប</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>សមត្ថភាពអាចបម្លែងបានបំផុត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>ម៉ូឌែលការបម្លែងបំផុត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>ចំនួនឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ទំហំ BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>ថ្ងៃចេញផ្សាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ឈ្មោះតំបន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>ទំហំ SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ប្រភេទការពិពណ៌នាកិច្ចការភាសា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>ភាសាដែលអាចដំឡើងបាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>ភាសាដែលបានដំឡើងបច្ចុប្បន្ន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>អាស៊ីត BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ការផ្ទេរ ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>ការផ្ទេរ SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>ប្រភេទការផ្ទេរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>គំរូតភ្ជាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>ប្រភេទតភ្ជាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>ប្រភេទសេវា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>ប្រភេទឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>វ៉េរ៉េស៊េន HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>វ៉េរ៉េស៊េន LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>ស៊េវ៉េស៊េនកូដ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>ឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>អត្តសញ្ញាណស៊េរីយ៉ាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>ផលិតផ្លូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>ពិពណ៌នា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>បានបើកដំណើរការ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>អាចស្គាល់បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>អាចគ្រប់គ្រងការតភ្ជាប់បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>រូបរាងតំណាង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>កំពុងស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>មូឌុលកម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ឯកសារឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ឯកសារឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>លេខឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>កម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ស្ថានភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ឈ្មោះស៊េរីយ៉ាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>វ៉េរ៉េស៊េន ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>អ្នកអនុវត្ត CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>ស៊េរីយ៉ាល់ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>ប្រភេទ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>ផ្នែក CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>កំណែ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>មួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>ពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>បួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>ដប់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>ដប់មួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ដប់ពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>ដប់បី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>ដប់បួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>ដប់ប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>ដប់ប្រាំបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>ដប់ប្រាំបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>ដប់ប្រាំបួនបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>ដប់ប្រាំបួនបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ដប់ប្រាំបួនប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ដប់ប្រាំបួនប្រាំបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបួនបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបួនបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបួនប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>ដប់ប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបួនប្រាំបួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>៦២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>ំ៤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>៦៦</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ំ៨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>៧០</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>៧២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>៧៤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>៧៦</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>៧៨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>៨០</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>៨២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>៨៤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>៨៦</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>៨៨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>៩០</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>៩២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>៩៤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>៩ំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>៩៨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>១០០</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>១០២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>១០៤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>១០ំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>១០៨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>១១០</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>១១២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>១១៤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>១១ំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>១១៨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>១២០</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>១២២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>១២៤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>១២៦</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>១២៨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>១៩២</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>២៥៦</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>កំណត់ហេតុនៃ GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>អ្នកផ្គត់ផ្គង់ GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>ប្រភេទ GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>ទំរង់ EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API អ្នកប្រើប្រាស់ EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>ទំរង់ GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>ទំរង់ GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>មិនបានស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ថតកម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>មេរោល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>មិនមានមេរោលនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>មេរោលបំរើ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>មិនមានមេរោលបំរើនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>ផ្ទះកម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>មិនមានផ្ទះកម្មវិធីនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>អាងការរក្សាទុក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>មិនមានឌីសកំណត់ហេតុនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ការស្វែលស្វែងវិញបានបរាជ័យ!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>សូមព្យាយាមម្តងទៀតឬផ្តល់យោបល់ដល់យើង</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ការកែតម្រូវការបំពាក់បានបរាជ័យ!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>ប្រអប់បង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>មិនមាន GPU នៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>ម៉ូនីទ័រ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>មិនមានម៉ូនីទ័រនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>កម្មវិធីសម្គាល់បណ្តាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>គ្មានកម្មវិធីសម្គាល់បណ្តាញមួយផ្នែកនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>កម្មវិធីសម្គាល់សំលេង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>គ្មានឧបករណ៍សំលេងមួយផ្នែកនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>ប្រព័ន្ធប្រតិបត្តិប្រដាប់ប្រវត្តិ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>គ្មានឧបករណ៍ Bluetooth មួយផ្នែកនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>ឧបករណ៍ PCI ផ្សេងទៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>គ្មានឧបករណ៍ PCI ផ្សេងទៀតនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>ថាមពល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>គ្មានថ្មនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>ម៉ាស៊ីនបើកបរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>គ្មានម៉ាស៊ីនបើកបរនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>ម៉ាស៊ីនផ្ទះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>គ្មានម៉ាស៊ីនផ្ទះនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>ម៉ាស៊ីនបោះពុម្ព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>គ្មានម៉ាស៊ីនបោះពុម្ពនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>កាមេរ៉ា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>គ្មានកាមេរ៉ានៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>គ្មាន CD-ROM នៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>ឧបករណ៍ផ្សេងទៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>គ្មានឧបករណ៍ផ្សេងទៀតនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>គ្រប់គ្រប់ប្រព័ន្ធមួយផ្នែក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>រាងរូបរាង</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>ការកំនត់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>ស្ថានិ្តស្ថានិ្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>ប្រភេទលំអិត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>លេខផ្នែក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>ថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>បច្ចេកទេសផ្ទះកម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>សមត្ថភាព​ការ​ដំណើរ​ការ​ក្នុង​ការ​ផ្ទុក​ទិន្នន័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ទំរង់​វេរ្យ៉ែរ​ស៊ី​ម៉ា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>អត្តសញ្ញាណ​ក្រុម​ការ​ផលិត​ម៉ូឌុល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>អត្តសញ្ញាណ​ផលិតផល​ម៉ូឌុល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>អត្តសញ្ញាណ​ក្រុម​ការ​ផលិត​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធផ្ទុកទិន្នន័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>អត្តសញ្ញាណ​ផលិតផល​អ្នក​គ្រប់គ្រង​ប្រព័ន្ធផ្ទុកទិន្នន័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>ទំហំ​ក្នុង​ការ​ផ្ទុក​ដោយ​មិន​ប្រែ​ប្រួល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>ទំហំ​ក្នុង​ការ​ផ្ទុក​ដោយ​ប្រែ​ប្រួល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>ទំហំ​ការ​ផ្ទុក​ក្នុង​តំបន់​កែសម្រួល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ទំហំ​នៃ​ការ​ផ្ទុក​នៅ​ក្នុង​ការ​គណនា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>អោនស៊ី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>ថ្ងៃ​ខែ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ប្រព័ន្ធស៊ី​អោន​អោត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>ប្រព័ន្ធស៊ី​អោន​បណ្ដាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>ថ្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>ផ្លូវ​ដើម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>ប្រព័ន្ធស៊ី​អោន​ថាមពល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>បាន​ធ្វើ​ការ​កែ​សម្រួល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>មាន​ប្រវត្តិ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>មាន​ទិន្នន័យ​សម្ភាសន៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>អាច​ផ្ទះ​ថាមពល​បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>ស្ថានភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>កាំភាព​កម្រិត</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ថាមពល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ស្ថាន​ភាព​ថាមពល​ទាប</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ស្ថានភាព​ថាមពល​ពេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ស្ថានភាព​ថាមពល​ពេញ​តាម​គោលនយោបាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>អត្រា​ថាម​ពល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>អាកាស​ថាម​ពល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>ភាគ​រយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>បច្ចេកទៅសៈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ឈ្មោះសញ្ញាណាតិ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>បន្តផ្ទាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>អ៊ីនធឺណែត វែងស័ក្ដិ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>នៅលើថ្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ក្រាហ្វីស័ក្ដិ បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ក្រាហ្វីស័ក្ដិ មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>សកម្មភាពសំខាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>សន្លឹក​កំណែ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>បិទ​ការងារ​បន្ទាប់​ពី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>បន្ត​ការងារ​ដល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>សំណើច​ការងារ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>ពេល​ផ្លាស់​ប្ដូរ​សញ្ញា​សំខាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>ចំនួន​អោយ​លើ​ក្នុង​មួយ​ប៉ាណែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>កំណត់​ទំហំ​អោយ​លើ​ក្នុង​ប៉ាណែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>ការ​បង្ហាញ​ពន្លឺ​ពណ៌</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>ប្រព័ន្ធប៉ុន្មាន​កំពុង​ទទួល​ការងារ​ប៉ាណែល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>ប្រព័ន្ធប៉ុន្មាន​ត្រូវ​បាន​ចែកចាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>ប្រព័ន្ធប៉ុន្មាន​ជា​ប្រព័ន្ធប៉ុន្មាន​ដែល​មាន​ពេល​កាត់​ត្រឹម​តែ​មួយ​កាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>ការ​ផលិត​និង​ទម្រង់​ប្រព័ន្ធប៉ុន្មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>ពេល​កើត​ឡើង​ការ​ផ្លាស់​ប្ដូរ​ស្ថានភាព​ប្រព័ន្ធប៉ុន្មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>មូលហេតុ​ស្ថានភាព​ប្រព័ន្ធប៉ុន្មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>ប្រភេទ​ប្រព័ន្ធប៉ុន្មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>អ៊ីនធឺណែត​ប្រព័ន្ធប៉ុន្មាន​ដែល​គាំទ្រ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>ផ្នែក​ក្រឡុក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>ព័ត៌មាន​បើក​ការ​ផ្ទុក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ទំហំ​សំណើច​ក្រឡុក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>ទំហំ​ក្រឡុក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>កូដអត្តសញ្ញាណ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>រูបរាង (ទំនាក់ទំនង)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>អ្នកគ្រប់គ្រងឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>អ្នកគ្រប់គ្រងឧបករណ៍គឺជាឧបករណ៍មួយដែលប្រើប្រាស់ដើម្បីមើលពត៌មានអំពីឧបករណ៍ដែលបានបញ្ចូល និងគ្រប់គ្រងឧបករណ៍។</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>មានកូដទំនាក់ទំនងថ្មីមក! បញ្ចូលឬធ្វើឱ្យប្រសើរឡើងវិញឥឡូវនេះ។</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>មើល</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>រួមបញ្ចូលថ្នាក់ក្នុងរូប</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ស្វែងរកកូដទំនាក់ទំនងនៅក្នុងផ្លូវនេះ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>មានការកែសំរួលកូដទំនាក់ទំនង %1 មក។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>ពេលបានពិនិត្យ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>កំពុងទាញយកកូដទំនាក់ទំនងសម្រាប់ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>ល្បឿនទាញយក: %1 ដំណើរការបានទាញយក %2/%3</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>កំពុងដំឡើងកូដទំនាក់ទំនងសម្រាប់ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>កូដទំនាក់ទំនង %1 បានដំឡើង និងកូដទំនាក់ទំនង %2 បានបំពាក់។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>កូដទំនាក់ទំនង %1 បានដំឡើង</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>បានបំពាក់កូដទំនាក់ទំនងដោយមិនបានដំឡើង</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>កំហុសបណ្តាញ។ កំពុងភ្ជាប់ឡើងវិញ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>ល្បឿនទាញយក: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>កូដទំនាក់ទំនងរបស់អ្នកបានប្រសើឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>កូដទំនាក់ទំនងទាំងអស់បានកែសំរួល</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>មានសរុប %1 កូដទំនាក់ទំនង ដែលកូដទំនាក់ទំនង %2 បានបំពាក់។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>អ្នកមានកូដទំនាក់ទំនង %1 ដែលអាចបំពាក់បាន ដែលត្រូវបានណែនាំឱ្យធ្វើដូចនេះភ្លាមៗ។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>អ្នកមានកូដទំនាក់ទំនង %1 ដែលអាចបំពាក់បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>កំពុងបំពាក់កូដទំនាក់ទំនង %1 ដែលមានសរុប %2 កូដទំនាក់ទំនង។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>កំពុងបំពាក់: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>កូដទំនាក់ទំនង %1 បានបំពាក់ និងកូដទំនាក់ទំនង %2 បានបំពាក់ដោយមិនបានបញ្ចូល។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>បានបំពាក់កូដទំនាក់ទំនងដោយមិនបានបញ្ចូល។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>កូដទំនាក់ទំនង %1 បានបំពាក់។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>អ្នកមានកូដទំនាក់ទំនង %1 ដែលអាចស្វែងរកបាន។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>សូមជ្រើសរើសកូដទំនាក់ទំនងដើម្បីស្វែងរក។</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>កម្មវិធីបណ្តុះបណ្តាលកំពុងត្រឡប់មកវិញ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>កំពុងត្រឡប់មកវិញ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>បើកឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>សូមធ្វើឱ្យប្រសើរឡើងវិញ %1 ដើម្បីឱ្យកម្មវិធីបណ្តុះបណ្តាលដែលបានបណ្តុះបណ្តាលមានប្រសិទ្ធភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>មើលផ្លូវការស៊ូម្បី</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>ការស៊ូម្បីទាំងអស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>ផ្ញើការត្រឡប់មកវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>សូមព្រួInvariant ម្តងទៀតឬ %1 ដល់យើង</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>បណ្តុះបណ្តាលទាំងអស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>ស្កានម្តងទៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>កំពុងស្កានកម្មវិធីបណ្តុះបណ្តាលឧបករណ៍កម្មវិធី សូមរង់ចាំ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>កំពុងស្កាន %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>ស្កានបានបរាជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>ប្រព័ន្ធអ៊ីនធឺណែតមិនមាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>សូមពិនិត្យមើលការតភ្ជាប់ប្រព័ន្ធអ៊ីនធឺណែតរបស់អ្នក</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>សូមស្កានម្តងទៀតឬ %1 ដល់យើង</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>អ្នកកំពុងបណ្តុះបណ្តាលកម្មវិធី ដែលនឹងបានបិទប្រសើរបើអ្នកចាកចេញ។</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>អ្នកបានប្រាកដថាចង់ចាកចេញមែនទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ចាកចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>អ្នកកំពុងការស៊ូម្បីកម្មវិធី ដែលនឹងបានបិទប្រសើរបើអ្នកចាកចេញ។</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>អ្នកកំពុងកំពុងត្រឡប់មកវិញកម្មវិធី ដែលនឹងបានបិទប្រសើរបើអ្នកចាកចេញ។</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>អ៊ីនធឺណែត Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ឧបករណ៍រូបថត</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>អ៊ីនធឺណែតបង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>ការបញ្ចេញសំលេង</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>អ៊ីនធឺណែតបណ្តុះបណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>អ៊ីនធឺណែតបណ្តុះបណ្តាលគ្មានខ្សែ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>ការបណ្តុះបណ្តាលបានជោគជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ការស្ទុះស្ទាក់បានបំពាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>កំពុងទាញយក</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>កំពុងស្ទាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>មិនបានស្ទាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>ចាក់ស្ទុះចាក់ស្ទាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>កំពុងរង់ចាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>មិនបានធ្វើការស្ទុះស្ទាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>កំពុងធ្វើការស្ទុះស្ទាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>ការស្ទុះស្ទាក់បានបំពាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>ការស្ទុះស្ទាក់បានបំពាក់ដោយជោគជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>កំពុងស្ទុះស្ទាក់ឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>កំហុសមិនស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>កំហុសបណ្តាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>បានបិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>មិនអាចទទួលបានឯកសារបណ្តាញបាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>កំណើន</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>ស្ទុះស្ទាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>ដំណើរការឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ស្ទាក់</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>ផ្ដាច់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>ចែករំលែក</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>កំណើនបណ្តាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ដោយបិទបណ្តាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>អនុញ្ញាតឱ្យវាប្រើប្រាស់កុំព្យូទ័រ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>បើក</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>ផ្ដាច់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>ចែករំលែក</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>ចែករំលែក</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>មិនអាចប្រើបាន</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>សូមជ្រើសរើសថតិកាប្រទេសមួយ</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>កំពុងផ្ទះ</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_kn_IN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_kn_IN.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="kn_IN">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ಆಪ್ತತೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ಆಯ್ಕೆ</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>ಹೆಚ್ಚು</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ಜಾಲ ಸೂಚನೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>ನಿಯಮಿತ ಪುನರಾವರ್ತನೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>ಇಂಟರ್ಫೇಸ್ 6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>ಹೆಚ್ಚು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>ಕುಸಿತ</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>ಅನುpಸ್ಥಾಪಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>ಉಪಯೋಗಿಸಲಾಗಿಲ್ಲ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ವಸ್ತು ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>ಸಂಚಾಲಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ಚಿಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>ಸಾಮರ್ಥ್ಯಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>ಸಿಸ್ಇಫ್ಎಸ್ ಮಾರ್ಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ವಿವರಣೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>ಕರ್ನೆಲ್ ಮೋಡ್ ಡ್ರೈವರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>ಮೆಮರಿ ಅಡ್ಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>ಐಆರ್ಒ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>ಉಪಯೋಗಿಸಲಾಗಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>ಅನುpಸ್ಥಾಪಿಸು</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>ಸಂಚಾಲಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>ಮಾದರಿ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ಸಂಚಾಲಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ವರ್ಷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ಚಿಪ್ಸೆಟ್</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>ಅಲೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ಶಕ್ತಿಯ ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ವರ್ಷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>ಮಾದರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>ವೇಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>ಅತ್ಯುತ್ತಮ ಶಕ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ಡ್ರೈವರ್ ವರ್ಷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ಡ್ರೈವರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>ಸಾಮರ್ಥ್ಯಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ಬಸ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>ಲಾಗಿಕಲ್ ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>ಮ್ಯಾಕ್ ಅಧಿಕೃತ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ಲಭ್ಯವಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>ನಿಷೇಧಿಸಿ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>ಶಕ್ತಿಯ ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>ಮಾದರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>ವರ್ಷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ಬಸ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>ಸಾಮರ್ಥ್ಯಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ಡ್ರೈವರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>ಅತ್ಯುತ್ತಮ ಶಕ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>ವೇಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>ಲಭ್ಯವಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>ನಿಷೇಧಿಸಿ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>ಶಕ್ತಿಯ ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ಸಿಪಿಯು ಐಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>ಕರ್ ಐಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>ಥ್ರೆಡ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>বোগোমিপস</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>আর্কিটেকচার</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>সিপিয়ু ফ্যামিলি</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>মডেল</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>প্রসেসর</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>কোর (গুলি)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ভার্চুয়ালাইজেশন</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>ফ্ল্যাগস</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>এক্সটেনশনস</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>এল ৩ ক্যাশ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>এল ২ ক্যাশ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>এল ১ আই ক্যাশ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>এল ১ ডি ক্যাশ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>স্টেপিং</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>স্পিড</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>ম্যাক্স স্পিড</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>নাম</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ভেন্ডর</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>মডেল</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ভেরসন</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>গ্রাফিক্স মেমরি</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ফিজিক্যাল আইডি</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>মেমরি এড্রেস</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>আইও পোর্ট</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>বাস ইনফো</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>ম্যাক্সিমাম রেজোলিউশন</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>মিনিমাম রেজোলিউশন</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>সার্ভান্ট রেজোলিউশন</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ড্রাইভার</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>বর্ণনা</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>প্রতিক্রিয়া</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>প্রদর্শন প্রতিক্রিয়া</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>ক্ষমতা</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>আইআরকিউ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>অন্যান্য</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>নাম</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>ব্যবসায়ী</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>সংস্করণ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>মডেল</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>বাস তথ্য</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>গতি</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>সর্বোচ্চ শক্তি</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>ড্রাইভার</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ক্ষমতা</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>সিরিয়াল নম্বর</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>অন্যান্য</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>নিষ্পাদন</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>নাম</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>ব্যবসায়ী</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>মডেল</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>সংযোগ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>বাস তথ্য</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>গতি</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>সর্বোচ্চ বর্তমান</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ড্রাইভার</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>ಶಕ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>ವರ್ಷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>ಪರಿಶೀಲನೆಯಲ್ಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>ನಿಷೇಧಿಸಿ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>ವ್ಯವಸ್ಥೆಯ ಸಾಮಗ್ರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>ಸಿಪಿಯು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>ಸಿಪಿಯು ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>ಮುಖ್ಯ ಕಾರ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>ಮೆಮೊರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>ಪ್ರದರ್ಶನ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>ಸೌಂಡ್ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>ಸಂಗ್ರಹಣೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>ಇತರ ಪಿಸಿಐ ಉಪಕರಣಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>ಬ್ಯಾಟರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>ಬ್ಲೂಟೂತ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>ನೆಟ್ವರ್ಕ್ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>ಮೌಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>ಕೀಬೋರ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>ಮಾನಿಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>ಸಿಡಿ-ರೋಮ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>ಪ್ರಿಂಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>ಕ್ಯಾಮೆರಾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>ಇತರ ಉಪಕರಣಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>ಉಪಕರಣ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>ವೇಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>ಗಾತ್ರ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>ವಿಧಾನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>ವೇಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ಕೆಜಿಐ ವಿಶಾಲತೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ಸ್ಥಾನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>ಸಿರಿಯಲ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>ಸೆಟ್ ಮಾಡಿದ ವೋಲ್ಟೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>ಅತ್ಯುತ್ತಮ ವೋಲ್ಟೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>ನ್ಯೂನತೆ ವೋಲ್ಟೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>ಸೆಟ್ ಮಾಡಿದ ವೇಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ಡೇಟಾ ವಿಶಾಲತೆ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>ವಿಧಾನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>ಡಿಸ್ಪ್ಲೇ ಇನ್ಪುಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ಇಂಟರ್ಫೇಸ್ ವಿಧಾನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>ಸೂಪ್ಪೋರ್ಟ್ ರೆಸಲ್ಯೂಶನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>ಕ್ಯಾರೆಂಟ್ ರೆಸಲ್ಯೂಶನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>ಡಿಸ್ಪ್ಲೇ ಅನುಪಾತ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>ಪ್ರೈಮರಿ ಮಾನಿಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ಆಕಾರ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>ಸಿರಿಯಲ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>ವಿಧಾನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>ವರ್ಷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ಬಸ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>ಸಾಮರ್ಥ್ಯಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ಡ್ರೈವರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ಡ್ರೈವರ್ ವರ್ಷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>ಅತ್ಯುತ್ತಮ ದರ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>ನೆಗೋಸಿಯೇಷನ್ ದರ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>ಪೋರ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>ಮ್ಯುಲ್ಟಿಕಾಸ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>ಲಿಂಕ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>ಅವಘಾತಕಾಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>ಐಪಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>ಫೈರ್ವೇರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ಡ್ಯುಪ್ಲೆಕ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>ಬ್ರೋಡ್ಕಾಸ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ಆಟೊ ನೆಗಾಟಿಯೇಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>ಮೆಮೊರಿ ಅಧ್ಯಯನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ಐಆರ್ಕ್ಯು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>ಎಂಎಚ್ ಅಧ್ಯಯನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ಲಾಜಿಕಲ್ ನಾಮ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>ಉಪಯೋಗಿಸಲಾಗದು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>ನಿರ್ಬಂಧಿಸಿ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>ಮಾಡಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>ಬಸ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>ವೇರ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>ಊಟ/ಆವರ್ತನೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>ಮೆಮೊರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ಐಆರ್ಕ್ಯು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>ಅವಘಾತಕಾಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>ಡ್ರೈವರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>ಸಾಮರ್ಥ್ಯಗಳು</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>ಮಾಡಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>ವೇರ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>ಬಸ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ಶಕ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ಡ್ರೈವರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>ಅತ್ಯುತ್ತಮ ಶಕ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>ವೇಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>ಸರಿಲ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>ಲಭ್ಯತೆಯಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>ಮುಚ್ಚು</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>ಮಾದರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>ಸರಿಲ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>ವಿಧಾನ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>ಕ್ಷಮತೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ವೋಲ್ಟೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>ಸ್ಲಾಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>ನಿರ್ಮಾಣ ಕ್ಷಮತೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>ನಿರ್ಮಾಣ ವೋಲ್ಟೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>ಎಸ್ಬಿಡಿಎಸ್ ಆವೃತ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>ಎಸ್ಬಿಡಿಎಸ್ ಸರಿಲ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>ಎಸ್ಬಿಡಿಎಸ್ ನಿರ್ಮಾಣ ದಿನಾಂಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>ಎಸ್ಬಿಡಿಎಸ್ ರಾಸಾಯನಿಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>ಉಷ್ಣತೆ</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>ಮಾದರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>ಸರಿಲ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>ಸಂಯೋಜಿತ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>ಯುಆರ್ಐ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>ಐಂಟರ್ಫೇಸ್ ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>ಅನ್ ಮಾಡಿ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>ಮೀಡಿಯಾ ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>ಆಕಾರ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>ವೇರ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>ಸಾಮರ್ಥ್ಯ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>ಫೈರ್ಮ್ವೇರ್ ವೇರ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>ವೇಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>ವಿವರಣೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>ಸರಿಯಲ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>ಐಂಟರ್ಫೇಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>ಘೂರ್ತನೆ ದರ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ಉಪಯೋಗಿಸಲಾಗಿಲ್ಲ</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>ಪ್ರಕರ್ಶನ ಸ್ಥಾಪನೆಗಾಗಿ ಡ್ರೈವರ್ ಆಯ್ಕೆ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>ಈ ದಾಖಲೆಯಲ್ಲಿ ಯಾವುದೇ ಡ್ರೈವರ್ ಕಂಡುಬಂದಿಲ್ಲ</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ಆಡಿಯೋ ಡಿವೈಸ್ ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>ಬಿಐಒಸ್ ಮಾಧ್ಯಮ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>ಸಿಡಿ-ಆರ್ಒಂಎಂ ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಮ್ ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>ಸಿಪಿಯು ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>ಇತರೆ ಡಿವೈಸ್ ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ಪವರ್ ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>ಪ್ರಿಂಟರ್ ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>ಮೌಸ್ ಮಾಹಿತಿ ಪ್ರಕರ್ಶನ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>ಜಾಲ ಅಡಾಪ್ಟರ್ ಮಾಹಿತಿ ಪ್ರಕ್ರಿಯೆಯಲ್ಲಿ...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>ಅನ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ಉಪಯೋಗಿಸಲಾಗಿಲ್ಲ</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>ಅನ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ಉಪಯೋಗಿಸಲಾಗಿಲ್ಲ</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ಐ ಡಿ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>ದಿಸ್ಪ್ಲೇ ಶರ್ಟ್ಕಟ್‌ಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>ಮುಚ್ಚು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>ಸಹಾಯ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>ಕಾಪಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>ಸಿಸ್ಟಂ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ಎಕ್ಸ್ಪೋರ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>ರೀಫ್ರೆಶ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>ಐ ಡಿ ಮ್ಯಾನೇಜರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>ಹಾರ್ಡ್ವೇರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ಡ್ರೈವರ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>ಮಾನಿಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>ಆವ್ಯೂರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>ದಿಸ್ಪ್ಲೇ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>ಸಿಪಿಯು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>ನೆಟ್ವರ್ಕ್ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>ಬ್ಯಾಟರಿ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>ಹೆಚ್ಚು</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ಡ್ರೈವರ್ ಪ್ಲಾಟ್ಫಾರ್ಮ್ ವೇರ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>ಬ್ಯಾಕಪ್ ಮಾಡುವ ಡ್ರೈವರ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>ಬ್ಯಾಕಪ್ ಮಾಡಲಾದ ಡ್ರೈವರ್ಸ್</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>ಅಪ್ಡೇಟ್ ಮಾಡುತ್ತಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ವಿಪರ್ಯಾಸ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>ನೆಕ್ಸ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>ನೋಟಿಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ಡ್ರೈವರ್ ಅನಿನ್ಸ್ಟಾಲೇಶನ್ ನಂತರ ಸಾಮಾನ್ಯ ಡಿವೈಸ್ ಅವಲಂಬನೆಯಿರುವುದಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>ಅನಿನ್ಸ್ಟಾಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>ಅನಿನ್ಸ್ಟಾಲ್ ಮಾಡುತ್ತಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>ಅಪ್ಡೇಟ್ ಯಶಸ್ವಿಯಾಗಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>ಅನಿನ್ಸ್ಟಾಲೇಶನ್ ಯಶಸ್ವಿಯಾಗಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>ಅಪ್‌ಡೇಟ್ ವಿಫಲವಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>ಅನಿಸ್ಟಾಲೇಶನ್ ವಿಫಲವಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ಆಯ್ಕೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>ಮುಂದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>ಆಯ್ಕೆ ಮಾಡಿದ ದಾಸ್ತಾನು ಇದು, ಮತ್ತೆ ಆಯ್ಕೆ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>ಅಪ್‌ಡೇಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>ಗುರುತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>ಅಶ್ವಾಸ್ಥಾನು ಪ್ಯಾಕೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>ಅಶ್ವಾಸ್ಥಾನು ಪ್ಯಾಕೇಜ್ ಆರ್ಕಿಟೆಕ್ಚರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>ಆಯ್ಕೆ ಮಾಡಿದ ಫೈಲ್ ಇದು, ಮತ್ತೆ ಆಯ್ಕೆ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ಅದು ಡ್ರೈವರ್ ಅಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>ಇನ್ಸಾಲೇಶನ್ ಮಾಡಲಾಗಿಲ್ಲ - ಡಿಜಿಟಲ್ ಸಿಗ್ನ್ಚರ್ ಇಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>ಅನುಗುಣವಾದ ತಪ್ಪು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ಡಾಯ್ವರ್ ಮಾದ್ಯಮ ಕಂಡುಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>ಅನುಗುಣವಾದ ಮಾದ್ಯಮ ರೂಪಾಂತರ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ಡಾಯ್ವರ್ ಮಾದ್ಯಮ ಅವಲಂಬನೆಗಳನ್ನು ಹೊಂದಿದೆ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ಡ್ರೈವರ್ ಇನ್ಸ್ಟಾಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ಡ್ರೈವರ್ ಬ್ಯಾಕಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ಡ್ರೈವರ್ ರೆಸ್ಟೋರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>ಪ್ರತಿಕ್ರಿಯೆ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>ನೀವು ಯಾವುದೇ ರೆಸ್ಟೋರ್ ಮಾಡಲು ಡ್ರೈವರ್ಗಳನ್ನು ಹೊಂದಿಲ್ಲ, ಮೊದಲು ಬ್ಯಾಕಪ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>ಬ್ಯಾಕಪ್ ಡ್ರೈವರ್‌ಗೆ ಹೋಗಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>ಬ್ಯಾಕಪ್ ಅಥ್ವಾ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>ರೆಸ್ಟೋರ್ ಮಾಡಲು ಸಾಧ್ಯವಾದ ಡ್ರೈವರ್ಗಳು</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>ನವೀಕರಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ನಿರ್ಗಮಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>ಪರಿಶೀಲನೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ಡ್ರೈವರ್ ಇನ್ಸ್ಟಾಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ಡ್ರೈವರ್ ಬ್ಯಾಕಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ಡ್ರೈವರ್ ರೆಸ್ಟೋರ್</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>ಪರಿಕರವನ್ನು ಸಕ್ರಿಯಗೊರಿಸಲು ವಿಫಲವಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>ಪರಿಕರವನ್ನು ಅನ್ಯೂಯಿಸಲು ವಿಫಲವಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ಅನ್ಯೂಯಿಸಲು ವಿಫಲವಾಯಿತು: ಪರಿಕರದ ಸಿಎನ್ ಪಡೆಯಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಅಪ್ಡೇಟ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಅನ್ಸ್ಥಾಪಿಸಿ</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>ನವೀಕರಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ನಿರ್ಗಮಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ನಕಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ಪರಿಶೀಲನೆ</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>ನವೀಕರಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ನಿರ್ಗಮಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>ನಕಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>ಸಕ್ರಿಯಗೊರಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಅಪ್ಡೇಟ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಅನ್ಸ್ಥಾಪಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>ಅದನ್ನು ಕಂಪ್ಯೂಟರ್ ಅನ್ನು ಎಚ್ಚರಗೊಳಿಸಲು ಅನುಮತಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>ಅನ್ಯೂಯಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ಅನ್ಯೂಯಿಸಲು ವಿಫಲವಾಯಿತು: ಪರಿಕರದ ಸಿಎನ್ ಪಡೆಯಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>ಪರಿಕರವನ್ನು ಅನ್ಯೂಯಿಸಲು ವಿಫಲವಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>ಪರಿಕರವನ್ನು ಸಕ್ರಿಯಗೊರಿಸಲು ವಿಫಲವಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಅಪ್ಡೇಟ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಅನ್ಸ್ಥಾಪಿಸಿ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>ಸಬ್ ವೆಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>ಸಬ್ ಡೆವ್ಯೂಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ದ್ರವ್ಯ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ದ್ರವ್ಯ ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ದ್ರವ್ಯ ಸಕ್ರಿಯಕರಣ ಆಜ್ಞೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>ಕಂಪ್ಯೂಟರ್ ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>ಅವಧಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>ಫಿಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>ಸಿಸ್ಫ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>ಹ್ಯಾಂಡಲರ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>ಪ್ರೊಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ಇವಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>ಕೀ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ವರ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>ಬಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ಬಿಐಒಎಸ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ಬೇಸ್ ಬೋರ್ಡ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>ಸಿಸ್ಟಂ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ಚೆಸಿಸ್ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ಫಿಜಿಕಲ್ ಮೆಮರಿ ಐರಿಯಾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>ರಿಲೀಸ್ ಡೇಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>ಆಡ್ರೆಸ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>ರೂನ್ಟೈಮ್ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ಆರ್ಒಎಂ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>ಚಾರ್ಯಕ್ಟರಿಸ್ಟಿಕ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ಬಿಐಒಎಸ್ ರಿವ್ಯೂಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ಫಿರ್ಮ್ವೇರ್ ರಿವ್ಯೂಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ಪ್ರೊಡಕ್ಟ್ ನೇಮ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>ಸರಿಯಲ್ ನಂಬರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ಅಸೆಟ್ ಟಾಗ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>ಫೀಚರ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ಲೋಕೇಶನ್ ಇನ್ ಚೆಸಿಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>ಚೆಸಿಸ್ ಹ್ಯಾಂಡಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>ಕಂಟೇನ್ಡ್ ಓಬ್ಜೆಕ್ಟ್ ಹ್ಯಾಂಡಲ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>ಯುವಿಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>ವೇಕ್-ಅಪ್ ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>ಎಸ್ಕ್ಯೂ ನಂಬರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>ಪ್ರಾಣಿಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ಬ್ಲಾಕ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>ಬೂಟ್ಅಪ್ ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>ಪವರ್ ಸರ್ವೈಸ್ ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>ಥರ್ಮಲ್ ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>ಸುರಕ್ಷತೆ ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ಒಇಎಂ ಮಾಹಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ಆಳ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>ಪವರ್ ಕಾರ್ಡ್‌ಗಳ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>ಒಳಗೊಂಡಿರುವ ಅಂಶಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ಸ್ಥಳ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>ಏರ್ರರ್ ಕರೆಕ್ಷನ್ ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ಮೊದಲ ಸಾಮರ್ಥ್ಯ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>ಏರ್ರರ್ ಮಾಹಿತಿ ಹ್ಯಾಂಡಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>ಆವೃತ್ತಿಗಳ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ಬಿಯೋಸ್ ಆರ್ಒಎಂಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>ವಿಸ್ತರಣೆ ದಿನಾಂಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ಬೋರ್ಡ್ ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>ಎಸ್ಎಮ್ಬಿಐಒಸ್ ಆವೃತ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ಭಾಷೆ ವಿವರಣೆ ರೂಪಾಂತರ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>ಸ್ಥಾಪನೆಯಾಗಿರುವ ಭಾಷೆಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>ಇದೀಗ ಸ್ಥಾಪನೆಯಾಗಿರುವ ಭಾಷೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>ಬಿಡಿ ಸ್ಥಳ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ಎಎಸ್ಎಲ್ ಎಮ್ಟ್ಯು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>ಎಸ್ಸಿಒ ಎಮ್ಟ್ಯು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>ಪ್ಯಾಕೆಟ್ ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>ಲಿಂಕ್ ಪಾಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>ಲಿಂಕ್ ಮೋಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>ವರ್ಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>ಸೇವಾ ವರ್ಗಗಳು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>ಆಸ್ಟ್ರಾನ್ ವರ್ಗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>ಎಚ್ಸಿಐ ಆವೃತ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>ಎಲ್ಎಂಪಿ ಆವೃತ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>ಅಪ್ಪ್ರ್ಯಾವೃತ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>ಆಸ್ಟ್ರಾನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ಸರಿಯಾದ ಐಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>ಮಾಲಿಕತ್ವ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>ವಿವರಣೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>ಪವರ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>ಅತಿದೃಢವಾದ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>ಪೇರ್ ಮಾಡಲಾದ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>ಮೋಡಲಿಯಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>ಅತಿದೃಢವಾದ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>ಡ್ರೈವರ್ ಮಾಡ್ಯೂಲ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ಆಸ್ಟ್ರಾನ್ ಫೈಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ಆಸ್ಟ್ರಾನ್ ಫೈಲ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>ಆಸ್ಟ್ರಾನ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>ಆವೃತ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ಲಾಜಿಕಲ್ ಹೆಸರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ಅನ್ಸಿವರ್ಶನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>ಸಿಪಿಯು ಅನುಸ್ಥಾಪಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>ಸಿಪಿಯು ಆರ್ಕಿಟೆಕ್ಚರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>ಸಿಪಿಯು ವೇರಿಯಂಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>ಸಿಪಿಯು ಪಾರ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>ಸಿಪಿಯು ರಿವ್ಯೂಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>ಒಂದು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ಆರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>ಆರ್ಜಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>ತೊಂಬತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>ಎಂಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>ಮೂವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>ಬಾರ್ಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>ತೊಂಬತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>ಅರ್ಜಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>ಅರ್ಜಿ ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>ಅರ್ಜಿ ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ಅರ್ಜಿ ಆರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ಅರ್ಜಿ ಎಂಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>ಮೂವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>ಮೂವತ್ತು ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>ಮೂವತ್ತು ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>ಮೂವತ್ತು ಆರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>ಮೂವತ್ತು ಎಂಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>ತೊರ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>ತೊರ್ತು ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>ತೊರ್ತು ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>ತೊರ್ತು ಆರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>ತೊರ್ತು ಎಂಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>ಐವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>ಐವತ್ತು ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>ಐವತ್ತು ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ಐವತ್ತು ಆರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ಐವತ್ತು ಎಂಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>ಆವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>ಆವತ್ತು ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>ಆವತ್ತು ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ಐವತ್ತು-ಆರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ಐವತ್ತು-ಆಸ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>ಸತ್ತತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>ಸತ್ತತ್ತು-ಐವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>ಸತ್ತತ್ತು-ಐವತ್ತು-ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>ಸತ್ತತ್ತು-ಐವತ್ತು-ಆರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>ಸತ್ತತ್ತು-ಐವತ್ತು-ಆಸ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ಅರ್ವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು-ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು-ಆರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು-ಆಸ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು-ಐವೆರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು-ಐವೆರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು-ಐವೆರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>ಅರ್ವತ್ತು-ಐವತ್ತು-ಐವೆರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>ಒಂದು ನೂರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>ಒಂದು ನೂರು ಮಾತ್ರ ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಆರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಎಂಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಒಂದು ದಶಮಾಂಶ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಒಂದು ದಶಮಾಂಶ ಎರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಒಂದು ದಶಮಾಂಶ ನಾಲ್ಕು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಒಂದು ದಶಮಾಂಶ ಆರು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಒಂದು ದಶಮಾಂಶ ಎಂಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಐವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಐವತ್ತು-ಐವತ್ತು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>ಒಂದು ನೂರು ಮತ್ತು ಐವತ್ತು-ಐವತ್ತು-ಐವೆರಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>ಐ ಹೆಂಡ್ರೆಡ್ ಆರ್ಡಿನಾಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>ಐ ಹೆಂಡ್ರೆಡ್ ಆರ್ಡಿನಾಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>ಐ ಹೆಂಡ್ರೆಡ್ ನಿನ್ಟಿ-ಟು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>ಟೂ ಹೆಂಡ್ರೆಡ್ ಫಿವ್ಟಿ-ಸಿಕ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR ಸಾಮರ್ಥ್ಯ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU ವೇಂಡರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL ವೇರ್ಸನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL ಕ್ಲಿಯೆಂಟ್ ಐಪಿಐಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL ವೇರ್ಸನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL ವೇರ್ಸಾನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>ಅನುಚಿತ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>ಅನುಚಿತ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>ಮ್ಯಾಸ್ಕ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ಹಾರ್ಡ್ವೇರ್ ಕ್ಲಾಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>ಸಿಪಿಯು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>ಸಿಪಿಯು ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>ಮಾತರ್ಬ್ಯಾರ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>ಮಾತರ್ಬ್ಯಾರ್ಡ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>ಮೆಮೊರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>ಮೆಮೊರಿ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>ಸ್ಟೋರೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>ಡಿಸ್ಕ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ದ್ರೈವರ್ ರೆಸ್ಟೋರ್ ವಿಫಲವಾಯಿತು!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ ಅಥವಾ ನಮಗೆ ಫೀಡ್ಬ್ಯಾಕ್ ನೀಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ದ್ರೈವರ್ ಬ್ಯಾಕಪ್ ವಿಫಲವಾಯಿತು!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>ಡಿಸ್ಪ್ಲೇ ಆಡಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>ಗ್ರಾಫಿಕ್ಸ್ ಪ್ರಕ್ರಿಯೆ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>ಮಾನಿಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>ಮಾನಿಟರ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>ಪ್ರಿನ್ಟರ್ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>ಪ್ರಿನ್ಟರ್ ಅಡಾಪ್ಟರ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>ಆಡಿಯೋ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>ಆಡಿಯೋ ಸೆಟ್ಅಪ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>ಬ್ಲೂಟೂತ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>ಬ್ಲೂಟೂತ್ ಸೆಟ್ಅಪ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>ಇತರ PCI ಸೆಟ್ಅಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>ಇತರ PCI ಸೆಟ್ಅಪ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>ಪವರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>ಬ್ಯಾಟರಿ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>ಕೀಬೋರ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>ಕೀಬೋರ್ಡ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>ಮೌಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>ಮೌಸ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>ಪ್ರಿನ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>ಪ್ರಿನ್ಟರ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>ಕ್ಯಾಮೆರಾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>ಕ್ಯಾಮೆರಾ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>ಸಿಡಿ-ಆರ್ಒಎಂ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>ಸಿಡಿ-ಆರ್ಒಎಂ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>ಇತರ ಸೆಟ್ಅಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>ಇತರ ಸೆಟ್ಅಪ್ ಕಂಡು ಬರಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>ಆರ್ರೇ ಹ್ಯಾಂಡಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>ಫಾರ್ಮ್ ಫ್ಯಾಕ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>ಸೆಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>ಬ್ಯಾಂಕ್ ಲೋಕೇಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>ಟೈಪ್ ಡೆಟೈಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>ಪಾರ್ಟ್ ಸಂಖ್ಯೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>ರೇಂಕ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>ಮೆಮರಿ ಟೆಕ್ನಾಲಜಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ಮೆಮೊರಿ ಓಪರೇಟಿಂಗ್ ಮೋಡ್ ಕ್ಯಾಪಾಬಿಲಿಟಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ಫೌರ್ಮ್ ವರ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ಮಾಡ್ಯೂಲ್ ಮ್ಯಾನುಫ್ಯಾಕ್ಚರರ್ ಐಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ಮಾಡ್ಯೂಲ್ ಪ್ರೊಡಕ್ಟ್ ಐಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ಮೆಮೊರಿ ಸಬ್ಸಿಸ್ಟಂ ಕಂಟ್ರೋಲ್ಲರ್ ಮ್ಯಾನುಫ್ಯಾಕ್ಚರರ್ ಐಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ಮೆಮೊರಿ ಸಬ್ಸಿಸ್ಟಂ ಕಂಟ್ರೋಲ್ಲರ್ ಪ್ರೊಡಕ್ಟ್ ಐಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>ನನ್-ವೋಲೇಟಿಲ್ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>ವೋಲೇಟಿಲ್ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>ಕೇಶ್ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ಲಾಜಿಕಲ್ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>ಅಂಚು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>ದಿನಾಂಕ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ಐಒಪೋರ್ಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>ನೆಟ್ವರ್ಕ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>ಬ್ಯಾಟರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>ನೇಟಿವ್-ಪ್ಯಾಥ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>ಪವರ್ ಸರಬರಾವು</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>ಅಪ್ಡೇಟ್ ಆಗಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>ಹಾಸ್ ಹಿಸ್ಟರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>ಹಾಸ್ ಸ್ಟ್ಯಾಟಿಸ್ಟಿಕ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ರೀಚಾರ್ಜ್ ಆಗುವ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>ಸ್ಥಿತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>ವರ್ನಿಂಗ್ ಲೆವೆಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ಎನರ್ಜಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ಎನರ್ಜಿ-ಖಾಲಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ಎನರ್ಜಿ-ಪೂರ್ಣ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ಎನರ್ಜಿ-ಪೂರ್ಣ ಡಿಸೈನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ಎನರ್ಜಿ-ರೇಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>ವಾಲ್ಟೇಜ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>ಶೇಕಡಾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>ತechnology</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>icon-name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ಆನ್ಲೈನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>ಡೇಮಾನ್ ವೇರ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>ಆನಿಂಗ್ ಬ್ಯಾಟರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ಲಿಡ್ ಇಸ್ ಕ್ಲೋಸ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ಲಿಡ್ ಇಸ್ ಪ್ರೆಸೆಂಟ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>ಕ್ರಿಟಿಕಲ್ ಐಕ್ಷನ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>ಕಾಪಿಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>ಜಾಬ್ ಕ್ಯಾನ್ಸಲ್ ಆಫ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>ಜಾಬ್ ಹೋಲ್ಡ್ ಯುನ್ಟಿಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>ಜಾಬ್ ಪ್ರಿಓರಿಟಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>ಮಾರ್ಕರ್ ಚೇಂಜ್ ಟೈಮ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>ನಂಬರ್ ಅಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ಆರಿಯೆನ್ಟೇಶನ್ ರೀಕ್ವೆಸ್ಟೆಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>ಪ್ರಿಂಟ್ ಕಾಲರ್ ಮೋಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>ಪ್ರಿಂಟರ್ ಇಸ್ ಅಕ್ಸೆಪ್ಟಿಂಗ್ ಜಾಬ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>ಪ್ರಿಂಟರ್ ಇಸ್ ಶೇರ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>ಪ್ರಿಂಟರ್ ಇಸ್ ಟೆಮ್ಪರೇರಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>ಪ್ರಿಂಟರ್ ಮೇಕ್ ಅಂಡ್ ಮಾಡಲ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>ಪ್ರಿಂಟರ್ ಸ್ಟೇಟ್ ಚೇಂಜ್ ಟೈಮ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>ಪ್ರಿಂಟರ್ ಸ್ಟೇಟ್ ರಿಯಾನ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>ಪ್ರಿಂಟರ್ ಟೈಪ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>ಪ್ರಿಂಟರ್ ಯುಆರ್ಐ ಸುಪ್ಪೋರ್ಟೆಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>ಸೈಡ್ಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>ಎಸ್ಎಸ್ಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>ಎಚ್ಚ್ಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>ಬಸ್ ಇನ್ಫೋ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ಲಾಗಿಕಲ್ ಸೆಕ್ಟರ್ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>ಸೆಕ್ಟರ್ ಸೈಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>هندسي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>هندسة (منطقية)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير الأجهزة هو أداة مفيدة لعرض معلومات الأجهزة وإدارة الأجهزة.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>تمامًا أحدث تحديثات الأجهزة! قم بتثبيتها أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>شامل المجلدات الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ابحث عن تحديثات الأجهزة في هذا المسار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 تحديثات جهاز متوفرة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'وقت التحقق: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل تحديثات الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تثبيت ترقية الأجهزة لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 تحديثات أجهزة مثبتة، %2 تحديثات أجهزة فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 تحديثات أجهزة مثبتة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تثبيت تحديثات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعة التنزيل: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>تحديثات الأجهزة الخاصة بك محدثة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع تحديثات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>'إجمالي %1 تحديثات أجهزة، منها %2 تم نسخها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 تحديثات أجهزة يمكن نسخها، يُنصح بالقيام بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 تحديثات أجهزة يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ تحديثات الأجهزة لـ %1، إجمالي %2 تحديثات أجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'النسخ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 تحديثات أجهزة نسخت، %2 تحديثات أجهزة فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ تحديثات الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 تحديثات أجهزة نسخت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 تحديثات أجهزة يمكن استعادةها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار تحديث جهاز لاستعادته</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ಚಾಲನೆ ಮಾಡಲಾಗುತ್ತಿದೆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>ಪುನರುಸ್ಥಾಪನೆ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>ಪುನರಾವರ್ತನೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>ಮುಕ್ಕಳು ಸೆಟ್ಟಾಗಲು %1 ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>ಬ್ಯಾಕಪ್ ಪಥವನ್ನು ನೋಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>ಎಲ್ಲವನ್ನು ಬ್ಯಾಕಪ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>ಪ್ರತಿಕ್ರಿಯೆಯನ್ನು ಸಲ್ಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ ಅಥವಾ %1 ನಮಗೆ ಸಲ್ಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>ಎಲ್ಲವನ್ನು ಸ್ಥಾಪಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>ಮತ್ತೆ ಸ್ಕ್ಯಾನ್ ಮಾಡಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>ವಾಪಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>ಹೈರ್ವೇರ್ ಡೆವೆಲಾಪ್ ಡ್ರೈವರ್ ಗಳನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡುತ್ತಿದ್ದೀರಿ, ಕೊನೆಗೊಳಿಸಲು ಕಾಯಿರಿ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>ಸ್ಕ್ಯಾನ್ ಮಾಡುತ್ತಿದ್ದೀರಿ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>ಸ್ಕ್ಯಾನ್ ವಿಫಲವಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>ಜಾಲ ಲಭ್ಯವಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>ನಿಮ್ಮ ಜಾಲ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>ಮತ್ತೆ ಸ್ಕ್ಯಾನ್ ಮಾಡಿ ಅಥವಾ %1 ನಮಗೆ ಸಲ್ಲಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>ನೀವು ಡ್ರೈವರ್ ಸ್ಥಾಪಿಸುತ್ತಿದ್ದೀರಿ, ನೀವು ಹೊರಗೆ ಬಂದರೆ ಇದು ಅಡಚಾಗುತ್ತದೆ.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>ನೀವು ವಾಪಸ್ ಮಾಡಲು ನಿಶ್ಚಯಿಸಿದ್ದೀರಾ?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ಹೊರಗೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ವಾಪಸ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>ನೀವು ಡ್ರೈವರ್ ಬ್ಯಾಕಪ್ ಮಾಡುತ್ತಿದ್ದೀರಿ, ನೀವು ಹೊರಗೆ ಬಂದರೆ ಇದು ಅಡಚಾಗುತ್ತದೆ.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>ನೀವು ಡ್ರೈವರ್ ಪುನರುಸ್ಥಾಪಿಸುತ್ತಿದ್ದೀರಿ, ನೀವು ಹೊರಗೆ ಬಂದರೆ ಇದು ಅಡಚಾಗುತ್ತದೆ.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>ಬ್ಲೂಟೂತ್ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ಚಿತ್ರಗ್ರಹಣ ಯಂತ್ರ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>ಪ್ರದರ್ಶನ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>ಧ್ವನಿ ಕಾರ್ಡ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>ಜಾಲ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>ವಾಯುಗತ್ತಿನ ಜಾಲ ಅಡಾಪ್ಟರ್</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>ಸ್ಥಾಪನೆ ಯಶಸ್ವಿಯಾಯಿತು</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ಆವರ್ಜಿ ವಿಫಲವಾಗಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>ಗ್ರಾಹಕರನ್ನು ಡೌನ್ಲೋಡ್ ಮಾಡುತ್ತಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>ಆವರ್ಜಿ ಮಾಡುತ್ತಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>ಆವರ್ಜಿ ಇಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>ಮುಖ್ಯ ಆವರ್ಜಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>ನಿರೀಕ್ಷಿಸುತ್ತಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>ಪುನರುತ್ಪತ್ತಿ ಆಗಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>ಪುನರುತ್ಪತ್ತಿ ಮಾಡುತ್ತಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>ಪುನರುತ್ಪತ್ತಿ ವಿಫಲವಾಗಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>ಪುನರುತ್ಪತ್ತಿ ಯಶಸ್ವಿಯಾಗಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>ಪುನರುತ್ಪತ್ತಿ ಮಾಡುತ್ತಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>ಅನುಚಿತ ತಪ್ಪು</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>ನೆಟ್ವರ್ಕ್ ತಪ್ಪು</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>ವಾಪಸೀರಿಸಲಾಗಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ದ್ರವ್ಯ ಅಥವಾ ಅಪ್ಲಿಕೇಶನ್ ಫೈಲ್ಗಳನ್ನು ಪಡೆಯಲಾಗಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>ಸುಧಾರಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>ಪುನರುತ್ಪತ್ತಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>ಪುನರುತ್ಪತ್ತಿ ಮಾಡು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ಆವರ್ಜಿ</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>ಅನುಚಿತಗೊಳಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>ನವೀಕರಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>ನಿರ್ಗಮನ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಸುಧಾರಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ದ್ರವ್ಯಗಳನ್ನು ಅನುಚಿತಗೊಳಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>ಕಂಪ್ಯೂಟರ್ ಅನುಚಿತಗೊಳಿಸಲು ಅನುಮತಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>ಪ್ರವರ್ತನೆ</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>ನವೀಕರಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>ನಿರ್ಗಮನ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>ನಕಲಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>ಅನುಚಿತಗೊಳಿಸು</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>ಅವಲಬ್ಲಿನ</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>ಯಾವುದೇ ಲೋಕಲ್ ಫೋಲ್ಡರ್ ಆಯ್ച್ಛೆಸ್ ಮಾಡಿ</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>ವಿತರಣ...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ko.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ko.ts
@@ -1,29 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ko">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
-        <source>OK</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
+        <source>OK</source>
+        <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>피드백</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>확인</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation>더 보기</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation>접기</translation>
     </message>
 </context>
 <context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation>더 보기</translation>
     </message>
 </context>
 <context>
@@ -31,140 +46,121 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>EC_NOTIFY_NETWORK</source>
-        <translation type="unfinished"/>
+        <translation>네트워크 알림</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>EC_REINSTALL</source>
-        <translation type="unfinished"/>
+        <translation>재설치</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>EC_6</source>
-        <translation type="unfinished"/>
+        <translation>EC_6</translation>
     </message>
 </context>
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation>더 보기</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
-        <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation>접기</translation>
     </message>
 </context>
 <context>
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가</translation>
     </message>
 </context>
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>장치 이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>칩</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>모듈 별칭</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>물리적 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
-        <translation type="unfinished"/>
+        <translation>SysFS 경로</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>설명</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
-        <translation type="unfinished"/>
+        <translation>리비전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
-        <translation type="unfinished"/>
+        <translation>커널 모드 드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>메모리 주소</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
 </context>
 <context>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>칩셋</translation>
     </message>
@@ -206,163 +202,163 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>앨리어스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>모듈 별칭</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>물리적 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>최대 전원</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>드라이버 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>버스 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>논리 이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC 주소</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
 </context>
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>버스 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>최대 전원</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>모듈 별칭</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>물리적 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
 </context>
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>코어 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>쓰레드</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>아키텍처</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU 제품군</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>프로세서</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>코어</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>가상화</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>플래그</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>확장</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 캐시</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 캐시</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 캐시</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i 캐시</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d 캐시</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>스테핑</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>최대 속도</translation>
     </message>
@@ -488,488 +479,450 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>그래픽 메모리</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>모듈 별칭</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>물리적 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>메모리 주소</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO 포트</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>버스 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>최대 해상도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>최소 해상도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>현재 해상도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>설명</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
-        <translation type="unfinished"/>
+        <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>디지털 출력</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>디스플레이 출력</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가</translation>
     </message>
 </context>
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>버스 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>모듈 별칭</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>물리적 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>최대 전원</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>최대 전류</translation>
     </message>
 </context>
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>모델</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>인터페이스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>버스 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>모듈 별칭</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>물리적 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
 </context>
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>개요</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
-        <translation type="unfinished"/>
+        <translation>CPU 수량</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>마더보드</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>메모리</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>디스플레이 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>사운드 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>스토리지</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>다른 PCI 장치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>배터리</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>블루투스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>네트워크 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>마우스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>키보드</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>모니터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>프린터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>카메라</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>다른 장치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>장치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
-        <translation type="unfinished"/>
+        <translation>OS</translation>
     </message>
 </context>
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>전체 너비</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>로케이터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>설정된 전압</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>최대 전압</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>최소 전압</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>설정된 속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>데이터 너비</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>디스플레이 입력</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>인터페이스 유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>지원 해상도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>현재 해상도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>디스플레이 비율</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>기본 모니터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>일련 번호</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>유형</translation>
     </message>
@@ -1090,12 +1040,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
         <source>Maximum Rate</source>
-        <translation type="unfinished"/>
+        <translation>최대 속도</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
         <source>Negotiation Rate</source>
-        <translation type="unfinished"/>
+        <translation>협상 속도</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
@@ -1165,12 +1115,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가능</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
 </context>
 <context>
@@ -1286,12 +1236,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가능</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
 </context>
 <context>
@@ -1374,7 +1324,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
         <source>Temperature</source>
-        <translation type="unfinished"/>
+        <translation>온도</translation>
     </message>
 </context>
 <context>
@@ -1422,154 +1372,149 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
 </context>
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>공급 업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>미디어 유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>모듈 별칭</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>물리적 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>펌웨어 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>설명</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>인터페이스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>회전 속도</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가능</translation>
     </message>
 </context>
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
-        <translation type="unfinished"/>
+        <translation>업데이트용 드라이버 선택</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
-        <translation type="unfinished"/>
+        <translation>이 폴더에 드라이버가 없습니다</translation>
     </message>
 </context>
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>오디오 장치 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>운영 체제 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>CPU 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>기타 장치 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>전원 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>프린터 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>마우스 정보 불러오는 중...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>네트워크 정보 불러오는 중...</translation>
     </message>
@@ -1577,116 +1522,114 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가능</translation>
     </message>
 </context>
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가능</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>장치 정보</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>단축키 표시</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>도움말</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>시스텝</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>새로고침</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>장치 관리자</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
-        <translation type="unfinished"/>
+        <translation>하드웨어</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
-        <translation type="unfinished"/>
+        <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>모니터</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>개요</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>디스플레이 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>네트워크 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>배터리</translation>
     </message>
@@ -1694,377 +1637,359 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
-        <translation type="unfinished"/>
+        <translation>더 보기</translation>
     </message>
 </context>
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>현재 버전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 플랫폼 버전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>상태</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>작업</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>백업 가능한 드라이버</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>백업된 드라이버</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
-        <translation type="unfinished"/>
+        <translation>업데이트 중</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>Warning</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>The device will be unavailable after the driver uninstallation</source>
-        <translation type="unfinished"/>
+        <translation>다음</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
-        <source>Uninstall</source>
-        <comment>button</comment>
-        <translation type="unfinished"/>
+        <source>Warning</source>
+        <translation>경고</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>드라이버를 해제한 후 장치는 사용 불가능해집니다</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>설치 해제</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
-        <translation type="unfinished"/>
+        <translation>설치 해제 중</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
-        <translation type="unfinished"/>
+        <translation>업데이트 성공</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>제거 성공</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>업데이트가 실패</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>제거 실패</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>다음</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>선택한 폴더가 존재하지 않습니다. 다시 선택하십시오</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>업데이트</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>이전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>깨진 패키지</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>맞지 않는 패키지 아키텍처</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>선택한 파일이 존재하지 않습니다. 다시 선택하십시오</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>드라이버가 아닙니다</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
-        <translation type="unfinished"/>
+        <translation>설치할 수 없습니다. 디지털 서명이 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>알수없는 오류</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>드라이버 모듈을 찾을 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>잘못된 모듈 형식</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 모듈이 종속성에 있습니다</translation>
     </message>
 </context>
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>장치 이름</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
-        <translation type="unfinished"/>
+        <translation>사용 가능한 버전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>크기</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>상태</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>작업</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
-        <translation type="unfinished"/>
+        <translation>새로운 버전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>현재 버전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>결과 드라이버가 누락되었습니다 (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>이상한 드라이버 (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>최신 드라이버 (%1)</translation>
     </message>
 </context>
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 설치</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 백업</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 복원</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation>확인</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>피드백</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>복원할 드라이버가 없습니다. 먼저 백업해 주세요</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>백업 드라이버로 이동</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>현재 버전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>백업 버전</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>작업</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>복원 가능한 드라이버</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>새로고침</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>개요</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 설치</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 백업</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 복원</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>장치를 활성화하지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>장치를 비활성화하지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>비활성화 실패: 장치 SN을 가져올 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>드라이버 업데이트</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>드라이버 제거</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>새로고침</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>개요</translation>
     </message>
@@ -2111,53 +2036,51 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
-        <translation type="unfinished"/>
+        <translation>활성화</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 업데이트</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 제거</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>컴퓨터를 깨우도록 허용</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>비활성화 실패: 장치 SN을 가져올 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>장치를 비활성화하지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>장치를 활성화하지 못했습니다.</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>드라이버 업데이트</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>드라이버 제거</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>하위 공급업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>보조장치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>드라이버</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>드라이버 상태</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>드라이버 활성화 Cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>구성 상태</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>레이턴시</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>핸들러</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>키</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>버스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>기본 보드 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>시스템 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>섀시 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>실제 메모리 배열</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>출시일</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>런타임 크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM 크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>특성</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS 리비전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>펌웨어 리비전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>제품 이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>일련 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Asset 태그</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>섀시 내 위치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>섀시 핸들</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>포함된 개체 핸들</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>절전모드 해제 유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>제품군</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>잠금</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>부팅 상태</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>전원 공급 상태</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>열 상태</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>보안 상태</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>높이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>전원 코드 수</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>포함된 요소</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>위치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>오류 수정 유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>최대 용량</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>오류 정보 핸들</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>장치의 수</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS 롬크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>출시일</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>보드 이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>언어 설명 형식</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>설치 가능한 언어</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>현재 설치된 언어</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD 주소</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>패킷 유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>링크 정책</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>링크 모드</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>클래스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>서비스 클래스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>장치 클래스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>서브버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>장치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>직렬 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>제품</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>설명</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>전원 공급됨</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>발견 가능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>페어링 가능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>발견 중</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>드라이버 모듈</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>장치 파일</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>장치 파일</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>장치 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>응용 프로그램</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>상태</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>논리 이름</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansi버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU 구현도구</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU 아키텍처</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU 변종</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU 부품</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU 리비전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>일</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>사</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>육</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>팔</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>구</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>십</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>십이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>십사</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>십육</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>십팔</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>이십</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>이십 이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>이십 사</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>이십 육</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>이십 팔</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>삼십</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>삼십 이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>삼십 사</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>삼십 육</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>삼십 팔</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>사십</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>사십 이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>사십 사</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>사십 육</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>사십 팔</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>오십</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>오십 이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>오십 사</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>오십 육</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>오십 팔</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>육십</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>육십 이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>육십 사</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
-        <source>Sixty-six</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
-        <source>Sixty-eight</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
-        <source>Seventy</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
-        <source>Seventy-two</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
-        <source>Seventy-four</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
-        <source>Seventy-six</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
-        <source>Seventy-eight</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
-        <source>Eighty</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
-        <source>Eighty-two</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
-        <source>Eighty-four</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
-        <source>Eighty-six</source>
-        <translation type="unfinished"/>
+        <source>Sixty-six</source>
+        <translation>육십육</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
-        <source>Eighty-eight</source>
-        <translation type="unfinished"/>
+        <source>Sixty-eight</source>
+        <translation>육십팔</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
-        <source>Ninety</source>
-        <translation type="unfinished"/>
+        <source>Seventy</source>
+        <translation>칠십</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
-        <source>Ninety-two</source>
-        <translation type="unfinished"/>
+        <source>Seventy-two</source>
+        <translation>칠십이</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
-        <source>Ninety-four</source>
-        <translation type="unfinished"/>
+        <source>Seventy-four</source>
+        <translation>칠십사</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
-        <source>Ninety-six</source>
-        <translation type="unfinished"/>
+        <source>Seventy-six</source>
+        <translation>칠십육</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
-        <source>Ninety-eight</source>
-        <translation type="unfinished"/>
+        <source>Seventy-eight</source>
+        <translation>칠십팔</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
-        <source>One hundred</source>
-        <translation type="unfinished"/>
+        <source>Eighty</source>
+        <translation>팔십</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
-        <source>One hundred and Two</source>
-        <translation type="unfinished"/>
+        <source>Eighty-two</source>
+        <translation>팔십이</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
-        <source>One hundred and four</source>
-        <translation type="unfinished"/>
+        <source>Eighty-four</source>
+        <translation>팔십사</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
-        <source>One hundred and Six</source>
-        <translation type="unfinished"/>
+        <source>Eighty-six</source>
+        <translation>팔십육</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
-        <source>One hundred and Eight</source>
-        <translation type="unfinished"/>
+        <source>Eighty-eight</source>
+        <translation>팔십팔</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
-        <source>One hundred and Ten</source>
-        <translation type="unfinished"/>
+        <source>Ninety</source>
+        <translation>구십</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
-        <source>One hundred and Twelve</source>
-        <translation type="unfinished"/>
+        <source>Ninety-two</source>
+        <translation>구십이</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
-        <source>One hundred and Fourteen</source>
-        <translation type="unfinished"/>
+        <source>Ninety-four</source>
+        <translation>구십사</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
-        <source>One hundred and Sixteen</source>
-        <translation type="unfinished"/>
+        <source>Ninety-six</source>
+        <translation>구십육</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
-        <source>One hundred and Eighteen</source>
-        <translation type="unfinished"/>
+        <source>Ninety-eight</source>
+        <translation>구십팔</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
-        <source>One hundred and Twenty</source>
-        <translation type="unfinished"/>
+        <source>One hundred</source>
+        <translation>백</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
-        <source>One hundred and Twenty-two</source>
-        <translation type="unfinished"/>
+        <source>One hundred and Two</source>
+        <translation>백이</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
-        <source>One hundred and Twenty-four</source>
-        <translation type="unfinished"/>
+        <source>One hundred and four</source>
+        <translation>백사</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
-        <source>One hundred and Twenty-six</source>
-        <translation type="unfinished"/>
+        <source>One hundred and Six</source>
+        <translation>백육</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>백팔</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>백십</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>백십이</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>백십사</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>백십육</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>백팔십여</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>백이십</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>백이십이</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>백이십사</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>백이십육</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>백 이십 팔</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
-        <translation type="unfinished"/>
+        <translation>백구십이</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
-        <translation type="unfinished"/>
+        <translation>이백오십육</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR 용량</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU 공급업체</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU 유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL 클라이언트 API</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL 버전</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>알 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>하드웨어 클래스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>CPU를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>마더보드</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>마더보드를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>메모리</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>메모리를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>스토리지</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>디스크를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 복구 실패!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>다시 시도하거나 피드백을 제공해 주세요</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 백업 실패!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>디스플레이 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>GPU를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>모니터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>모니터를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>네트워크 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>네트워크 어댑터를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>사운드 어댑터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>오디오 장치를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>블루투스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>블루투스 장치를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>다른 PCI 장치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>다른 PCI 디바이스를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>전원</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>배터리를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>키보드</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>키보드를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>마우스</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>마우스를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>프린터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>프린터를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>카메라</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>카메라를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>CD-ROM을 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>다른 장치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>다른 장치를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>배열 핸들</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>폼 팩터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>지정</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>뱅크 로케이터</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>세부사항 유형</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>부품 번호</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>순위</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>메모리 기술</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>메모리 작동 모드 기능</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>펌웨어 버전</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>모듈 제조업체 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>모듈 제품 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>메모리 서브시스템 컨트롤러 제조업체 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>메모리 서브시스템 컨트롤러 제품 ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>비휘발성 크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>휘발성 크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>캐시 크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>논리적 크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>인치</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
@@ -3692,406 +3453,387 @@
         <translation>sides</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>버스 정보</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>논리섹터크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>섹터크기</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>기하학적 구조(논리적)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>장치 관리자</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>장치 관리자는 하드웨어 정보를 보고 장치를 관리하기 위한 편리한 도구입니다.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
-        <translation type="unfinished"/>
+        <translation>새로운 드라이버가 있습니다! 즉시 설치하거나 업데이트하세요.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
-        <translation type="unfinished"/>
+        <translation>보기</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
-        <translation type="unfinished"/>
+        <translation>서브 폴더 포함</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
-        <translation type="unfinished"/>
+        <translation>이 경로에서 드라이버 검색</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
-        <translation type="unfinished"/>
+        <translation>'%1 드라이버 업데이트 가능'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
-        <translation type="unfinished"/>
+        <translation>'확인 시간: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>%1 드라이버 다운로드 중...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation type="unfinished"/>
+        <translation>'다운로드 속도: %1 다운로드 완료: %2/%3'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>%1 드라이버 설치 중...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 드라이버 설치됨, %2 드라이버 실패'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 드라이버 설치됨'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 설치 실패</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
-        <translation type="unfinished"/>
+        <translation>네트워크 오류. 재연결 중...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
-        <translation type="unfinished"/>
+        <translation>'다운로드 속도: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
-        <translation type="unfinished"/>
+        <translation>드라이버가 최신 상태입니다</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>모든 드라이버가 백업되었습니다</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1개의 드라이버 중 %2개가 백업되었습니다</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>You have %1 drivers that can be backed up, it is recommended to do so
+immediately</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>You have %1 drivers that can be backed up</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>Backing up the %1 driver, a total of %2 drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>백업 중: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>%1 드라이버가 백업되었고, %2 드라이버는 실패했습니다</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 백업 실패</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 드라이버가 백업되었습니다</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>복구할 수 있는 %1 드라이버가 있습니다</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>복구할 드라이버를 선택해 주세요</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 복구 중입니다...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>복구 중: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
-        <translation type="unfinished"/>
+        <translation>재시작</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
-        <translation type="unfinished"/>
+        <translation>설치된 드라이버가 적용되도록 %1해 주세요</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>백업 경로 보기</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
-        <source>submit feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
-        <source>Please try again or %1 to us</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
-        <source>Install All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
-        <source>Scan Again</source>
-        <translation type="unfinished"/>
+        <translation>모두 백업</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>피드백 제출</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>다시 시도해 주세요 또는 %1해 주세요</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>모두 설치</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>다시 스캔</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>하드웨어 드라이버를 스캔 중입니다, 기다려 주세요...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
-        <translation type="unfinished"/>
+        <translation>%1 스캔 중</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
-        <translation type="unfinished"/>
+        <translation>스캔 실패</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
-        <translation type="unfinished"/>
+        <translation>네트워크 사용 불가능</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
-        <translation type="unfinished"/>
+        <translation>네트워크 연결을 확인해 주세요</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
-        <translation type="unfinished"/>
+        <translation>다시 스캔해 주세요 또는 %1해 주세요</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>드라이버를 설치 중입니다. 종료 시 중단됩니다.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"/>
+        <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>나가기</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>드라이버를 백업 중입니다. 종료 시 중단됩니다.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>드라이버를 복구 중입니다. 종료 시 중단됩니다.</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
         <source>Bluetooth adapter</source>
-        <translation type="unfinished"/>
+        <translation>블루투스 어댑터</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
-        <translation type="unfinished"/>
+        <translation>이미징 장치</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="38"/>
         <source>Display adapter</source>
-        <translation type="unfinished"/>
+        <translation>디스플레이 어댑터</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="40"/>
         <source>Sound card</source>
-        <translation type="unfinished"/>
+        <translation>사운드 카드</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="42"/>
         <source>Network adapter</source>
-        <translation type="unfinished"/>
+        <translation>네트워크 어댑터</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="46"/>
         <source>Wireless network adapter</source>
-        <translation type="unfinished"/>
+        <translation>무선 네트워크 어댑터</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="66"/>
         <source>Installation successful</source>
-        <translation type="unfinished"/>
+        <translation>설치 성공</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="67"/>
         <source>Installation failed</source>
-        <translation type="unfinished"/>
+        <translation>설치 실패</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="68"/>
         <source>Downloading</source>
-        <translation type="unfinished"/>
+        <translation>다운로드 중</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="69"/>
         <source>Installing</source>
-        <translation type="unfinished"/>
+        <translation>설치 중</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="70"/>
         <source>Not installed</source>
-        <translation type="unfinished"/>
+        <translation>설치되지 않음</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="71"/>
         <source>Out-of-date</source>
-        <translation type="unfinished"/>
+        <translation>오래된 버전</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="72"/>
         <source>Waiting</source>
-        <translation type="unfinished"/>
+        <translation>대기 중</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>백업되지 않음</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>백업 중</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>백업 실패</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>백업 성공</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>복구 중</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4101,37 +3843,37 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Network error</source>
-        <translation type="unfinished"/>
+        <translation>네트워크 오류</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Canceled</source>
-        <translation type="unfinished"/>
+        <translation>취소됨</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Failed to get driver files</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 파일을 가져올 수 없음</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>업데이트</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>백업</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>복구</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation>설치</translation>
     </message>
     <message>
         <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
@@ -4142,83 +3884,81 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>새로고침</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 업데이트</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>드라이버 언인스톨</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>컴퓨터를 깨우도록 허용</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
-        <translation type="unfinished"/>
+        <translation>활성화</translation>
     </message>
 </context>
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>새로고침</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>내보내기</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation>비활성화</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>사용 불가능</translation>
     </message>
 </context>
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
-        <translation type="unfinished"/>
+        <translation>로컬 폴더를 선택해 주세요</translation>
     </message>
 </context>
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>불러오는 중...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ku.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ku.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ku">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ئەمەجەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>بەر</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>بەرە</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ئەمەجەت بۆ ڕەشە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>بەرە بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>بەرە</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>بێکار</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ئەسەمانە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>ئەسەمانە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>پەروەردگەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>چیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>توانایەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>بەرزکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>داورەکانی کرنێل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>دەرەکەتی ھەممە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>بێکار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>بەرە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>ئەسەمانە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>پەروەردگەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>مۆدێل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>پەروەردگەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ڤەرژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>چیپسێت</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>ئەلیاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>ئەسەمانە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>تەرجىبە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ناڤە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>مۆدەل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>سەرەکت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>بەرەمە چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ناڤە چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>دەرۋەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>قابىلىتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>بۇس مەلumat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>لۆجىکى نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC ئادرىس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>بەرەمە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>دېسەبىل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>ناڤە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>تەرجىبە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>مۆدەل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>ناڤە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>بۇس مەلumat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>قابىلىتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>دەرۋەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>بەرەمە چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>سەرەکت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>بەرەمە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>دېسەبىل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>ناڤە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>ناڤە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>تەرجىبە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ئىد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>كۆر ئىد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>تېرەد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجو میبس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>ئەرەکىتەکى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>کۆپى فامىلىیە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>پرۆسەسۆر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>کۆر(ە)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ڤىرچوئالىزاسىیە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>فلاگس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>ئەنچىە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 کەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 کەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i کەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d کەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>ستىپىنگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>سەپىد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>ماکس سەپىد</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>ئەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ڤىندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ڤىرشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>گرافىک مەمۆرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>فېزىکى دىد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>مەمۆرى ئەددىس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>ئىو پۆرت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>بۇس ئىنفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>ماکس ئىمەمۇر شىلە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>مىن ئىمەمۇر شىلە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>كۈرەن ئىمەمۇر شىلە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>دراىۋر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>ئەپىسىیە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>ئەرەپەتەكى ئەسلى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>ئەرەپەتەكى ئەسلى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>ئەمکانات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>بەرەت نەدە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>ئادە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>ڤېندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>ڤېرسيۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>بۇس مەلumat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>سۈرەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>ئەڭ كۆپ قۇۋۋەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>درايڤر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ئەمکانات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>سېرىال نومۇر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>بەرەت نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>بەرەت كى</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>ئادە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>ڤېندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>ئىنتەرفيس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>بۇس مەلumat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>سۈرەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>ئەڭ كۆپ گۆرۈن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>درايڤر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>ئەمەندە چەکى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>ڤىرسيۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>بەرکەم نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>بەرکەم كى</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>ئەگەرچى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>کۆن ئەمەندە CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>بەرکەم بۆرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>ئەمەندە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>ئەمەندە گەمار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>سۆندا گەمار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>پەرچى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>ئەمەندە PCI دىگەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>بەتري</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>نەتۋورك گەمار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>مووس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>كىبورد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>مۆنیتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>پرینتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>کامەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>دىگەر دىۋىسە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>دەۋىسە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ئىسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>ڤىندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>كۆر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>نەچى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>سۈرەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ئەمەیشکریتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ئەمەیشکریتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>شیروانی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>تەکڵیف شووی نیرو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>نیروی کۆکریت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>نیروی کۆکریت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>تەکڵیف شووی سێد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ئەمەیشکریتی داتا</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ئەدەم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>پەروەردگار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>نەتیجە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>ئەندێرەکە بەرەو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>نەتیجە تایپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>کۆکریت کۆتا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>کۆتای کۆرەکریت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>ئەندێرەکە نیشتمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>ئەندێرەکە کۆکریت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>بەرزی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>شیروانی</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ئەدەم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>پەروەردگار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>نەتیجە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>ناوەند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>بەس ئینفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>کۆنەسەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>دراڤەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>دراڤەر ناوەند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>نیشتمان رەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>نەگۆتیەتی رەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>پۆرت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>کۆچەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>لینک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>کەشکردنی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>فیرمەوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>دۆپڵەکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>بڕۆکاست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ئاوتۆ نەگۆسیەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>ئەدەressی ھەممە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC ئەدەress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>نەمە ھەممە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>بەکارهێنانەوە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>نامە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>مۆدڵ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>بەس ئەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>وێرشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>ئەوتو/ئەوتو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>ھەممە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>کەشکردنی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>دراڤەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>کەمەکتی</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>نامە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>مۆدڵ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>وێرشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>بەس ئەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ئەمكانات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>درايڤر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>توانیەتی بەرزە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>سۆر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>نەمەری سری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>نەدۆزر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>بەکارھێنانی کەوتو</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>نەمەری سری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>تیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>ستاتوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>کەپاسیتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ولتەج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>سۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>دەزاین کەپاسیتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>دەزاین ولتەج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>ڤەرژنی SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>نەمەری سری SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاریخ ئەوەی کردو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>کیمیایی SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>تەمپرەتۇر</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>نەمەری سری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>بەشدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>ستاتوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>تایب نیشانی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>بەکارهێنەر</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>سەرچاپەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>نیشانی دەرەکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>بەرزی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>وەرگە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>توانایەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>وەرگە نەخشە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>سەریعەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>تەخمینە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>نەمەرە سەریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>تایب نیشانی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>نرخی چرۆی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>نەدەبەست</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>دەرەکەیەک بەکارهێنەر بۆ بەروارکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>هیچ دەرەکەیەک لە ئەم پەڕەیەوە نەدۆزرایەوە</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی دەرەکەی ھۆیزی...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>بەڕووکردنی تەقەمęتی CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی سیستەمی ھۆیزی...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی دەرەکەکانی تەنیا...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی کەشکردن...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی چاپکردن...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی گۆڕەک...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>بەڕووکردنی تەقەمەتی نیشانی کۆمەنە...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>بەکارهێنەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>نەدەبەست</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>بەکارهێنەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>نەدەبەست</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ئەمەكىنىن ئۇيغۇرلىقى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>ئەمەكىنى كۆرسىتىش كۇرەكلىكلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>بەكىت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>يەردىم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>كۆپى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>سىستېم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>چыغۇر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>يېڭىلىت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>ئەمەكى مىنىتېر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>هەرۋەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>دراىۋەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>مۆنېتور</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>كۆرۈنۈش</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>كۆرسىتىش ئاداپتېرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>سىستېم ئاداپتېرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>بەتارىيە</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>بىرگە</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>دراىۋەر پىلتاف ئىنتىرىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>بەكىپلىنىشلىق دراىۋەرلەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>بەكىپلىنىلغان دراىۋەرلەر</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>يېڭىلىتىش</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>بىلەن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>كىرەك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>ئېھۋال</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>دراىۋەرنى ئۆچۈرگەن سەنەتىن كېيىن ئەمەكى ئۇيغۇرلىقىنىڭ كىرىشىنى ئۆچۈرۈشى مۇمكىن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>ئۆچۈر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>ئۆچۈرۈلىۋاتىدۇ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>يېڭىلىتىش مۇۋەفەقئەتلى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>ئۆچۈرۈش مۇۋەفەقئەتلى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>ئەوە بەرەو بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>تۆمار کردنی بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>بەرەو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>بەرەو دووبارە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>فۆlderەکە نەدەتەو بەرەو بەرھەم بەرەو بەرھەم بەرەو بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>بەروەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>پێش</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>پەکەکە بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>پەکەکە ھەڵبەندی نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>فایلەکە نەدەتەو بەرەو بەرھەم بەرەو بەرھەم بەرەو بęرھام نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ئەو ھەڵبەندی نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>تۆمار کردنی بەرھام نەدەت - ھەڵبەندی دیجیتالی نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>هەڵەی نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>مۆدیولی ھەڵبەندی نەدەتەو بەرەو بەرھەم بەرەو بەرھەم بەرەو بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>فرۆمەتی مۆدیولی نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>مۆدیولی ھەڵبەندی دەبێتەو بەرھەم بەرەو بەرھەم بەرەو بەرھەم نەدەت</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>تۆمار کردنی ھەڵبەند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>تۆمار کردنی ھەڵبەند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>تۆمار کردنی ھەڵبەند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>بەھەڵە</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>ھەڵبەندی کە بەرھەم نەدەتەو بەرەو بەرھەم بەرەو بەرھەم بەرەو بەرھەم نەدەت، لەوە بەرھەم بەرەو بەرھەم بەرەو بەرھەم بەرەو بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>بەرھەم بەرەو بەرھەم بەرەو بەرھەم بەرەو بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>تۆمار کردنی نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>تۆمار کردنی ھەڵبەندی</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>بەرەو بەرھەم بەرەو بەرھەم بەرەو بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ئەوە بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>ئەوە بەرھەم نەدەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>تۆمار کردنی ھەڵبەند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>تۆمار کردنی ھەڵبەند</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>تۆمار کردنی ھەڵبەند</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>بە دووستنی دەستگەرەکە نەکردوو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>بە دووستنی بەکارهێنەرەکە نەکردوو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>بە دووستنی بەکارهێنەرەکە نەکردوو: دەستگەرەکە SN بەدەست نەهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>دەرەکەتەکان رەنگەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>دەرەکەتەکان کەن</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>بەرەکەوت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>دەرەکەت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کۆپی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>بەشدارکردن</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>بەرەکەوت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>دەرەکەت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کۆپی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>دەستگەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>دەرەکەتەکان رەنگەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>دەرەکەتەکان کەن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>بەکارهێنەرەکە بە دووستنی کامپیوتەرەکە بەدەر بکات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>بەکارهێنەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>بە دووستنی بەکارهێنەرەکە نەکردوو: دەستگەرەکە SN بەدەست نەهێنراوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>بە دووستنی بەکارهێنەرەکە نەکردوو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>بە دووستنی دەستگەرەکە نەکردوو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>دەرەکەتەکان رەنگەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>دەرەکەتەکان کەن</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>سەبدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>سەبدەڤەیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>دەرەکەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>بەشدارکردنی دەرەکەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>کامانداکەی دەرەکەتەکان بەشدارکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>بەشدارکردنی کۆنفیگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>بەرەکەوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>فیزیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ناویسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>بُس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ئەمەکانی BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ئەمەکانی پەنەرەکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>ئەمەکانی سیستەم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ئەمەکانی چاسس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ئەمەکانی ھەجمنەی ڤەیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>تاریخ پەروەردە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>ئەدەرس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>پەرەمەنەی ڤەیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>پەرەمەنەی ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>ئەیتەریستیکا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ناویسی BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ناویسی فیرمۆرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ناوی ڤروډوکت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>نۆمەری سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>تەگی ئەسەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>ئەیتەریستیکا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ئەمەکانی چاسس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>هەندڵی چاسس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>تیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>هەندڵەکانی چەنەد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>تیپی ڤائک-اپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>نۆمەری SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>خانە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ئەرکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>بەرکەوتوویتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>بەرکەوتوویتی ئەوەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>تەرمەلی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>بەرکەوتوویتی سەكۆریتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>مەلumatی OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ئەرتفاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>تەواوی ئەوەر بەرکەوتوویتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>ئەرەنەکان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ئەرەنە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>تایبەتی تەقەرەری سەرکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ئەکسەری ئەکسەریتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>هەندڵی تەقەرەری سەرکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>تەواوی دەڤیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>بیوس ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاریخ چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ناڤی بۆرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>ڤەرژنی SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>فرمەتی تەرجیمەی زمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>زانانەکانی نیشاندەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>زانانەکانی نیشاندەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>بەرکەوتوویتی BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>تایبەتی پەکەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>پولیسی لینک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>مودی لینک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>کلاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>کلاسەکانی سەرڤیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>کلاسی دیویس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>وێریۆن H.C.I</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>وێریۆن L.M.P</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>سەبدەریۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>دیویس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ئایدی سێریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>پرودۆکت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>تەخمینە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>بەکارهێنراو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>دەکۆشتووە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>بەکارهێنراو بۆ پەیروبکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>مودالیاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>دەکۆشتووە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>مودیولەکانی درایڤر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>فایلی دیویس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>فایلەکانی دیویس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>نەمەری دیویس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>کارکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ستاتوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ناڤێ لۆجیکال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>وێریۆن ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>ئەمپلیمەنتەری CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>ئەرکیتەکتۇری CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>ڤاریانتی CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>پارتی CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>ریڤیژۆنی CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>یەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>دوو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>شەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>هەشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>دوك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>دوات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>چوارت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>شانزەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>هەشتا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>ئیکسان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>ئیکسان دوات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>ئیکسان چوارت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ئیکسان شانزەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ئیکسان هەشتا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>سەکسان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>سەکسان دوات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>سەکسان چوارت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>سەکسان شانزەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>سەکسان هەشتا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>چوارت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>چوارت دوات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>چوارت چوارت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>چوارت شانزەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>چوارت هەشتا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>سەکسان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>سەکسان دوات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>سەکسان چوارت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>سەکسان شانزەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>سەکسان هەشتا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>شانزەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>شانزەت دوات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>شانزەت چوارت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ئەتتى چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>ئەتتى چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>بىر ئىقتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>بىر ئىقتى وە چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>بىر ئىقتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>بىر ئىقتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>بىر ئىقتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>بىر ئىقتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>بىر ئىقتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>بىر ئىقتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>بىر ئەتتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>بىر ئەتتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>بىر ئەتتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>بىر ئەتتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>بىر ئەتتى وە چەكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Yezda kêmî 126</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Yezda kêmî 128</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Yezda kêmî 192</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Yezda kêmî 256</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapasîte GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Peyvandhî GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Tip GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Versiyon EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API-ya EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Versiyon GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Versiyon GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Bilinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Sîlî Hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU ya wî bilinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Bordî Anbar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Bordî anbar ya wî bilinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Pamîry</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Pamîry ya wî bilinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Kurî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Disk ya wî bilinî</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Îşkîrî Driver bişû</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Lû ezmîne ya yekî ya bê şikî û bê rastî</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Îşkîrî Driver bişû</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Adapterê Îşkîrî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU ya wî bilinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Monitor ya wî bilinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>ئەدەپتەر نەتۋورك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>ئەدەپتەر نەتۋوركی نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>ئەدەپتەر سۆند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>ئەۋدیۆ دەۋیسی نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>بلوتوت دەۋیسی نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>ئەرەن PCI دەۋیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>ئەرەن PCI دەۋیسی نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>قۇۋڤە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>بەتەریە نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>کەمبەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>کەمبەر نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>مۇس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>مۇس نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>پرینتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>پرینتەر نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>کامەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>کامەرە نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>ئەرەن دەۋیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>ئەرەن دەۋیسی نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>ئەرەی هەندڵ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>فورم فاکتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>سەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>بەنک لۆکیتۆر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>تایپ دیتەیڵ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>پارت نوۋمەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>رەنک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>مەمۆری ئەکتەنولۆژی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ئەمەندە ھەڵقۇرەتلىرى ئەمەندە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ئەمەندە ئەمەندە ۋەرسين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Module Manufacturer ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Module Product ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Memory Subsystem Controller Manufacturer ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Memory Subsystem Controller Product ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Non-Volatile Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Volatile Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Cache Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logical Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>inch</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>تىن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>تېکىنە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>بەتىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>ئەمەندە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>ئەمەندە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>تېكىنە ھەقىقىتلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تکنولوژî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>نام ئیکون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ئەوە ئۆنلاىن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>ڤەرژىیە ئەیمۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>ئەوە بەتۆمارە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>بەرگە پێکانەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>بەرگە ئەوە دەبێت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>کریتاڵ ئەکسیۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>کۆپى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>جۆب کەلەل کردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>جۆب هۆڵ کردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>جۆب پریۆریتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>مەرکەر چەنچەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>نومبر یو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ئۆریەنتەشن ڕەقەستەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>پرینت کۆرە چۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>پرینتەر ئەوە جۆبەکان بەکاردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>پرینتەر ئەوە شارەدەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>پرینتەر ئەوە تەمپۆرەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>نامە و مۆدل پرینتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>تایم چەنچەوە پرینتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>کاروان پرینتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>تایپ پرینتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>پرینتەر یوآری سەرەکتەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>سایدز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>بەس ئىنفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>لۆجیکال سەکتۆرسایز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>سەکتۆرسایز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>ئەمەندىرىك (لىكىسى)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>ئەگەزى ئىشلىتىشچى</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>ئەگەزى ئىشلىتىشچى ھەردو ھەۋارى ئىنفورمىسىنى گۆشۈۋېتىش ۋە ئەگەزى ئىشلىتىش ئۈچۈن ئىشلىتىشچى</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>ئېڭىن ئىشلىتىشچىلار بار! ئالدىن ھەم ئېڭىن ئىشلىتىشچىلارنى ئۇچرىتىڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>كۆرۈش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>ئىچىدىكى كۆرۈنەرلەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>بۇ يېللىقدا ئىشلىتىشچىلارنى ئىزدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 ئىشلىتىشچى ئۈزگۈرۈشى بار'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'ۋاقىت كۆرۈنگەن: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>بۇ %1 ئۈچۈن ئىشلىتىشچىلارنى چۈشۈرۈۋەتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'چۈشۈرۈش ھەزىمى: %1 چۈشۈرۈلغەن %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>بۇ %1 ئۈچۈن ئىشلىتىشچىلارنى ئۇچرىتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 ئىشلىتىشچى ئۇچرىلىدۇ، %2 ئىشلىتىشچى بىلەن ھەل قىلىنمىدۇ'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 ئىشلىتىشچى ئۇچرىلىدۇ'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ئىشلىتىشچىلارنى ئۇچرىتىشنى باشقاش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>تېكىنى ئەھۋاللىش. ئەھۋاللىشنى تەكىرىتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'چۈشۈرۈش ھەزىمى: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>سىزنىڭ ئىشلىتىشچىلارىڭىز ھەل قىلىنغان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>بەزى ئىشلىتىشچىلارنى ھەل قىلىنغان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 ئىشلىتىشچى، ئۇنىڭنىڭ %2 ئىشلىتىشچىلىرى ھەل قىلىنغان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 ئىشلىتىشچىنى ھەل قىلىشنى ئۇچرىتىشنى ئېھلىتىدۇ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 ئىشلىتىشچىنى ھەل قىلىشنى ئۇچرىتىشنى ئۇچرىتىدۇ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 ئىشلىتىشچىنى ھەل قىلىش، ئۇنىڭنىڭ %2 ئىشلىتىشچىلىرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'ھەل قىلىۋېتىدۇ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 ئىشلىتىشچى ھەل قىلىنغان، %2 ئىشلىتىشچى باشقاش'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ئىشلىتىشچىلارنى ھەل قىلىشنى باشقاش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 ئىشلىتىشچى ھەل قىلىنغان'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 ئىشلىتىشچىنى باشقاش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>بىر ئىشلىتىشچىنى باشقاش ئۈچۈن ئىشلىتىشچىنى تەييارلىغىز</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>درویرەکە دوبارە کەشتووە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>دوبارە کەشتووە: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>بەرگرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>لەبەرگرەوە بەکەشتووە یان %1 بۆ کەشتووەی درویرەکان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>ڕاستەکەی بەکەشتووە ببینە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>بەکەشتووە کۆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>فێدمبک بەکەشتووە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>لەبەرگرەوە بەکەشتووە یان %1 بۆ ما</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>کەشتووە کۆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>بەرگرەوە بەکەشتووە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>پەرەسەنکرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>بەرگرەوە بەکەشتووەی درویرەکانی تەکنیکی، بەکەشتووە بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>بەرگرەوە %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>بەرگرەوە فەیل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>سەرچاونەکە نەدەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>لەبەرگرەوە سەرچاونەکەنی تووشیت بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>لەبەرگرەوە بەکەشتووە یان %1 بۆ ما</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>تووشیت درویرەکە کەشتووە، کەشتووەی درویرەکە لەبەرگرەوە بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>ئەگەر تووشیت بەرگرەوە بەکەرەوە؟</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>بەرگرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>پەرەسەنکرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>تووشیت درویرەکە بەکەشتووە، کەشتووەی درویرەکە لەبەرگرەوە بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>تووشیت درویرەکە دوبارە کەشتووە، کەشتووەی درویرەکە لەبەرگرەوە بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>کۆمەنەکەی بلوتوو</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>دەستگێرەکەی چاپکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>کۆمەنەکەی نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>کارتی سۆندا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>کۆمەنەکەی سەرچاونە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>کۆمەنەکەی سەرچاونە بێسیلی</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>کەشتووەی چەمەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ئەمەسە نەتیجە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>دوانلود کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>ئەنستاڵەسیون کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>ئەنستاڵەسی نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>بەرە وەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>بەرە چاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>بەرە چاک نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>بەرە چاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>بەرە چاک نەتیجە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>بەرە چاک دەتیجە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>بەرە چاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>هەڵەیەکی نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>هەڵەیەکی نەتۋۆرک</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>بەرە چاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ئەمەسە دەریڤەر فایلەکان نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>یەنی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>بەرە چاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>بەرە چاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ئەنستاڵەسیون کردن</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>دیسەبلە کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>نوو کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>ئەکسپورت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>دەریڤەرەکان یەنی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>دەریڤەرەکان ئەنستاڵەسی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>کۆمپیوتەر چاک کردن بەرە چاک کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>ئەنەبلە کردن</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>نۆو کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>ئەکسپورت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>کۆپی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>دیسەبلە کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>بەکارهێنە</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>لە چەندەکانی بەکارهێنەیەوە بەردەوام بکەرەوە</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>بەکارهێنە</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ku_IQ.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ku_IQ.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ku_IQ">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ئەپەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>تەکمە</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>بەرە</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ئەپەرە بۆ نەتۋرەک</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>بەرە دووبارە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>بەرە کۆکردن</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>بەکسیت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>بەکسیت نەدە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ئەتەت ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>تەرجەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>چیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>ئەمکانییەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ئەیەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>ئەیەر دووبارە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>ئەمەنی دەرەزە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>بەکسیت نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>بەکسیت</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>تەرجەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>مەدەل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>تەرجەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ڤەرژەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>چیپست</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>ئەلیاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>وەرەندەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ڤەرژىۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>سەپید</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>پۆواىەکە ئەکەم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ڤەرژىۆنی ڤەرۆیەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ڤەرۆیەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>کەمەسیتەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ئەنچىۆنی بوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>نامی ئەنچىۆنی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>ئەدەرسی MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>بەکەم کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>وەرەندەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>ڤەرژىۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ئەنچىۆنی بوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>کەمەسیتەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ڤەرۆیەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>پۆواىەکە ئەکەم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>سەپید</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>بەکەم کردن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>وەرەندەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ئىدىی CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>ئىدىی کۆر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>تىرەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجومیپس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>ئەرەکیتەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>خانەی CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>پرۆسەسەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>کۆر(ە)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ڤیرتیوالیزاسیۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>فلاگس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>ئەنجامەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>کەشی L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>کەشی L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>کەشی L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>کەشی L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>سەپینگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>سەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>سەری ئەکسی</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>ناڤ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ڤەرژەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>مەمۆری جرافیک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ئیدی فیزیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>ئەدەرسی مەمۆری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>پورتی IO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>ئەنformationی باس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>ئەنکرەسیونی ئەکسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>ئەنکرەسیونی کۆچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>ئەنکرەسیونی ھەڵقە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>دراڤەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>ئەنdescription</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>ئەرە بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>ئەرە بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>توانایەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>ناچالا</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>سەرچاوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>ڤەرسيۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>مودەل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>بۇس ئىنفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>سەرچاوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>ئەگەرە ئەکسەر ڤاىە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>دراۋىر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>توانایەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>سيリアル نومر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>ناچالا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>بەرە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>ناو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>سەرچاوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>مودەل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>ئەرە بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>بۇس ئىنفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>سەرچاوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>ئەگەرە ئەکسەر ڤاىە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>دراۋىر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>توانیه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>وERSION</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>نەدەیە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>بەکارھێنەرە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>تەواوی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>پی سی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>تەواوی پی سی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>بۆردەکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>هەمە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Adapterەکەی دەیسپڵ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Adapterەکەی سۆند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>سەرچاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>ئەو دەڤیسەیەنە PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>بەتەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوتۆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Adapterەکەی نیوتۆک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>مۆس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>کەبۆرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>مۆنیتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>کدی ڕۆم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>پرنتەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>کامەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>ئەو دەڤیسەیەنە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>دەڤیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>سیستەمی ئۆس</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ناڤ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>بەرنە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>تیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>سەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>بەرەت ھۆجەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ئەمەجەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>نەمەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>تەواوەت ڤولتەج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>مەکسیمۆم ڤولتەج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>مینیمۆم ڤولتەج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>تەواوەت سەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>دەتا ھۆجەت</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ناڤ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>تىپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>دەیسپلەی ڤەرگەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ئەنترفېس تىپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>پەرەمەت ڕەزولوشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>کەرەن ڕەزولوشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>دەیسپلەی رەسیۆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>پرایمەر دەیسپلە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>بەرەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>نەمەرە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ناڤ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>ڤەندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>تىپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>ڤەرژەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>بۇس ئىنفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>کەپاسیتىس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>دراڤەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>دراڤەر ڤەرژەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>مەکسیمۆم رەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>نەگۆسیەت رەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>پۆرت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>چندرەکسە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>بەند</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>ئەوەیەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>فۆرمۋەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>دۆپڵەکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>بەرەکسە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ئەوتو نەگۆسیەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>ئەدەressی ئەمەنری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC ئەدەress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ئەدەمەنری ئەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>نەدەیەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>بەکارھێنە</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>ناڤ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>ڤێندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>بەس ئىنفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>ڤەرسیۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>ئىنتۆوت/ئۆوتپوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>ئەمەنری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>ئەوەیەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>دەریڤەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>کەپاسیتیەس</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>ناڤ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>ڤێندور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>مۆدل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>ڤەرسیۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>بەس ئىنفو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ئەمكەرلىك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>درايwer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>توانىیەتى ھەنگە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>سەرچە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>سېریال نوڤر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>بەکار نەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>بەکار نەدە</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>ئەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>مۆدێل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>ڤەندۆر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>سېریال نوڤر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>تىپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>ستاتوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>کەپاسيتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ولتاژ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>سۆت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>ئەرەمە کەپاسيتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>ئەرەمە ولتاژ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>ڤەرسىیۆن SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>سېریال نوڤر SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تىپەرە SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>كىمیاىى SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>تېمپېراتۇرە</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>ئەدە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>مۆدێل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>ڤەندۆر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>سېریال نوڤر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>بەشدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>ستاتوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>تیپ دۆرەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>بەکارهێنەر</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>سەرچاوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>تیپی مادیە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>بەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>وەرگە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>توانایەکان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>وەرگەی فیرمەوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>سێرەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>توضیح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>نومرەی سەریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>دۆرەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>نرخی چەمکاندن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ناکۆبکراو</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>دەریڤەرێک بۆ بەکارهێنەرەوە بەکارهێنەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>هیچ دەریڤەرێک لە ئەم پوتوکەیە نەدۆزراوە</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ئەوە بارکردنەوە لە ئەوە بەرەنە دەرەنەوە...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>ئەوە بارکردنەوە لە BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>ئەوە بارکردنەوە لە CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ئەوە بارکردنەوە لە ئەوە بەرەنە سیستەمی...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>ئەوە بارکردنەوە لە CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>ئەوە بارکردنەوە لە ئەوە بەرەنە دەرەنەکان...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ئەوە بارکردنەوە لە ئەوە بەرەنە کۆمەڵە...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>ئەوە بارکردنەوە لە ئەوە بەرەنە چاپکردن...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>ئەوە بارکردنەوە لە ئەوە بەرەنە چاپکردن...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>ئەوە بارکردنەوە لە ئەوە بەرەنە چاپکردن...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>بەکارهێنەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ناکۆبکراو</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>بەکارهێنەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ناکۆبکراو</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ئەمەکە بەرھەم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>ئەمەکە کوتەکان</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>بەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>کارکوونەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>کۆپی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>سیستەم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ئەگەر کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>نووسیار کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>ئەمەکە ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>هاردوار</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>دراڤەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>مۆنیتور</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>بەرھەم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>دەیسپلەی ئەدapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>نیوتەرک ئەدapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>بەتاری</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>بەرھەم</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ڤلەتەفۆرم دراڤەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>دراۋەر بەکەپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>دراۋەر بەکەپ کردن</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>بەروەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>بەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>پەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>ئەقەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ئەمەکە پسەن دراڤەر ئەوەرکردنەوە بەرەوە بێت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>ئەوەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>ئەوەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>بەروەرکردنەوە سەرکەوتووە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>ئەوەرکردنەوە سەرکëوتووە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>بەروەھەڵکردن دەستکاری دەکات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>نەرخانەکردن دەستکاری دەکات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>بەڵا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>بەتەواو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>ئەمە بۆ ئەمە كاتى بىر گەشە نەدە بارە، دووبارە ئەمە بۆ ئەمە كاتى بىر چۈشىنىڭىز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>بەروەھەڵکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>بەپێچەوانە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>پەکەکە ئەوەیەتەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>پەکەکە ئەرکیتەوە نەدەستکاری دەکات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>ئەمە بۆ ئەمە كاتى بىر فايل نەدە بارە، دووبارە ئەمە بىر فايل چۈشىنىڭىز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ئەوە نەدەروەھەڵکردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>نەدەستکاری دەکات - نەدەروەھەڵکردنەوەی دیجیتالی نەدەستکاری دەکات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>کارەکەیەتەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>مودیلی دەروەھەڵکردنەوە نەدەستکاری دەکات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>فرۆمەتی مودیلی ناچووکە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>مودیلی دەروەھەڵکردنەوە دەبێتەوە نەدەستکاری دەکات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>بەروەھەڵکردنەوەی دەروەھەڵکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>بەکارهێنەری دەروەھەڵکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>بەکارهێنەری دەروەھەڵکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>تەواوکردن</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>دەروەھەڵکردنەوەی دەروەھەڵکردنەوە نەدەستکاری دەکات، دووبارە بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بęکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهێنەری بەکارهiece</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>بىر گەشە كۆرۈڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>ناوەندەوەی بەکارهێنەر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>دەروەھەڵکردنەوەی دەروەھەڵکردنەوە</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>بەروەھەڵکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>چاکەکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>تەواوکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>بەروەھەڵکردنەوەی دەروەھەڵکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>بەکارهێنەری دەروەھەڵکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>بەکارهiece</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>بە دووستنی دەستگیرکردنەوە ناکردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>بە دووستنی دەستگیرکردنەوە ناکردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>بە دووستنی دەستگیرکردنەوە ناکردەوە: دەستگیرکردنەوە یەکەم ناکردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>دەرەجەی چاکەکان بەهۆیەت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>دەرەجەی چاکەکان دەستکاری کردن</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>نێوەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ئەنجام دەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کۆپی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>تەمەم</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>نێوەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ئەنجام دەرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کۆپی کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>دەستگیرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>دەرەجەی چاکەکان بەهۆیەت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>دەرەجەی چاکەکان دەستکاری کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>بە دووستنی کامپیوتەر بەدەر بگرێ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>دەستگیرکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>بە دووستنی دەستگیرکردنەوە ناکردەوە: دەستگیرکردنەوە یەکەم ناکردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>بە دووستنی دەستگیرکردنەوە ناکردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>بە دووستنی دەستگیرکردنەوە ناکردەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>دەرەجەی چاکەکان بەهۆیەت کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>دەرەجەی چاکەکان دەستکاری کردن</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>سەبدەرەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>سەبدەڤایس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>دەرەجە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>دەرەجە چاکەکان دەستکاری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>دەرەجە چاکەکان دەستکاری کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>کۆنفیگ دەستکاری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>کەشکەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>فیزیکی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ناوەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ئەمە بىۆس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>مەبەستى بۆرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>سىستىم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>چاسىس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ئەمە ھەجمەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>تارىخ چاپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>ئەددىس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>بەرەمەن چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>خاسىيەتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>بىۆس چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>فۆرمۋەر چەك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ناوی کۆمەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>سېریال نەمەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ئەسەت تەگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>خاسىيەتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ئەمە چاسىس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>چاسىس هەندڵ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>تىپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>ئەمە ئۆبجېكت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>بەرەمەن تىپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU نەمەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>خانە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>بەکێشەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>هەڵبژاردنی کۆمەڵە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>هەڵبژاردنی کەمەڵە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>حەلەتی گرمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>حەلەتی باری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>مەلیمەتی OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>بەرپەر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>ژمارەی کەمەڵەکانی برق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>ئەمەنەی کۆمەڵە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>مەکان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نەتەوەی تەمەمکردنی خاتە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>مەکسیمم کۆمەڵە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>ئەمەنەی خاتە بەکێشەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>ژمارەی دەڤیسە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>بیۆس ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاریخ چاپکردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>نامی بۆرد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>ڤەرژیونی SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>فۆرماتی تەمەمکردنی زمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>زمانەکانی چاپکردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>زمانی چاپکردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD نامە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>نەتەوەی پەکەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>سیاستی لینک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>مودی لینک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>کلاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>کلاسەکانی خدمەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>کلاسی دیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>ناونه HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>ناونه LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>زیر نونه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>دیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>یدی سریال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>کۆتا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>تەکرارە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>تەواو کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>بەرە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>مودالیاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>تەواو کردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>مودولەکانی دراور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>فایلی دیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>فایلەکانی دیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>ناونه دیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>کارکردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ستاتوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ناونه لۆجیک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ناونه ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>پیمپلەنتری CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>ارکیتیکتوری CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>وەریانت CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>پارت CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>ریڤیژن CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>یەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>شەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>هەشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>نەوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>دوزد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>چوارده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>شەشده</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>هەشتەوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>بیست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>بیست و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>بیست و چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>بیست و شەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>بیست و هەشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>سەکسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>سێکسی و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>سێکسی و چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>سێکسی و شەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>سێکسی و هەشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>چوارتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>چوارتی و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>چوارتی و چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>چوارتی و شەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>چوارتی و هەشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>پێنجتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>پێنجتی و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>پێنجتی و چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>پێنجتی و شەش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>پێنجتی و هەشت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>سەکسیتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>سەکسیتی و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>سەکسیتی و چوار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>ئەتىيەتى چەک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>بىر ى百分</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>بىر ى百分 و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>بىر ى百分 و چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>بىر ى百分 و شىز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>بىر ى百分 و ھەت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>بىر ى百分 و دەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>بىر ى百分 و ھىزىن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>بىر ى百分 و چارتكەن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>بىر ى百分 و ھىزن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>بىر ى百分 و ھىزن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>بىر ى百分 و چەكىن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>بىر ى百分 و چەكىن و دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>بىر ى百分 و چەكىن و چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Yezdîn û Yekîzîn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Yezdîn û Dîwazîn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Yezdîn û Nînîzîn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Dîwazîn û Pêncîzîn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapasîteya GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Peyvandî GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Tîpa GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Versiyona EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API-ya client EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Versiyona GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Versiyona GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Guhî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Tîpa rêjî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU ne bû</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Bordîya anî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Bordîya anî ne bû</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Rîyek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Rîyek ne bû</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Rûpel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Rûpel ne bû</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Îşê destûrînî ne bû!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Lûftîne dûrîn û yekî dîsa bîrê dîsa</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Îşê pêncîrînî ne bû!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Adapterê dîsplay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU ne bû</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Monitor ne bû</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Adapterêya Werend</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Adapterêya Werendî Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Adapterêya Sond</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Wêjeyî Audio Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Wêjeyî Bluetooth Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Wêjeyî PCI Din</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Wêjeyî PCI Din Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Kuvveta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Baterî Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Klavya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Klavya Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mîs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Mîs Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Printer Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Kamera Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Wêjeyî Din</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Wêjeyî Din Gotinî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Handleya Array</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Form Factor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Set</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bank Locator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Type Detail</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Part Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Teknologiya Bawerî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ئەمەندە چەک گەڕاندنەوەی ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ناوەندی فرمۋېر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ئەیدان چەک ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ئەیدان چەک ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ئەمەندە چەک ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ئەمەندە چەک ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>چەک ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>ئەمەندە چەک ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>بەرگە چەک ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ھەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>ئینچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>تاریخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ئیوپۆرت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>ناوەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>بەتارى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>ناوەندی پات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>بەرەنەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>بەرواردن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>تەرەنەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>تەرەنەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>بەرەنەری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>هەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>هەڵبەندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ئەنرژی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ئەنرژی کەم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ئەنرژی ھەلکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ئەنرژی ھەلکە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ئانرژی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>ڤۆلتەج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>پەرەنسیج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تکنولوژî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>adana-name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>dîyan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>versiyona-daemon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>baterî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>tîrêkî dîs qîrîn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>tîrêkî dîs qîrîn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>dîstîrînî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>dîstîrînî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>dîstîrînî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>dîstîrînî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>wîkîlî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>nûmera-up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientasyona tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>moda tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer dîs tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer dîs tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer dîs tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer dîs tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>wîkîlî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>wîkîlî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>tîpî tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>uri tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>tîrêkî</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logicalsectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>ئەیتى (لۆجىكى)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>تەکىلى ئەمەن</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>تەكىلى ئەمەن ھاردوۋار ئىنformationىنى كۆرۈش ۋە تەكىلى ئەمەنلىرىنى بىلەن ئىشلەتىش چۈشىنىشلىرى چوڭ ئۇچۇت</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>ئېڭىن دېۋىسلىرى ھازىردا مۇھىتىن! ئۇنى ئۈستۈن چېكىنىش ۋە يېڭىلاشنى ھازىردا بىلەن ئىشلېتىڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>كۆرۈش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>ئىچىدىكى كىتابخانىلىرىنى ئەپەت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>بۇ يېلنىڭ ئىچىدىكى دېۋىسلىرىنى ئىزدە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 دېۋىسلىرى يېڭىلاش مۇمكىن'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'ۋاقىت تەكىسى: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>بۇ %1 چۈشىنىشلىرىنى يۈكلىۋېتىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'يۈكلىش سۈرەتى: %1 يۈكلىنگەن %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 چۈشىنىشلىرىنى ئۈستۈن چېكىنىدۇ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 دېۋىسلىرى ئۈستۈن چېكىنگەن، %2 دېۋىسلىرى باشقا'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 دېۋىسلىرى ئۈستۈن چېكىنگەن'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>دېۋىسلىرىنى ئۈستۈن چېكىنىش مۇھىتىن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>'يۈكلىش سۈرەتى: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>سىزنىڭ دېۋىسلىرىڭىز ھازىردا ھۆجوملىنىشقا تىيىدۇ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>بەزى دېۋىسلىرى ھازىردا باشقا قىلغان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>%1 دېۋىسلىرى بار، ئۇلارنىڭ %2 ھازىردا باشقا قىلغان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 دېۋىسلىرى باشقا قىلىنىشى مۇمكىن، ئۇنى ھەققىدە ئۇچۇت قىلىش چوڭ ئۇچۇت</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 دېۋىسلىرى باشقا قىلىنىشى مۇمكىن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 دېۋىسلىرىنى باشقا قىلىدۇ، ئۇلارنىڭ %2 ھازىردا باشقا قىلغان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>'بىلەن باشقا قىلىدۇ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'%1 دېۋىسلىرى باشقا قىلغان، %2 دېۋىسلىرى باشقا قىلىمىدۇ'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>دېۋىسلىرىنى باشقا قىلىش مۇھىتىن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>'%1 دېۋىسلىرى باشقا قىلغان'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 دېۋىسلىرلىرى باشقارۇشى مۇمكىن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>بىر دېۋىسلىرىنى باشقارۇش ئۈچۈن ئەپەت تەكىسى</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>بىر چۈشىنىڭىزنى باكەپ دىرەۋى بىلەن دووبارە كۆرۈڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver bi şikilîn...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Şikilîn: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>بەرگرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>لەوانە %1 بۆ ئەوە دەرکەوتوانە کە چاک کردنەوەی ڕەوانەکان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>بەکاربەرەوەی ڕەوانەکان</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>بەکاربەرەوەی هەموو</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>ئەرەپەنەکانی دەرکەوتوانە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>لەوانە چەک کەرەوە یان %1 بۆ ئەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>چاک کردنەوەی هەموو</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>بەرەوە چەک کەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>پەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>بەرەوە چەک کەرەوە بۆ ڕەوانەکانی ڕەشەتەکان، لەوانە کەرەوە...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>بەرەوە چەک کەرەوە %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>بەرەوە چەک کردنەوە گەڕاوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>نەتڤورک نەدەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>لەوانە چەک کەرەوە نەتڤورکی ئەتە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>لەوانە چەک کەرەوە یان %1 بۆ ئەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>توانە دەرکەوتوانە کە چاک کردنەوەی ڕەوانەکان گەڕاوە بەرەوە کەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>توانە دەرکەوتوانە کەرەوە چەک کەرەوە؟</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>بەرگرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>پەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>توانە دەرکەوتوانە کە بەکاربەرەوەی ڕەوانەکان گەڕاوە بەرەوە کەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>توانە دەرکەوتوانە کە چاک کردنەوەی ڕەوانەکان گەڕاوە بەرەوە کەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>بلاتوت چاککردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>چاککردنەوەی ئەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>چاککردنەوەی نمایش</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>چاککردنەوەی سۆن</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>نەتڤورک چاککردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>نەتڤورک بێسەرکەوتنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>چاک کردنەوە گەڕاوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ئەستەنکردنەوە دەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>دوانلۆد کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>ئەستەنکردنەوە کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>ئەستەنکردنەوە نەدەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>بەروەرەوە نەدەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>کەش کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>بەکەرەوە نەدەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>بەکەرەوە کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>بەکەرەوە دەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>بەکەرەوە باش نەدەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>بەرەوە کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>کەمکەرەوە بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>کەمکەرەوە بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>بەکەردنەوە دەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>دەریڤەر فایلەکە دەربوون</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>بەروەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>بەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ئەستەنکردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>بەکەردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>نوو کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>ئەگەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>دەریڤەر بەروەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>دەریڤەر بەکەردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>کومپیوتەر بەکەردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>بەکەردنەوە</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>نەو کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>ئەگەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>کۆپی کردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>بەکەردنەوە</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>بەکارهێنە</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>لە فولدری کۆمەڵەکان بەکارهێنە</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>بەکارهێنە</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ky.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ky.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ky">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Бағалау</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Түгә</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Күп</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Электрондык хабарлау</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Қайта инсталляция</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Күп</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Жылың</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Түгә</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Қоллоң</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Төҙөө аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Төҙөөчө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Чип</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Мөмкиндәр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Путь</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Ревизия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Ядро режимы драйверы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Мәмәртә адресы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Қоллоң</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Түгә</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Төҙөөчө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Төҙөөчө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Чипсет</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Алиас</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Иркет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Ныгы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Тыны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Максималды қуат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Драйвер ныгы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Мүмкіндіктер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Бус маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Логикалык ат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC манзили</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Колдонуу үстөнө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Таськалоо</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Ат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Иркет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Ныгы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Бус маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Мүмкіндіктер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Максималды қуат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Тыны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Колдонуу үстөнө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Таськалоо</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Ат</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Иркет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>Көрсөткү ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Төгөнөлөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Төҙөлгөндер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>БогоМИПС</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Архитектура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Семейство CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Процессор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Ядро(а)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Виртуализация</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Флаги</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Расширения</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Кэш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Кéш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Кэш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Кэш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Шаг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Скорость</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Максимальная скорость</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Тираж</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>График Қызмети</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Физикалыҡ ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Мемори Қайтарылышы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Бус Инфо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Максималдыҡ Разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Минималдыҡ Разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Барлыҡ Разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Тavsý</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>چыгышты өйкөтөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Экран өйкөтөрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Мүмкүнчөлөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Колдонуу үчүн мүмкин эмес</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Ат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Сатыкчы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Берүүнөн үзгөрүү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Жүйө өйкөтөрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Тездүүлөгү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Эң үлкөн қуат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Мүмкүнчөлөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Сериялык һан</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Колдонуу үчүн мүмкин эмес</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Жеткеләйт</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Ат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Сатыкчы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Байланыш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Жүйө өйкөтөрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Тездүүлөгү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Эң үлкөн ток</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Мүмкүнлөктөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Берүү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Күпкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Тартып өлөө</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Көрүнүү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>Процессор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Процессордун саны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Анықтама</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Мемория</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Көрсөткүч адаптатор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Сезгі адаптатор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Сақтау</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Башка PCI өнөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Батарея</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Жалын адаптатор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Мышка</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Клавиатура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Принтер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Башка өнөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Өнөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>Операциялык жүйө</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Төгөө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Көлөм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Түрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Тездүүлүгү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Жалпы үлгө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Тапшыруу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Серийдик нөмөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Тапшырылған көлөм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Максимал көлөм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Минимал көлөм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Тапшырылған тездәм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Мәләмәт үлгө</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Салыҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Төрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Көрсәтілгән кірү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Аралаштыруу төрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Төзөлөшөнөн чыгыш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Алдыңғы чыгыш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Көрсәтілгән өлкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Баш көрсәткіч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Көлөм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Серийдик нөмөр</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Салыҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Төрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Бус маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Мөмкиндіктер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Драйвер версиясы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Максимал һыҙыҡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Аңыҡтау һыҙығы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Порт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Мультикаст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Сувалга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Кырчылыгы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Фирмвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Дуплекс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Броадкаст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>АвтоНеготиация</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Мемориялык Адрес</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Адрес</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Логикалык Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Куллануу өмөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Дизэбле</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Салыкча</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Бус Инфо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Кире/Чыгы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Мемория</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Кырчылыгы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Мумкиндиктер</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Салыкча</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Бус Инфо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Мүмкүнлөктөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Максималдык үчөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Тездөө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Серийный номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Күпчөлөнбөө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Тартып өтөр</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Ат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Салынғыч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Серийный номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Түр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Дүйнөлөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Көлөм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Электр үчөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Слот</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Түзүлгән көлөм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Түзүлгән үчөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS нөктеләре</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS серийный номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS өйрөнү өнө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS химия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Температура</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Ат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Салынғыч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Серийный номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Бөткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Дүйнөлөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Аралаштыруу типи</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Активкалоо</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Тааныч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Медия типи</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Көлбүрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Мүмкүнчөлөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Фирмвар Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Тыяна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Түшүндүрүү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Серийлүү нөмөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Аралаштыруу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Турлануу ылдамдыгы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Колдонуу мүмкин эмес</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Жаңыртуу үчүн драйверди тандаңыз</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Бул папкада драйвер таптылым</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Аудио ылдамдыгын өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>BIOS өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>CD-ROM өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Жүйе өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>CPU өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Башка өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Энергия өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Принтер өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Түшүнүү өңдөө...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Жалогылар өңдөө...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Активкалоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Колдонуу мүмкин эмес</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Активкалоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Колдонуу мүмкин эмес</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Төҙөлгөн маълумат</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Кыскалтын көрсөтүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Жабуу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Ярдам</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Көчүрүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Экспорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Яңылау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Төҙөлгөн үзгөртүүчөлөр</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Машиналыق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Драйверлар</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Көрсөтүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Көрсөтүү үзгөртүүчөсү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Телекоммуникация үзгөртүүчөсү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Батарея</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Көп</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Драйвер платформасынин номерин</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Сақлауға болгон драйверлар</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Сақланган драйверлар</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Жаңылау</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Баш тартуу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Кийинки</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Эскертеу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Драйверды алып тартып, төҙөлгөн үзгөртүүчө эркин эмес</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Алып тартуу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Алып тартылуу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Жаңылау муайыш</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Алып тартуу муайыш</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Жаңылаштыру үйләнбеде</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Чығару үйләнбеде</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Барабазы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Кийенки</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Танланган папка мөнәсәбәтсез, таңдап ҡуйынғыҙ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Жаңылаштыру</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Алдынғы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Бәрәнгән пакет</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Тапшырылмаған пакет архитектураһы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Танланған файл мөнәсәбәтсез, таңдап ҡуйынғыҙ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Был драйвер түгел</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Ҡуйыуға мөмкин түгел - дигиталь ҡулыҡ булмаҫҡа</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Белгесеҙ хата</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Драйвер модулы табылмады</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Тырыулы модуль форматы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Драйвер модулы бәхәттәре бар</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Драйвер ҡуйыу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Драйвер ҡабырғаһы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Драйвер ҡайтарыу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Тикшереү</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Ҡайтарыу өсөн драйверҙарың юҡ, ҡабырғаға ҡуйыуҙан өйрән</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Ҡабырғаға ҡуйыуға барырға</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Ҡабырғаға ҡуйылған нәҫлә</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Ҡайтарылырға мөмкин драйверҙар</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Түҙәтеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Экспорт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Күҙәтеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Драйвер ҡуйыу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Драйвер ҡабырғаһы</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Драйвер ҡайтарыу</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Төҙөө үткәрмәй ҡалды</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Төҙөө үткәрмәй ҡалды</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Төҙөө үткәрмәй ҡалды: ҡұрылғы SN һыҙыҡтан алынмай ҡалды</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Драйверҙарҙы ҡабул итеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Драйверҙарҙы ҡайтарып әләт</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Төҙәтеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Импорт итеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Күчереү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Күренеш</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Төҙәтеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Импорт итеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Күчереү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Төҙәтеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Драйверҙарҙы ҡабул итеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Драйверҙарҙы ҡайтарып әләт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Ҡомпьютерҙы ҡына һыҙыҡтан алып ҡуйырға рәхмәт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Төҙәтеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Төҙөө үткәрмәй ҡалды: ҡұрылғы SN һыҙыҡтан алынмай ҡалды</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Төҙөө үткәрмәй ҡалды</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Төҙөө үткәрмәй ҡалды</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Драйверҙарҙы ҡабул итеү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Драйверҙарҙы ҡайтарып әләт</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Иҫтәләткәр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Иҫтәләткәр ҡұрылғы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Драйвер һыҙыҡтары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Драйвер әрәкәтләнеш ҡомаҡы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Конфигурация һыҙыҡтары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>Тәртип буйынса</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Физик</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Бус</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>БИОС маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>База платы маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Система маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Чассис маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Физикалык мемория массивы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Шығару күнү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Манзил</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Жүзөөлөө өлчөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM өлчөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Сипаттары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>БИОС өзгергендиги</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Фирмвара өзгергендиги</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Продукт аты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Серийный номер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Активтын теги</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Функциялар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Чассис өзөндөгү манзил</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Чассис өзөнө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Түрү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Контейнерленген объект өзөнө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Түшүү типи</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU номери</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>ئائىلىق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>كىلىش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Бут-ап Статусу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Энергия Күзәтәм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Термал Статусу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Безопарынлыق Статусу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM Маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ئېлچىلىق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Энергия ھۆلۈكىسىنىڭ саны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Иچىنде ھەлە</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>مۇنداق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>ھەتا ھەлەسىن ئۈرۈنۈش تىپى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ئەڭ كۆپ ئەھۋال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>ھەتا ھەلەسىن ئېھۋال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>ئۈسكۈنەلەر سانى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>چыغыش تارىخى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>پەن ئۈسكۈنى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS نەشىرلىكى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>تىل ئېھۋاللىقى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>ئالماشتۇرۇش تىلى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>ھازىر ئالماشتۇرۇلغان تىل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD ئېھۋالى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>پاكېت تىپى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>بۇلۇنۇش ھەققىدا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>بۇلۇنۇش تىپى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>سىنىف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>سىنىفلار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Жүрөктөр класы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI номары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP номары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Субверсия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Жүрөктөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Серийный ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>өнөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>сүрөт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Түзөлгөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Таң күрөнүү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Жүрөктөрдү биргелеткен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Модалия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Таң күрөнө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Драйвер модулдер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Жүрөктөр файлы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Жүрөктөр файлдары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Жүрөктөр номары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Барака</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>статус</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>логикалык ат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansi номары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU ишке ашыргычы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU архитектура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU варияция</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU бөлүгү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU биримин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Бир</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Эки</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Төрт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Алты</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Сегиз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Төнө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Яңы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Ирки</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Төрт һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Сегиз һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Икки һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Икки һәм өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Икки һәм өч һәм өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Икки һәм өч һәм өч һәм өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Икки һәм өч һәм өч һәм өч һәм өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Өч һәм өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Өч һәм өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Өч һәм өчу һәм өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Өч һәм өчу һәм өчу һәм өчу һәм өчу һән өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Төрт һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Төрт һән өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Төрт һән өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Төрт һән өчу һәм өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Төрт һән өчу һәм өчу һәм өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Төрт һәм өч һәм өч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Төрт һәм өч һәм өч һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Төрт һәм өч һәм өч һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Төрт ҺӘН өчу һАМ өчу һАМ өчу һАМ өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Төрт һән өчу һәм өчу һәм өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Икки һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Икки һәм өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Икки һәм өчу һәм өчу һәм өчу һәм өчу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Сексен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Сексятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Семьен</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Семьятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Семьятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Семьятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Семьятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Сегиз</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Сегизятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Сегизятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Сегизятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Сегизятын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Тын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Тын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Тын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Тын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Тын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Бир йөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Бир йөл ва Төкөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>126</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>128</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>192</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>256</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR сыйымы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU өкөлөө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU төрөө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL номы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL клиент APIлары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL номы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL номы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Билдирilmey</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Уник</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Техника классы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>CPU табылбай</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Аныҡ үткәзгіч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Аныҡ үткәзгіч табылбай</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Эмнә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Эмнә табылбай</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Сақлау</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Диск табылбай</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Драйвер қайта өсөрөө үзгәртілді!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Берілгән ҡылыу үзгәртің әлбеттә әҙерләгән ҡылыуҙы үҙеңдән өсөрөө</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Драйвер үҙеңдән сақлау үзгәртілді!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Түшән үзгәртә</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU табылмады</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Монитор табылмады</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Телекоммуникация адаптеры</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Телекоммуникация адаптеры табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Дыбыс адаптеры</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Дыбыс құрылғысы табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Bluetooth құрылғысы табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Башҡа PCI ҡұрылғылары</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Башҡа PCI ҡұрылғылары табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Энергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Батарея табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Клавиатура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Клавиатура табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Мыш</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Мыш табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Принтер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Принтер табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Камера табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Башҡа ҡұрылғылар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Башҡа ҡұрылғылар табылган</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Массив өлөшөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Форма факторы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Ҡушыу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Банк өҙәге</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Төр детале</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Төп һан</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Ранк</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Алмас технологияһы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Меморияны үйрөө өлөмү үмөтөсү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Фирмвара версиясы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Модуль өйрөөчү ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Модуль өнөктөөчү ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Меморияны үйрөө өлөмү контролерин өйрөөчү ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Меморияны үйрөө өлөмү контролерин өнөктөөчү ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Сақталған өлөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Түрлөөлүү өлөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Кэш өлөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Логикалық өлөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>инч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Күн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>жыныс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>батарея</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>энергия өткөрүү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>жаңылаштырылған</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>тарихы бар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>статистикасы бар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>тазаланатын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>күй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>ээләт өлөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>энергия</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>энергия түгел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>энергия толуу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>энергия толуу дизайн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>энергия өлөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>жылуу</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>процент</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>техника</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>иконанысы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>онлайн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>демон версиясы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>акумуляторда</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>қапқын қылын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>қапқын қылын</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>жылдам әрекет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>нуска</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>жоба өткөннөн кийин өлтөрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>жоба өткөннөн кийин өлтөрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>жоба өткөннөн кийин өлтөрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>мәркәр өзгөрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>саны</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>жүзгө өзгөрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>жанын өзгөрө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>жобалар қабыллана</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>төстөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus маълуматы</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>логикалык сектор өлчөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>сектор өлчөмү</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>айд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Геометрия (Логика)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Тауық үйләп үлгісі</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Тауық үйләп үлгісі - тауықтың үйләп үлгісін қарау үшін әрі тауықты басқару үшін қолайлы арнайы құрал</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Жаңа драйверлер бар! Қазір оларды орнатыңыз немесе жаңартыңыз</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Көрсету</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Алтын папкаларды кіргізу</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Бұл жолда драйверлерді іздеу</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>%1 драйвер жаңарту бар</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>Тексерілген уақыт: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 үшін драйверлер жүктелуде...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>Жүктеу жылдамдығы: %1 Жүктелген: %2/%3</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 үшін драйверлер орнатылуда...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>%1 драйвер орнатылды, %2 драйвер қателесті</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>%1 драйвер орнатылды</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Драйверлер орнату мүмкін емес</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Жалық қателескен. Қайта қосылып жатыр...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>Жүктеу жылдамдығы: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Сіздің драйверлеріңіз жаңартылған</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Барлық драйверлер жедел құралға алынды</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 драйвер бар, оның ішінде %2 драйвер жедел құралға алынды</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 драйвер жедел құралға алынады, оны қайта құралға алу үшін тіркесіңіз</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 драйвер жедел құралға алынады</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 драйверді жедел құралға алу, барлығы %2 драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>Жедел құралға алу: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>%1 драйвер жедел құралға алынды, %2 драйвер қателесті</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Драйверлер жедел құралға алу мүмкін емес</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 драйвер жедел құралға алынды</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 драйвер қайта қосылуға болады</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Қайта қосу үшін драйверді таңдаңыз</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Драйвер қайта қосулып...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Қайта қосу: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>қайта ишке қосу</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Инсталланган драйверлар әсер қылып қалу үчүн, қайта ишке қосуңыз</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Сақлашуу жолу көрсөт</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Барлығын сақла</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>түзүүлөрдө үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Биринчи үзгөртүүн үзгөртүү үчүн қайта тырышыңыз, әлбетте %1 үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Барлығын инсталла</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Биринчи үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Батал</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Жарау үзгөртүүлөрдө үзгөртүү, үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Үзгөртүү %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Үзгөртүү үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Тармак үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Тармак үзгөртүүн үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Биринчи үзгөртүүн үзгөртүү үчүн қайта тырышыңыз, әлбетте %1 үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Сиз драйвер инсталла қилып, үзгөртүүн үзгөртүүн үзгөртүү үчүн үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Сиз үзгөртүүн үзгөртүүн үзгөртүү үчүн үзгөртүүн үзгөртүү?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Чыгыңыз</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Батал</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Сиз драйверларды сақла қилып, үзгөртүүн үзгөртүүн үзгөртүү үчүн үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Сиз драйверларды қайта қосу қилып, үзгөртүүн үзгөртүүн үзгөртүү үчүн үзгөртүүн үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth адаптери</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Рәсмий құрылғы</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Экранны адаптери</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Сезімдік карта</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Тармак адаптери</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Сезімдік тармак адаптери</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Инсталла үзгөртүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Тапшырмалар ортосунда өткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Жүклоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Тапшырмалар ортосунда өткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Тапшырмалар ортосунда өткөн эмес</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Жаңылаштырылган эмес</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Күтүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Сақтоо үчүн өткөн эмес</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Сақтоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Сақтоо үчүн өткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Сақтоо муваффақияттүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Кайта өткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Белгисиз қате</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Жалоо қате</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Бүтүрүүлөнгөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Драйвер файлдарын алуу үчүн өткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Жаңылаштыруу</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Сақтоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Кайта өткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Тапшырмалар ортосунда өткөн</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Жеткөнөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Яңылоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Экспорттоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Драйверди жаңылаштыруу</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Драйверди өчүрүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Эмне үчүн компьютерди үзүнөн өткөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Активлаштыруу</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Яңылоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Экспорттоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Көчүрүү</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Жеткөнөн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Мәлүмәт бармайты</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Кийинки ҡатнашты ҡушыңыз</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Яуап алып барылы</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_lt.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_lt.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>Gerai</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Ataskaita</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Gerai</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Daugiau</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Sukurkite</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Daugiau</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Daugiau</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Sukurkite</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Daugiau</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Sukurkite</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Įrenginio pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Pareigos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Galimybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Modulio pseudonimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fizinis ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_cheminius_kelius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Aprašymas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revizija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Atminties adresas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation> nepasiekamas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Liepkalnis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipsetas</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Liepkalnis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modelis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Modulio prieinamasis pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fizinė ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Didžiausias energijos riba</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Kūrėjo versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Kūrėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Galimybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Bus informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Loginė pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC adresas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation> nepasiekamas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Liepkalnis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modelis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Tarpinio informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Galimybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Valdiklis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maksimalus energijos uždarymas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Modulio pseudonímasis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fizinis ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation> neprieinamas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Liepkalnis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Kraštinės ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Sąsają</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Architektūra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU šeima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modelis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Procesorius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Kuršis(ai)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualizacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Žymi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Papildymai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 Cachė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Cachė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Cachė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Cachė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Cachė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Maksimalus greitis</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation> vardas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Tiekėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modelis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation> Grafikos atmintis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Modulio pseudonimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fizinis ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Atminties adresas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO portas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Bus informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maksimalus rezolūcijos dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Minimumus rezolūcijos dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Daugiausia naudojama rezolūcijos dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Trenkaris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Aprašymas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Digitali iešklė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Ekraninė iešklė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Galimybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation> nepasiekiamas</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Tiekėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modelis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Tinklo informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Modulio prieinamasis pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fizinis ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maksimalus energijos riba</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Trenkaris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Galimybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Serie numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation> nepasiekiamas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Tiekėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modelis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interfeisas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Bus Informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Modulio Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fizinis ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Maksimalus tarpas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Tulėtis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Galimybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation> neprieinamas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Peržiūra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>CPU kiekis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Materijaline konsolė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Atmintis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Vidinė atvaizduotojo karta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Vidinė garsos karta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Storijos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Kiti PCI įrenginiai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Akumulerricka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Tinklų konektoriaus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Mygtuvas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Klaviatūra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitorius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Spausdininkas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Kiti įrankiai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Įranga</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>Sistemos programos</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Pardavėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Viso plotis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Naudotojo narys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Serie numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Nustatytas tūris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Maksimalus tūris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Minimalus tūris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Nustatytas greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Duomenų plotis</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Laikus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Atvaizdavimo įvestis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Interfešo tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Galutinė išspėjimo resoliucija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Dabartinė resoliucija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Atvaizdo santykis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Pagrindinis monitorius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation> dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Serialinis numeris</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Laikus</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Tipas</translation>
     </message>
@@ -1115,32 +1065,32 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>Vėlė</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
         <source>IP</source>
-        <translation type="unfinished"/>
+        <translation>IP</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
         <source>Firmware</source>
-        <translation type="unfinished"/>
+        <translation>Firmūra</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
         <source>Duplex</source>
-        <translation type="unfinished"/>
+        <translation>Dupliksas</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
         <source>Broadcast</source>
-        <translation type="unfinished"/>
+        <translation>Raidymas</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
         <source>Auto Negotiation</source>
-        <translation type="unfinished"/>
+        <translation>Automatinės sutarties</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
@@ -1203,7 +1153,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
         <source>Input/Output</source>
-        <translation type="unfinished"/>
+        <translation>Įvedimas/Įvykdymas</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
@@ -1218,7 +1168,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>Vėlė</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Tiekėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Medių tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Plotis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Galimybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Modulio prieinamasis pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fizinis ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmware versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Aprašymas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Serieškio numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interfazas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Rotacijos greitis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Neprieinamas</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Pasirinkite atnaujinimo tarnyba</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Šiuo katalogu nerasta jokių tarnybių</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Carčiuoklės informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Operacinio sistemos informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>CPU informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Kitų įrenginių informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Power informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Tipografinės įranga informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Mygtuko informacijos įkėlimas...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Tinklo pristatymo prietaškio informacijos įkėlimas...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation> nepasiekiama</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation> nepasiekiama</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Įrenginio informacija</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Rodyti žymyksetis</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Uždaryti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Pagalba</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopijuoti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistemos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Eksportuoti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Atnaujinti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Įrenginių tvarkyklė</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Užduotys</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Vidinės įrangos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitorius</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Pagrindinis ekranas</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Piktogramos atvaizdavimo įrašas</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Tinklo įrašas</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Akumulieras</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Daugiau</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Esama versija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>Vidinės įrangos platformos versija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Būsena</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Veiksmas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Galimi atsarginiai kopijavimas vidinės įrangos</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Atsargiai kopijuotos vidinės įrangos</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Atnaujinimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Atšaukti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Kitas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Įspėjimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Užduotis bus neprieinama po įrangos atsaiminimo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Atsaiminti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Atsaiminimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Atnaujinimas sėkmingas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Atsaiminimas sėkmingas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Atnaujinimas nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Išėmimas nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Gerai</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Kitas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Esamo katalogo nėra, pasirinkite dar kartą</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atnaujinimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Ankstesnis</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Nepakankamai išplėstas paketas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Nesutampa paketo architektūra</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Esamo failo nėra, pasirinkite dar kartą</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation> tai nėra spalėtojas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Nepavyko įdiegti - neturi elektroninės署名</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Nežinomas klaida</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Nenorėtas spalėtojo modulis nerastas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Neteisingas modulio formatas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Spalėtojo modulis turi priklausomus elementus</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Įrenginio pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Galima versija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Dėl</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Statusas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Veiksmas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nauja versija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Esama versija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Trūkstamos spalėtos (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Atgalinti spalėtos (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Naujausi sürüjai (%1</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>Sürjų įdiegimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>Sürjų kopija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>Sürjų atkūrimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>Gerai</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Atsiliepimas</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Nėra atkurti galimybių, atsisiųskite pirmąja metodu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Peršokti į atsisiuntimą</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation> dabartinė versija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>kopijos versija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Veiksmas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Atkuriamos surijos</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Atnaujinti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Eksportuoti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Sumažinti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Sürjų įdiegimas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Sürjų kopija</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Sürjų atkūrimas</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Neįmanoma įjungti įrenginį</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Neįmanoma išjungti įrenginį</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Neįmanoma išjungti: negalima gauti įrenginio SN</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Atnaujinti surijas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Ištrinti surijas</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Atnaujinti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Eksportuoti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopijuoti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Aprašymas</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Įgalinti</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Leisti jį atjungti kompiuterį</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Nepavyko išjungti: negrįžtamas įrenginio ID</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Nepavyko išjungti įrenginio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Nepavyko įgalinti įrenginio</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Atnaujinti paveikslėlius</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Ištrinti paveikslėlius</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>Subproducentas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>Subpristatytas įrenginys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Paveikslėlis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Paveikslėlio būklė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Paveikslėlio aktyvuoti komanda</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Konfigūravimo būklė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>Užsėkimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fiziniai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Kontroluotojai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KLAVS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Busas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Pagrindinė kortelė informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Sistemos informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Kontejaro informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Fizinis atminties massivis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Išleidimo data</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adresas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Veikimo dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Savybės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS atnaujinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware atnaujinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Produktas pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Serie numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Asset žymė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Funkcijos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Kontejaro vieta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Kontejaro adresas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Apimokytų objektų manipuliacijos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Vakaro paleidimo tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Familija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Užluklas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Įkaininės statusas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Elektrinės energijos tinklelis statusas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Temperatūros statusas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Saugos statusas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Aukštis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Jungtinės vystuoliai skaičius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Apimokti elementai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Vieta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Klaidų korekcijos tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maksimalus dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Klaidų informacijos manipuliacijos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Įrenginių skaičius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Išleidimo data</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Kontroluotojo pavadinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Kalbos aprašymo formatas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Nustatomi kalbos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Esaminuota kalbos kalendorius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD adresatas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Paketo tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Nuorodos politika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Nuorodos režimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Klase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Paslaugos klasės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Įrenginio klasė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Įrenginys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Seriavietės ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>Produktas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>Aprašymas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Galvotas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Išklinkiamas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Paieškos priemonės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Išklinkamas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Kontroluotojo moduliai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Įrenginio failas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Įrenginio failai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Įrenginio numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplikacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>statusas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>loginis vardas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansi versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU impleментuotojas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU architektūra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU variantas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU dalis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU atnaujinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Vienas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Devyni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dviejų šimtų</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Sekmidesimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Sekmidesimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Sekmidesimt aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Penkiasdešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Penkiasdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Penkiasdešimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Penkiasdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Kilpkadantas aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trisdešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trisdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trisdešimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Trisdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trisdešimt aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Kvadrantas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Kvadrantas du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Kvadrantas keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Kvadrantas šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Kvadrantas aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Penkiasdešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Penkiasdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Penkiasdešimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Penkiasdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Penkiasdešimt aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Šešiasdešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Šešiasdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Šešiasdešimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Šešiasdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Šešiasdešimt aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Septyniasdešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Septyniasdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Septyniasdešimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Septyniasdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Septymerši šimtas aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Aštuoniasdešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Aštuoniasdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Aštuoniasdešimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Aštuoniasdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Aštuoniasdešimt aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Devyniasdešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Devyniasdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Devyniasdešimt keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Devyniasdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Devyniasdešimt aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Vienuolika šimtų</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Vienuolika šimtų du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Vienuolika šimtų keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Vienuolika šimtų šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Vienuolika šimtų aštuoni</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Vienuolika šimtų dešimt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Vienuolika šimtų dvylika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Vienuolika šimtų keturiolika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Vienuolika šimtų šešiolika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Vienuolika šimtų aštuoniolika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Vienuolika šimtų dvylikas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Vienuolika šimtų dvylikas du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Vienuolika šimtų dvylikas keturi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Vienuolika šimtų dvylikas šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Vienu šimtų ir šešiasdešimt aštunti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Vienu šimtų ir devyniasdešimt du</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Dviem šimtų penkiasdešimt šeši</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR galio</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU kūrėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU tipas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL kliento API</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL versija</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Nežinomas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Instrumentų klasė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Nerasta CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Moteriavimo karta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Nerasta moteriavimo karto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Atmintis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Nerasta atminties</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Saugykla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Nerastas diskas</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Valdiklio atkurti nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>Bandykite dar kartą arba išlaikykite kontaktą su mus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Valdiklio kopijavimas nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Ekranas kartytė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Nerasta GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitorius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Nerastas monitorius</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Tinklo kartytė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Nerasta tinklo kartytos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Garsos kartytė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Nerastas garso įrenginys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Nerastas Bluetooth įrenginys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Kitos PCI įrenginiai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Nerastos kitos PCI įrenginiai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Galvaus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Nerasta galvos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Klaviatūra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Nerasta klaviatūros</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Mėnesis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Nerastas mėnesis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Spausdinėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Nerastas spausdinėjas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Nerasta kamerės</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Nerastas CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Kiti įrenginiai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Kitų įrenginių nerasta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Masyvo krepšinys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Formo ženklas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Nustatyti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Banko užsienio numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Tipas išaiškinimas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Komponento numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Kūrimo numeris</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Atminties technologija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Atminties veikimo veiksena galimybė</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmware versija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Modulio gamintojo ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Modulio produkto ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Atminties sub-system controllerio gamintojo ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Atminties sub-system controllerio produkto ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Nevykdomojo dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Vykojamojo dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Cache dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Loginio dydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>dvinis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -3692,313 +3453,294 @@
         <translation>pusiai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>bus informacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>loginiųSektoriųDydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sektorųDydis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometrija (Logiška)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Užtikrinimo tvarkyklė</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Užtikrinimo tvarkyklė yra naudinga instrumentas, skirtas peržiūrėti įrankio informaciją ir tvarkyti įrankius.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Yra gauti nauji draiveriai! Įdiegti arba atnaujinti jus dabar.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Peržiūra</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Itraukti apskritai priešitekarčių folderius</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Ieškoti tvarkaraščio šiuo kelio</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 tvarkaraktoriai yra atnaujinti gali</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Laikas pārbaudėtas: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Atsisiuntimas tvarkaraktorių %1... </translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Atsisiuntimo greitis: %1 Atsisiuntas %2 iš %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Yra įdiegiami tvarkaraktoriai %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 tvarkaraktoriai įdiegti, %2 tvarkaraktoriai nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 tvarkaraktoriai įdiegti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Nepavyko įdiegti tvarkaraktorių</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Tinklo klaida. Pabandoma pritraukti prie tinklo...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Atsisiuntimo greitis: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Jūsų tvarkaraktoriai yra aktualūs</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Visi tvarkaraktoriai buvo pateikti atsaukimo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Viso %1 tvarkaraktoriai, iš to %2 buvo pateikti atsaukimo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Jums gali būti pateikti atsaukimo %1 tvarkaraktoriai, rekomenduoja to daroti tarpusavyje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Jums gali būti pateikti atsaukimo %1 tvarkaraktoriai</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Pateikiamas atsaukimo %1 tvarkaraktoriai, viso %2 tvarkaraktoriai</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Pateikiamas atsaukimo: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 tvarkaraktoriai pateikti atsaukimo, %2 tvarkaraktoriai nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Nepavyko pateikti atsaukimo tvarkaraktorių</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 tvarkaraktoriai pateikti atsaukimo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Jums gali būti atkurti %1 tvarkaraktoriai</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Pasirinkite tvarkaraktorių, kurį norėtumėte atkurti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Tvarkaraktoriai atkuriamas...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Atstatomasis: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>paieškoti įjungti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Būtumėte %1, kad įdiegtos įrankio valdikliai įveiktų</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Peržiūrėti atsikopos kelio</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Atsikopėti viską</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>pateikti atsiliepimą</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Būtumėte bandyti dar kartą arba %1 mus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Įdiegti viską</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Atsinaujinti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Atšaukti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Atsinaujinama įrankio valdikliai, lūkite...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Atsinaujinama %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Atsinaujinimas nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Tinklas nepasiekiamas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Būtumėte patikrinti tinklo prisijungimą</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Būtumėte atsinaujinti arba %1 mus</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Yrėtumėte įdiegti valdiklį, kuriame bus pristatoje pridarytas jei išeitsite.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ar tikrai norėtumėte išeiti?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Išeiti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Atšaukti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Yrėtumėte atsikopėti valdiklius, kuriuose bus pristatoje pridarytas jei išeitsite.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Yrėtumėte atstatyti valdiklius, kuriuose bus pristatoje pridarytas jei išeitsite.</translation>
     </message>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Nuotraukų įrenginys</translation>
     </message>
@@ -4114,22 +3855,22 @@
         <translation>Nepavyko gauti kūrinių failų</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Atnaujinimas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Apmokymas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Atstatymas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Pasikaininimas</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>At refreshed</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Eksportuoti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Atnaujinti spalėtojus</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Atimančių programa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Leisk kompiuteriui atsigauti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Įjungti</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>At refreshed</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Eksportuoti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopijuoti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Išjungti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation> neprieinamas</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Pasirinkite vietinį folderių, lūkesčiau</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Įkeliama...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ml.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ml.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ml">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ഫീഡ്ബാക്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ഓ.കേ</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>പുതിയ</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>ഇൻറർനെറ്റ് അറിയിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>പുനഃസ്ഥാപനം</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>പുതിയ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>ജോലി</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>നിർമാണം</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>നിലവില്ലാത്ത</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ഡിവൈസ് പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>വെണ്ടർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ചിപ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>ശക്തികൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>സിസ്എഫ്സ്_പാത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>പരീക്ഷണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>കർണൽ_മോഡ്_ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>മെമ്മറി_അഡ്രസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>എസ്.ആർ.ഇ.ഒ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>നിലവില്ലാത്ത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>നിർമാണം</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>വെണ്ടർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>വെണ്ടർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>വേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ചിപ്സെറ്റ്</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>അലീസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>പ്രതിരോധകർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>വേര്‍ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>വേഗത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>പരിധി ശക്തി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ഡ്രൈവർ വേര്‍ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>ശക്തികൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ബസ് വിവരങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>സംഗതി പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>എംഎംസി വിലാസം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ലഭ്യമല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>ഡിസേബിൾ ചെയ്യുക</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>പ്രതിരോധകർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>വേര്‍ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ബസ് വിവരങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>ശക്തികൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>പരിധി ശക്തി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>വേഗത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>ലഭ്യമല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>ഡിസേബിൾ ചെയ്യുക</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>പ്രതിരോധകർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>സീപിയു ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>കോർ ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>ത്രീഡ്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>ബോഗോമിപ്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>അര്ച്ചിടക്ചർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>CPU കുടുംബം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>പ്രോസസർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>കോർ (കോറുകൾ)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>വിർട്ടുവൽ ഇസെ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>ഫല്ഗ്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>എക്സ്ടൻഷന്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>എൽ 3 കേഷ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>എൽ 2 കേഷ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>എൽ 1ഇ കേഷ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>എൽ 1ഡി കേഷ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>സ്റ്റീപ്പിംഗ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>സ്പീഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>മാക്സിമം സ്പീഡ്</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>വെണ്ടർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ഗ്രാഫിക്സ് മെമ്മറി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ഫിസിക്കൽ ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>മെമ്മറി ആഡ്രസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>ഐ ഒ പോർട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>ബസ് ഇൻഫോ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>മാക്സിമം റെസല്യൂഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>മിനിമം റെസല്യൂഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>നിലവിലെ റെസല്യൂഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>ഡിസ്ക്രിപ്ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>ഡിഗിറ്റൽ ഔട്ട്പുട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>ഡിസ്പ്ലേ ഔട്ട്പുട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>ക്ഷമതകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>ഐആർക്യൂ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>നിലവിലില്ല</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>വെംഡർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>ബസ് ഇൻഫോ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>സ്പീഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>പരമാവധി ശക്തി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ക്ഷമതകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>സീരിയൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>നിലവിലില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>ഡിസ്പ്ലേ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>വെംഡർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>ഇന്റർഫേസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>ബസ് ഇൻഫോ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>സ്പീഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>പരമാവധി കറന്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>ശക്തികൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>വേര്ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>പ്രവർത്തനരഹിതമായിരിക്കുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>ഓഫ് ചെയ്യുക</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>സാമാന്യാവലോകനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>സെൻട്രൽ പ്രോസസ്സിംഗ് യൂണിറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>സെൻട്രൽ പ്രോസസ്സിംഗ് യൂണിറ്റിന്റെ എണ്ണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>മാതർബോർഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>മെമ്മറി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>ഡിസ്പ്ലേ അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>സൌണ്ട് അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>സ്റ്റോറേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>മറ്റ് PCI ഉപകരണങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>ബാറ്ററി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>ബ്ലൂട്ടൂത്ത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>നെറ്റ്വർക്ക് അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>മൗസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>കീബോർഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>മോണിറ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>സിഡി-റോം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>പ്രിന്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>ക്യാമറ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>മറ്റ് ഉപകരണങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>ഉപകരണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ഓഎസ്</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>വിപണിക്കാരൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>വലുപ്പം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>തരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>വേഗത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ആകൃതി പുരോഗ്രഹം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>സ്ഥലം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>സീരിയൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>സംവിധാനം ചെയ്ത വോൾട്ടേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>ഉയർന്ന വോൾട്ടേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>ന്യൂന വോൾട്ടേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>സംവിധാനം ചെയ്ത വേഗത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ഡാറ്റ പുരോഗ്രഹം</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>വിപണിക്കാരന്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>രൂപം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>പ്രദർശന പ്രവേശനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>അംഗീകരണ രൂപം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>സഹായം ചെയ്യുന്ന പരിഹാരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>ഇപ്പോൾ പരിഹാശം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>പ്രദർശന അംശം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>പ്രഥമ പ്രദർശനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>വലുപ്പം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>സീരിയൽ നമ്പർ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>വിപണിക്കാരന്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>രൂപം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ബസ് വിവരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>കഴിവുകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ഡ്രൈവർ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>ഉയർന്ന നിരക്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>സംവിധാനം ചെയ്യുന്ന നിരക്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>പോർട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>മൾട്ടിക്കാസ്റ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>ലിങ്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>ലേറ്റൻസി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>ഐ.പി.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>ഫിർമ്വേർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ഡുപ്ലെക്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>ബ്രോഡ്‌കാസ്റ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ഓട്ടോ നെഗോഷ്യേഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>മെമ്മറി അഡ്രസ്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ഐ.ആർ.ക്യൂ.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>എം.എ.സി. അഡ്രസ്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ലോജിക്കൽ പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>നിലവില്ലാത്ത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>ഡിസേബിൾ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>വെന്ഡർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>ബസ് സിസ്റ്റം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>വേര്‍ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>ഇൻപുട്ട്/ഔട്പുട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>മെമ്മറി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ഐ.ആർ.ക്യൂ.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>ലേറ്റൻസി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>ക്ഷമകൾ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>വെന്ഡർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>വേര്‍ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>ബസ് സിസ്റ്റം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ഉപയോഗം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>ഉയർന്ന ശക്തി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>വേഗത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>സീരിയൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>ഉപയോഗം സാധ്യമല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>നിയമം നിർബന്ധം</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>വെണ്ടർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>സീരിയൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>രൂപം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>നിലയ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>ക്ഷമത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>വോൾട്ടേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>സ്ലോട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>സിദ്ധാന്ത ക്ഷമത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>സിദ്ധാന്ത വോൾട്ടേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS സീരിയൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS ഉൽപാദന തീയതി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS രസായനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>താപനില</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>മോഡൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>വെണ്ടർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>സീരിയൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>സാധാരണ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>ഇൻറർനെറ്റ് ആഡ്രസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>നിലയ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Interface Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>ഡിസബിൾ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>വെംഡർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>മീഡിയ ടൈപ്പ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>സൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>ക്യാപാബിലിറ്റീസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>ഫിർമ്വേർ വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>സ്പീഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>ഡിസ്ക്രിപ്ഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>സീരിയൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>ഇന്റർഫേസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>റോടേഷൻ റേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>അപ്പ്രസന്റ്</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>പുതിയ അപ്ഡേറ്റിന് ഒരു ഡ്രൈവർ തിരഞ്ഞെടുക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>ഇത് ഫോൾഡറിൽ ഡ്രൈവർ കണ്ടെത്താനായില്ല</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ഓഡിയോ ഡിവൈസ് ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>ബിയോസ് ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>സിഡി-റോം ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ഓപ്പറേറ്റിംഗ് സിസ്റ്റം ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>CPU ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>ഓഥർ ഡിവൈസ് ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>പവർ ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>പ്രിന്റർ ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>മൗസ് ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>നെറ്റ്വർക്ക് ആഡപ്റ്റർ ഇന്ഫോ ലോഡിംഗ്...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>ഡിസബിൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>അപ്പ്രസന്റ്</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>ഡിസബിൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>അപ്പ്രസന്റ്</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ഉപകരണ വിശദാംശങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>ഇന്റർഫേസ് ശരിയായി പ്രദർശിപ്പിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>അടയ്ക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>സഹായം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>കോപ്പി</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>സിസ്റ്റം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ഇക്സ്പോർട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>പുനഃപ്രാപ്തി</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>ഉപകരണ മാനേജർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>ഹാർഡ്വെയർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>മോണിറ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>ഓവർവിയ്വ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>ഡിസ്പ്ലേ അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>സീപിയു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>നെറ്റ്വർക്ക് അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>ബാറ്ററി</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>ഇതിൽ കൂടുതൽ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ഡ്രൈവർ പ്ലാറ്റ്ഫോർമിന്റെ പതിപ്പ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>പിന്തിരിപ്പിക്കാവുന്ന ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>പിന്തിരിപ്പിട്ട ഡ്രൈവർ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>പതിപ്പിക്കുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>റദ്ദാക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>അടുത്തത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>നിരോധനം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ഡ്രൈവർ നീക്കം ചെയ്ത ശേഷം ഉപകരണം ലഭ്യമായിരിക്കില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>നീക്കം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>ഇപ്പോൾ നീക്കം ചെയ്യുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>പതിഞ്ഞ ആപ്ഡേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>നീക്കം പതിഞ്ഞു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>പdate ഫെയിൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>അൺഇൻസ്റ്റാൾ ഫെയിൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ഓക്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>പുതിയത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>നിങ്ങൾ തിരഞ്ഞെടുത്ത ഫോൾഡറിന് പ്രവർത്തനം ഉണ്ടായിട്ടില്ല, മീറ്റുകൊള്ളുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>പdate</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>പഴയത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>ബ്രോക്കൻ പാക്കേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>മാറ്റിയ പാക്കേജ് ആർക്കിറ്റെക്ചർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>നിങ്ങൾ തിരഞ്ഞെടുത്ത ഫയൽ പ്രവർത്തനം ഉണ്ടായിട്ടില്ല, മീറ്റുകൊള്ളുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>അത് ഡ്രൈവർ അല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>ഇൻസ്റ്റാൾ ചെയ്യാൻ കഴിയുന്നില്ല - ഡിജിറ്റൽ സിഗ്നേച്ചർ ഇല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>അപരിചിതമായ പിശക്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ഡ്രൈവർ മോഡ്യൂൾ കണ്ടെത്താൻ കഴിയില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>അസാധുവായ മോഡ്യൂൾ ഫോർമാറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ഡ്രൈവർ മോഡ്യൂളിന് പരിഭ്രാന്തികൾ ഉണ്ട്</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ഡ്രൈവർ ഇൻസ്റ്റാൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ഡ്രൈവർ ബാക്കപ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ഡ്രൈവർ റെസ്റ്റോർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>ഫീഡ്ബാക്</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>നിങ്ങൾക്ക് റെസ്റ്റോർ ചെയ്യാൻ ഡ്രൈവർ ഇല്ല, ആദ്യം ബാക്കപ് ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>ബാക്കപ് ഡ്രൈവർ പോകുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>ബാക്കപ് വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>റെസ്റ്റോർ ചെയ്യാൻ കഴിയുന്ന ഡ്രൈവർമാർ</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>പുതുക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ഐക്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>സാമാന്യാന്നം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ഡ്രൈവർ ഇൻസ്റ്റാൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ഡ്രൈവർ ബാക്കപ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ഡ്രൈവർ റെസ്റ്റോർ</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>ഉപകരണം പ്രവർത്തനരൂപം നൽകാൻ കഴിയാതിരുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>ഉപകരണം പ്രവർത്തനരൂപം നിർത്താൻ കഴിയാഞ്ഞു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>പ്രവർത്തനരൂപം നിർത്താൻ കഴിയാതിരുന്നു: ഉപകരണത്തിന്റെ സിഎൻ ലഭ്യമാക്കാൻ കഴിയാതിരുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ഡ്രൈവർ പുതിയതായി പുനഃസ്ഥാപിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ഡ്രൈവർ അൺഇൻസ്റ്റല്‍ ചെയ്യുക</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>പുതിയതായി പ്രദർശിപ്പിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ഇറ്റ് പ്രകടനം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>കൊണ്ടുവരുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ഓവറ്വീവ്</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>പുതിയതായി പ്രദർശിപ്പിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ഇറ്റ് പ്രകടനം</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>കൊണ്ടുവരുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>പ്രവർത്തനരൂപം നൽകുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ഡ്രൈവർ പുതിയതായി പുനഃസ്ഥാപിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ഡ്രൈവർ അൺഇൻസ്റ്റല്‍ ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>ഇത് കമ്പ്യൂട്ടർ എബിലിറ്റി ചെയ്യാൻ അനുവദിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>പ്രവർത്തനരൂപം നിർത്തുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>പ്രവർത്തനരൂപം നിർത്താൻ കഴിയാതിരുന്നു: ഉപകരണത്തിന്റെ സിഎൻ ലഭ്യമാക്കാൻ കഴിയാതിരുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>ഉപകരണം പ്രവർത്തനരൂപം നിർത്താൻ കഴിയാഞ്ഞു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>ഉപകരണം പ്രവർത്തനരൂപം നൽകാൻ കഴിയാതിരുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ഡ്രൈവർ പുതിയ പുനഃസ്ഥാപിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ഡ്രൈവർ അൺഇൻസ്റ്റല്‍ ചെയ്യുക</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>സബ് വെന്ഡർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>സബ് ഉപകരണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ഡ്രൈവർ പ്രവർത്തനരൂപം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ഡ്രൈവർ പ്രവർത്തനരൂപം ആക്ടിവേഷൻ കമാൻഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>കൺഫിഗ് പ്രവർത്തനരൂപം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>ലേറ്റൻസി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>ഫിസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>സിസ്ഫ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>ഹാൻഡിലർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>പ്രോപ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ഇവ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>കീ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>ബസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ബിയോസ് വിവരങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ബേസ് ബോർഡ് വിവരങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>സിസ്റ്റം വിവരങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ചെസ്സിസ് വിനിയോഗം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ഫിസിക്കൽ മെമറി അറay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>റിലീസ് ഡേറ്റ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>അഡ്രസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>റൺടൈം സൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>റോം സൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>ചാറക്ടർസ്റ്റിക്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>ബിയോസ് റീവിഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ഫിറ്റ്വേയർ റീവിഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>പ്രോഡക്ട് പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>സീരിഅൽ നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ആസ്റ്റ് ടാഗ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>ഫീച്ചർസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ചെസ്സിസ് ലോക്കേഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>ചെസ്സിസ് ഹാൻഡില്‍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ടൈപ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>കോൺടെയിൻഡ് ഓബ്‍ജക്ട് ഹാൻഡില്സ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>ഇഉയിഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>വേക്കപ് ടൈപ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>എസ് കുയി നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>ബാധ്യത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ലോക്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>സ്റ്റാർട്ട് സ്റ്റേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>പവർ സപ്ലൈ സ്റ്റേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>താപനില സ്റ്റേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>സുരക്ഷാ സ്ഥിതി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ഓഇഎം വിവരങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ഉയരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>പവർ കോർഡുകളുടെ എണ്ണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>നിർമ്മാണ ഘടകങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>സ്ഥലം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>പരിശീലന തരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ഉയരം ക്ഷമത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>പരിശീലന വിവരങ്ങൾ ഹാൻഡിൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>ഉപകരണങ്ങളുടെ എണ്ണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ബിയോസ് റോംസൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>പുറത്തിറക്കിയ തീയതി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ബോർഡ് പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>എസ്എംബിഇഒസ് വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ഭാഷാ വിവരം ഫോർമാറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>നിലവിലുള്ള ഭാഷകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>നിലവിലുള്ള ഭാഷ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>ബിഡി അഡ്രസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>എസ്എസ്എൽ എംട്യു</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>എസ്സിഒ എംട്യു</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>പാക്കറ്റ് തരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>ലിങ്ക് പോളിസി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>ലിങ്ക് മോഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>ക്ലാസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>സേവന ക്ലാസുകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>ഉപകരണ വർഗം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>എച്ചി പതിപ്പ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>എൽഎംപി പതിപ്പു</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>സബ്-വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>ഉപകരണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>സീരിയൽ ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>നിർമ്മാണം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>വിവരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>പവർഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>അന്വേഷിക്കാവുന്നത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>പേയർ ചെയ്യാവുന്നത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>മോഡലിയസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>അന്വേഷിക്കുന്നത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>ഡ്രൈവർ മോഡ്യൂളുകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ഉപകരണ ഫയൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ഉപകരണ ഫയലുകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>ഉപകരണ സംഖ്യ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>പ്രയോഗം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>നിലവിലെ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>സംഗതി പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ANSI പതിപ്പ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU പ്രിമ്പ്ലിമെന്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU ആർക്കിറ്റെക്ചർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU വേരിയന്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU പാർട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU റിവിഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>ഒന്ന്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>എഞ്ച്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>നെൺ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>ടെൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>മുക്കാല്‍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>പന്ത്രായിരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>പന്ത്രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>പന്ത്രെട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>പന്ത്രിന്ന്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>പന്ത്രിന്ന് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>പന്ത്രിന്ന് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>പന്ത്രിന്ന് ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>പന്ത്രിന്ന് എട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>മുക്കാല്‍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>മുക്കാല്‍ രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>മുക്കാല്‍ നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>മുക്കാല്‍ ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>മുക്കാല്‍ എട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>നാല്‍പത്ത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>നാല്‍പത്ത് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>നാല്‍പത്ത് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>നാല്‍പത്ത് ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>നാല്‍പത്ത് എട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>അഞ്ച്‍പത്ത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>അഞ്ച്‍പത്ത് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>അഞ്ച്‍പത്ത് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>അഞ്ച്‍പത്ത് ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>അഞ്ച്‍പത്ത് എട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>നാല്‍പത്ത് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>നാല്‍പത്ത് രണ്ട് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>നാല്‍പത്ത് രണ്ട് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>അഞ്ചുപത്തിഭിന്നം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>അഞ്ചുപത്തിമുന്നം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>അറുപത്തിയാറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>അറുപത്തിയാറ് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>അറുപത്തിയാറ് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>അറുപത്തിയാറ് ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>അറുപത്തിയാറ് എട்ட്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>എഴുപത്തിയാറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>എഴുപത്തിയാറ് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>എഴുപത്തിയാറ് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>എഴുപത്തിയാറ് ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>എഴുപത്തിയാറ് എട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>അറുപത്തിനാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>അറുപത്തിനാല് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>അറുപത്തിനാല് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>അറുപത്തിനാല് ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>അറുപത്തിനാല് എട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>ഒരു നൂറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>ഒരു നൂറ് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>ഒരു നൂറ് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>ഒരു നൂറ് ആറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>ഒരു നൂറ് എട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>ഒരു നൂറ് പത്ത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>ഒരു നൂറ് പത്തിരണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>ഒരു നൂറ് പത്തിച്ചാറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>ഒരു നൂറ് പത്തിച്ചാറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>ഒരു നൂറ് പത്തിച്ചൊന്ന്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>ഒരു നൂറ് പത്തിയാറ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>ഒരു നൂറ് പത്തിയാറ് രണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>ഒരു നൂറ് പത്തിയാറ് നാല്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>ഒരു നൂറ് ആറു പത്തിരട്ടി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>ഒരു നൂറ് ആറു പത്തിന് പത്തിരട്ടി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>ഒരു നൂറ് അഞ്ച് പത്തിന് ഏഴു പത്തിരട്ടി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>രണ്ടു നൂറ് അഞ്ച് പത്തിന് ആണ് പത്തിരട്ടി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR സാങ്കേതിക സാധ്യത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU വിപണി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU തരം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL പതിപ്പ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL ക്ലയന്റ് ഏപ്പി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL പതിപ്പ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL പതിപ്പ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>അപരിചിതമായ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>അപരിചിതമായ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ഹാർഡ്‌വെയർ ക്ലാസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>സെൻട്രൽ പ്രോസസ്സിംഗ് യൂണിറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>സെൻട്രൽ പ്രോസസ്സിംഗ് യൂണിറ്റ് കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>മാതർബോർഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>മാതർബോർഡ് കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>മെമ്മറി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>മെമ്മറി കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>സ്റ്റോറേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>ഡിസ്ക് കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ഡ്രൈവർ പുനർനിർമ്മാണം വിഫലമായി</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>നിങ്ങൾ മുതൽ ശ്രമിക്കുക അല്ലെങ്കിൽ നമ്മൾക്ക് അറിയിപ്പ് നൽകുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ഡ്രൈവർ പിന്തുടർച്ച വിഫലമായി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>ഡിസ്പ്ലേ ആഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU കണ്ടെത്താം വിഫലമായി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>മോണിറ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>മോണിറ്റർ കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>പ്രശസ്ത അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>പ്രശസ്ത അഡാപ്റ്റർ കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>സൌണ്ട് അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>ശബ്ദ ഉപകരണം കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>ബ്ലൂട്ടൂത്ത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>ബ്ലൂട്ടൂത്ത് ഉപകരണം കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>ബാക്ക് PCI ഉപകരണങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>ബാക്ക് PCI ഉപകരണങ്ങൾ കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>പവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>ബാറ്ററി കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>ക്ലാവിയറ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>ക്ലാവിയറ്റർ കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>മൗസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>മൗസ് കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>പ്രിന്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>പ്രിന്റർ കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>ക്യാമറ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>ക്യാമറ കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>സിഡി-റോം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>സിഡി-റോം കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>ബാക്ക് ഉപകരണങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>ബാക്ക് ഉപകരണങ്ങൾ കണ്ടെത്താനായില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>അറേ ഹാൻഡിള്‍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>ഫോർമ് ഫാക്ടർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>സെറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>ബാങ്ക് ലോക്കേറ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>ടൈപ്പ് ഡിറ്റേൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>പാർട്ട് നമ്പർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>റെങ്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>മെമ്മറി ടെക്നോളജി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>മെമ്മറി ഓപ്പറേറ്റിംഗ് മോഡ് ക്യാപാബിലിറ്റി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ഫിറ്റ്വേർ വേർഷൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>മോഡ്യൂൾ മാനുഫാക്ച്ചറർ ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>മോഡ്യൂൾ പ്രോഡക്റ്റ് ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>മെമ്മറി സബ്-സിസ്റ്റം കൺട്രോളർ മാനുഫാക്ച്ചറർ ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>മെമ്മറി സബ്-സിസ്റ്റം കൺട്രോളർ പ്രോഡക്റ്റ് ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>നോൺ-വോളാടൈൽ സൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>വോളാടൈൽ സൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>കേഷ് സൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ലോജിക്കൽ സൈസ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>ഇംച്ച്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>ഡേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ഐയോപ്പോർട്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>നെറ്റ്വർക്ക്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>ബാറ്ററി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>നേട്ടിവ്-പാത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>പവർ സപ്പ്ലൈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>പുതുക്കി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>ചരിത്രം ഉണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>സ്റ്റാറ്റിസ്റ്റിക്സ് ഉണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>പുണർജ്ജനിക്കുന്നത്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>സ്റ്റേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>വാർണിംഗ്-ലെവൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ഐനർജി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ഐനർജി-ഇമ്പ്റ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ഐനർജി-ഫുൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ഐനർജി-ഫുൾ ഡെസൈൻ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ഐനർജി-റേറ്റ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>വോൾട്ടേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>പെർസെന്റേജ്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknology</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>icon-name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>on-battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>lid-is-closed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>lid-is-present</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>critical-action</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>copies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>job-cancel-after</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>job-hold-until</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>job-priority</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>marker-change-time</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>number-up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientation-requested</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>print-color-mode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer-is-accepting-jobs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer-is-shared</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer-is-temporary</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer-make-and-model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>printer-state-change-time</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>printer-state-reasons</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>printer-type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer-uri-supported</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>sides</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logicalsectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ഗിഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>ജിയോമെട്രി (ലോജിക്കൽ)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>ഡെവീസ് മാനേജർ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>ഡെവീസ് മാനേജർ ഹാർഡ്‌വെയർ വിവരങ്ങൾ കാണാനും ഡെവീസ് നിർവഹിക്കാനും ഉപയോഗിക്കാനുള്ള ഒരു ഉപകരണമാണ്</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>പുതിയ ഡ്രൈവർമാർ ലഭിച്ചിട്ടുണ്ട്! ഇപ്പോൾ ഇൻസ്റ്റാൾ ചെയ്യുക അല്ലെങ്കിൽ അപ്ഡേറ്റ് ചെയ്യുക.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>നോക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>സബ്‌ഫോൾഡറുകൾ ഉൾപ്പെടുത്തുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ഈ പാതയിൽ ഡ്രൈവർമാരിൽ തിരയുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 ഡ്രൈവർ അപ്ഡേറ്റുകൾ ലഭിച്ചിട്ടുണ്ട്'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'സമയം പരിശോധിച്ചിട്ടുണ്ട്: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 ഡ്രൈവർമാർ ഡൗൺലോഡ് ചെയ്യുന്നു...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'ഡൗൺലോഡ് സ്പീഡ്: %1, ഡൗൺലോഡ് ചെയ്തിട്ടുണ്ട് %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 ഡ്രൈവർമാർ ഇൻസ്റ്റാൾ ചെയ്യുന്നു...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 ഡ്രൈവർമാർ ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, %2 ഡ്രൈവർമാർ വിഭവം ആയിട്ടുണ്ട്'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 ഡ്രൈവർമാർ ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ഡ്രൈവർമാർ ഇൻസ്റ്റാൾ ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>ഓൺലൈൻ പരാജയപ്പെട്ടു. പുനഃസ്ഥാപനത്തിന് പുനരാരംഭിക്കുക...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'ഡൗൺലോഡ് സ്പീഡ്: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>നിങ്ങളുടെ ഡ്രൈവർമാർ പുതിയതാണ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>എല്ലാ ഡ്രൈവർമാർക്കും പിൻവലിപ്പ് നല്കിയിട്ടുണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 ഡ്രൈവർമാർ ആകെ, അവയിൽ %2 ഡ്രൈവർമാർ പിൻവലിപ്പ് നല്കിയിട്ടുണ്ട്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 ഡ്രൈവർമാർ പിൻവലിപ്പ് ചെയ്യാനും കഴിയുന്നു, ഇത് പ്രായോഗികമായി ഇപ്പോൾ ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 ഡ്രൈവർമാർ പിൻവലിപ്പ് ചെയ്യാനും കഴിയുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 ഡ്രൈവർ പിൻവലിപ്പ് ചെയ്യുന്നു, ആകെ %2 ഡ്രൈവർമാർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'പിൻവലിപ്പ്: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 ഡ്രൈവർമാർ പിൻവലിപ്പ് നല്കിയിട്ടുണ്ട്, %2 ഡ്രൈവർമാർ വിഭവം ആയിട്ടുണ്ട്'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>പിൻവലിപ്പ് ചെയ്യാൻ പരാജയപ്പെട്ടു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 ഡ്രൈവർമാർ പിൻവലിപ്പ് നല്കിയിട്ടുണ്ട്'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 ഡ്രൈവർമാർ പുനരുപയോഗിക്കാനും കഴിയുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>പുനരുപയോഗിക്കാനുള്ള ഒരു ഡ്രൈവർ തിരഞ്ഞെടുക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ഡ്രൈവർ പുനർവിഭവം ചെയ്യുന്നു...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>പുനർവിഭവം: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>പുനർവിഭവം</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>നിങ്ങൾ ഇൻസ്റ്റാൾ ചെയ്ത ഡ്രൈവർകൾ പ്രവർത്തിക്കാൻ %1 ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>ബാക്കപ്പ് വഴി കാണു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>എല്ലാം ബാക്കപ്പ് ചെയ്യു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>പരിശോധന നൽകു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>നിങ്ങൾ വീണ്ടും ശ്രമിക്കുക അല്ലെങ്കിൽ %1 നമ്മളോട് ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>എല്ലാം ഇൻസ്റ്റാൾ ചെയ്യു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>പുനർപരിശോധന</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>നിർത്തു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>ഹാർഡ്‌വെയർ ഡിവൈസ് ഡ്രൈവർ പരിശോധിക്കുന്നു, കാത്തിരിക്കുക...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>പരിശോധിക്കുന്നു %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>പരിശോധന പരാജയപ്പെട്ടു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>ഇന്റർനെറ്റ് ലഭ്യമല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ പരിശോധിക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>നിങ്ങൾ വീണ്ടും ശ്രമിക്കുക അല്ലെങ്കിൽ %1 നമ്മളോട് ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>നിങ്ങൾ ഒരു ഡ്രൈവർ ഇൻസ്റ്റാൾ ചെയ്യുകയാണ്, നിങ്ങൾ വിടുന്നതുവരെ ഇത് തടഞ്ഞിരിക്കും.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>നിങ്ങൾ വിടാൻ തീരുമാനിച്ചിരിക്കുന്നു എന്ന് ഉറപ്പാണ്?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>പുറത്ത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>നിർത്തു</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>നിങ്ങൾ ഡ്രൈവർ ബാക്കപ്പ് ചെയ്യുകയാണ്, നിങ്ങൾ വിടുന്നതുവരെ ഇത് തടഞ്ഞിരിക്കും.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>നിങ്ങൾ ഡ്രൈവർ പുനർവിഭവം ചെയ്യുകയാണ്, നിങ്ങൾ വിടുന്നതുവരെ ഇത് തടഞ്ഞിരിക്കും.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>ബ്ലൂട്ടൂത്ത് അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ചിത്രീകരണ ഉപകരണം</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>പ്രദർശന അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>സൌണ്ട് കാർഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>ഇന്റർനെറ്റ് അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>വയർലസ് ഇന്റർനെറ്റ് അഡാപ്റ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>ഇൻസ്റ്റാൾ വിജയം</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>സ്ഥാപനം പരാജയപ്പെട്ടു</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>ഡൗൺലോഡ് ചെയ്യുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>സ്ഥാപനം ചെയ്യുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>സ്ഥാപിച്ചിട്ടില്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>പഴയത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>നിലവില്ലാത്തത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>പിൻവലിക്കാത്തത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>പിൻവലിക്കുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>പിൻവലിക്കൽ പരാജയപ്പെട്ടു</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>പിൻവലിക്കൽ വിജയം</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>പുനരധിവേഷം ചെയ്യുന്നു</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>അപരിചിത കെഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>ഉടമ്പടി കെഡ്</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>സ്ഥാപനം തടഞ്ഞു</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ഡ്രൈവർ ഫയൽ നേടുവാൻ പരാജയപ്പെട്ടു</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>പുതിയത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>പിൻവാങ്ങൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>പുനരധിവേഷം</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>സ്ഥാപനം</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>നിർബന്ധിതമാക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>പുതിയത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>ഇണക്കൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>ഡ്രൈവർ പുതിയത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ഡ്രൈവർ അൺസ്ഥാപനം</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>കമ്പ്യൂട്ടർ ജാഗ്രത ചെയ്യാൻ അനുവാദം നൽകുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>നിർബന്ധിതമാക്കുക</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>പുതിയത്</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>ഇണക്കൽ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>കോപ്പി ചെയ്യുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>നിർബന്ധിതമാക്കുക</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>അയിട്ടില്ല</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>ദയവായി ഒരു സ്ഥലീയ ഫോൾഡറിന് തിരഞ്ഞെടുക്കുക</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>ലോഡിംഗ്...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_mn.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_mn.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="mn">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Хоёлтоо</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Ха</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Үнэхээр</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Хэрэглэгчийн хуваалцах</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Баримтлах</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Үнэхээр</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Ха</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Ха</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Хэрэглэгчийн нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Хүчний бүтэц</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Хүчний бүтэц</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Ядварын хэлбэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Хадгалах хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Ха</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Хүчний бүтэц</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Хоёр хэлбэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Хүчин чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Хамгийн их чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Драйверийн верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Үзүүлэх чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Бүсийн мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Логик нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Хүчтэй байхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Дээшлүүлэх</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Хүчин чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Бүсийн мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Үзүүлэх чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Хамгийн их чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Хүчтэй байхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Дээшлүүлэх</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Хүчин чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Ядрын ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Хөршүүд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>БогоМИПС</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Архитектура</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>ЦПС Үйлдлийн төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Шинэчлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Ялгаатай нэг (үйлдлийн)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Хуваах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Флаг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Хөрвөх</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Хүрээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Хүрээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Хүрээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Хүрээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Хүчээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Хамгийн их хурд</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Худалдаачин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>График хувьсгал</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Физик ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Хувьсгалын хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO порт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Бусын мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Хамгийн их хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Хамгийн их хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Хүчээ хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Тайлбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Цифровын хэвлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Харилцагч хэвлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Үзүүлэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Худалдаачин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Бусийн мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Хамгийн их хүч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Үзүүлэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Хаах</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Худалдаачин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Хэрэгслэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Бусийн мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Хамгийн их хүч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Хүчтэй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Дээшлүүлэх</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Үзэгдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>ЦЭПУ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>ЦЭПУ нөөц</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Эхийн дэвсгэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Хадгалах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Харилцах дэвсгэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Хураах дэвсгэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Хадгалах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Бусад PCI дэвсгэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Батарей</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Хэрэглэгчийн дэвсгэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Хөдөлгэх</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Тавилга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Харах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Хэвлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Хөнгөнөөс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Бусад дэвсгэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Дэвсгэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>Үүсгэх</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Худалдаач</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Хуваарийн өндөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Хайх</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Бүтээгдэхүүн хүчдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Хамгийн их хүчдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Хамгийн бага хүчдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Бүтээгдэхүүн хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Хуваарийн өндөр</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Худалдаачин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Харах оролцоо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Холболтын төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Хэрэглэгдэхүүн хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Хүчдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Харах харьцаа</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Үндсэн харах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Худалдаачин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Бүсийн мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Хүчин чадал</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Драйверийн хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Хамгийн их хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Харилцах хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Хэсэг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Мультикаст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Холбон</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Хүчтэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>ИР</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Фирмвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Дөхөөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Броадкаст</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Автотоо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Хадгалах хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>МАК хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Логик нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Хаажуулах</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Бусын мэдээлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Нээлт/Хаалт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Хадгалах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Хүчтэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Хүчдэл</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Бусын мэдээлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Хүчийн үзүүлэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Драйвер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Хамгийн их хүч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Дээшлүүлэх</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Хөдөлгөөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Хүчдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Слот</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Хөдөлгөөний нөхөн хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Хөдөлгөөний нөхөн хүчдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS-ийн хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS-ийн серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS-ийн үйлдвэрлэх өдр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS-ийн химийн үзүүлэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Температура</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Модель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Хуваалцах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Хөдөлгөөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Хэрэглэгчийн төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Анхан шатны хөрөнгө</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Худалдаачин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Медиа төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Хүчин чадвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Фирмварс верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Товчлол</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Хэрэглэгчийн төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Хөдөлгөөний хурд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Шинчлэлтэй хөрөнгөгүйг сонго</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Энэ папраас хөрөнгөгүйг олдсонгүй</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Хэвлэлтийн хөрөнгөгүйг загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>BIOS-ийг загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>CD-ROM-ийг загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Үйлдлийн системийг загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>CPU-ийг загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Бусад хөрөнгөгүйг загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Хүчдэлтэй загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Хэвлэгчийг загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Мөрний загварлах...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Хэрэглэгчийн загварлах...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Анхан шатны хөрөнгө</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Анхан шатны хөрөнгө</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Хэрэглэгдэхгүй</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Хөтөчийн мэдээлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Хялбарчлалыг харуулах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Хаах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Тусламж</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Хуваах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Систем</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Хадгалах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Шинэчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Хөтөчийн менежер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Хөгжим</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Хөтөч</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Монитор</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Үзүүлэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Харуулах адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>ЦЭП</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Хэрэгслэлтийн адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Батарей</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Дээд</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Хөтөч платформын хувьсгал</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Хадгалах боломжтой хөтөч</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Хадгалаагүй хөтөч</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Шинэчлэж байна</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Цуцлах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Дараах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Дэлгэрэнгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Хөтөчийг устгахад хөтөчийн хэрэгслэл нь бүрэн бүтээгүй болно</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Устгах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Устгаж байна</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Шинэчлэл амжилттай</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Устгах амжилттай</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Шинчлэл хийхэд амжилтгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Устгахад амжилтгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Хүлээнзүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Дараах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Сонгосон дүрийг олдсонгүй, буцааж сонгоно уу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Шинчлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Эхний</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Хохирсан багц</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Харилцаж байхгүй багц архитектура</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Сонгосон файлыг олдсонгүй, буцааж сонгоно уу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Энэ нь драйвер биш</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Элдэв хүчийг нэмэх боломжгүй - дэлгэрэнгүй тэмдэг</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Хүснэгч алдаа</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Драйвер модулыг олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Буруу модулын формат</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Драйвер модулыг хүсэлтэй</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Драйвер нэмэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Драйвер нэмэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Драйвер буцаах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Санал хүсэл</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Та драйвер буцаах боломжгүй, эхлээд буцаахаа сонгоно уу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Буцаах драйвер руу</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Буцааж байсан хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Буцаах боломжтой драйверүүд</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Шинэчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Экспортох</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Үзүүлэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Драйвер нэмэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Драйвер нэмэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Драйвер буцах</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Хөтөчийг эхлүүлэхэд алдаа гарлаа</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Хөтөчийг тохируулахад алдаа гарлаа</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Хөтөчийг тохируулахад алдаа гарлаа: хөтөчийн SN-г авах боломжгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Драйверүүдийг оновчтой болгох</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Драйверүүдийг бүрэн устгах</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Шинчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Эхлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Хуваах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Үзүүлэлт</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Шинчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Эхлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Хуваах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Эхлүүлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Драйверүүдийг оновчтой болгох</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Драйверүүдийг бүрэн устгах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Хөтөчийг компьютерыг бүрэн ажиллуулах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Хөтөчийг тохируулах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Хөтөчийг тохируулахад алдаа гарлаа: хөтөчийн SN-г авах боломжгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Хөтөчийг тохируулахад алдаа гарлаа</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Хөтөчийг эхлүüлэхэд алдаа гарлаа</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Драйверүүдийг оновчтой болгох</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Драйверүүдийг бүрэн устгах</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Хөтөчийн дэд үндэс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Хөтөчийн дэд хөтөч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Хөтөч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Хөтөчийн төлөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Хөтөчийн эхлүүлэх команд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Тохиролт төлөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>Хугацаа</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Физик</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Хандлерууд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Верс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Бүс</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>BIOS-ийн мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Хүчдэлтэй дэвсгэр мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Систем мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Часис мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Физик мемори массив</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Хувилах өдөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Хөдөлгөөний хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM-ийн хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Үзүүлэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>BIOS-ийн шинэчлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Фирмвар-ийн шинэчлэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Үр ашигт нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Серийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Хөрөнгийн тэмдэг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Үзүүлэлтүүд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Часис доторх байр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Часисын хандлэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Хандсан объектын хандлэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Хүчдэлтэй байрлах төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Хувьд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Няцах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Хөдөлгөөний төлөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Хүчдэл үзүүлэгчийн төлөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Температур төлөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Анкадын төлөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM-ийн мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Өндөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Хүчдэл үзүүлэгчийн тоо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Хамааралт бүхий элементүүд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Худалдаа шалгах төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Хамгийн их хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Худалдаа мэдээгийн хэлбэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Хөдөлгөөний тоо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROM хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Хэвлэлдэх өдрөэ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Хөрөнгө зөвшөөрөх нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS-ийн хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Хэлний тайлбарын формат</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Хийгдэж буй хэлүүд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Хийгдсэн хэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD хаяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Пакетын төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Холболтын бодлог</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Холболтын төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Үйлчилгээний төрлүүд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Хөтөчийн ангилал</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI-ийн хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP-ийн хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Хөрөнгө</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Хөтөч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Сериал ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>туслах мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Хөдөлгөөнт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Хайхад бүрэн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Харилцахад бүрэн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Хайж байна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Драйвер модуль</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Хөтөчийн файл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Хөтөчийн файлууд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Хөтөчийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Хэрэглээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>үнийн төлөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>логик нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ANSI хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU-ийн хэрэглэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU-ийн архитектур</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU-ийн хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU-ийн хэсэг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU-ийн хувилбар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Нэг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation> Хоёр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Дөрөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Хоёр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Хоёр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Гурван</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Таван</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Тавандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Тавандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Хуваандуга</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Нэг зуун</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Нэг зуун ба Хоёр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Нэг зуун ба Дөрөв</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Нэг зуун ба Энэ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Нэг зуун ба Найм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Нэг зуун ба Хуваар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Хоёр зуун дөрөгт гадна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Хоёр зуун дөрөгт гадна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Хоёр зуун дөрөгт гадна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Хоёр зуун таван зуун гадна</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU үйлдвэрлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL версийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL хэрэглэгч API-ууд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL версийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL версийн дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Хааяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Хааяг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Харилцах ангилал</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>ЦЭП</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>ЦЭП олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Эхний бүтээгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Эхний бүтээгч олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Хадгалах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Хадгалах олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Хадгалах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Диск олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Драйвэр баталгаажуулах алдаа!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Хүндэтгээн дараа дахин оролдох, бидний хүсэлтийг өгөх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Драйвэр бэлтгэлтэй байх алдаж байна!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Харилцах адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Харилцах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Харилцах олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Хөтөчийн адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Хөтөчийн адаптер олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Хуулийн адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Хуулийн үүрэг олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Bluetooth үүрэг олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Бусад PCI үүрэг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Бусад PCI үүрэг олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Хүчдэл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Батарей олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Татвар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Татвар олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Хөдөлгэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Хөдөлгэгч олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Хэвлэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Хэвлэгч олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Хөнгөнөөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Хөнгөнөөр олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Бусад үүрэг</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Бусад үүрэг олдсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Форм фактор</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Сет</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Банк нэмэгч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Төрөл бүтэц</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Хэсэг дугаар</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Ранк</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Мемори технологи</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Memory Operating Mode Capability</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Firmware Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Module Manufacturer ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Module Product ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Memory Subsystem Controller Manufacturer ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Memory Subsystem Controller Product ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Non-Volatile Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Volatile Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Cache Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logical Size</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>дүрэм</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Огноо</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>network</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>power supply</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>updated</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>has history</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>has statistics</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>rechargeable</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>state</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>warning-level</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energy-empty</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energy-full</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>energy-full-design</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>energy-rate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>voltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>percentage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>тэхнологи</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>иконны нэр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>онлайн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>дэмонын хувьсагч</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>батарей дээр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>төрөө нь хаалттай</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>төрөө нь байрлалтай</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>хүчтэй ажил</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>хуучин</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>ажил хуваах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>ажил хадгалах</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>ажилын үнэ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>үзүүрийн өөрчлөлт</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>дэвтэртэй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ориентаци нь хүсэгдсэн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>хэвлэх өнгөнөөр</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>хэвлэгч ажилыг зөвшөөрөх</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>хэвлэгч нь хуваагдсан</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>хэвлэгч нь тэгшитгэлтэй</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>хэвлэгчийн үүсгэсэн болон модел</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>хэвлэгчийн төлөв өөрчлөгдсөн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>хэвлэгчийн төлөвийн шалтгаан</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>хэвлэгчийн төрөл</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>хэвлэгчийн URI нь дэмжигдсэн</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>талаа</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus мэдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>тогтмол секторын хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>секторын хэмжээ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>гуд</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Геометр (Логик)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Гадавы даржавы</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Гадавы даржавы нь гадавын мэдэлтийг үзэх болон даржавыг удирдах боломжийг олгодог хэрэгслээр</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Шинэ даржавын олдсон! Үүнийг түүхээс үзнэ үү.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Харах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Хоёр түвшний дүрсүүдийг хамарна</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Энэ замд даржавыг хайх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 даржавын шинчлэл олдсон'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Цагийн шалгалт: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1-д даржавыг түүхээс үзэх...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Түүхийн хурд: %1 Давтагдсан %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1-д даржавыг түүхээс үзэх...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 даржавын түүхээс үзэгдсэн, %2 даржавын түүхээс үзэхэд алдаа гарсан'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 даржавын түүхээс үзэгдсэн'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Даржавыг түүхээс үзэхэд алдаа гарсан</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Хэрэгслэлд алдаа гарсан. Бүхэлдээ дараах...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Түүхийн хурд: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Даржавын түүхээс үзэх нь шинэчлэгдсэн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Бүх даржавыг тэвхээс үзэгдсэн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 даржавын нийт, %2 нь тэвхээс үзэгдсэн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 даржавын тэвхээс үзэх боломжтой, түүхээс үзэхийг түүхээс үзэхэд алдаа гарсан</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 даржавын тэвхээс үзэх боломжтой</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 даржавыг тэвхээс үзэх, нийт %2 даржавын</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Тэвхээс үзэх: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 даржавын тэвхээс үзэгдсэн, %2 даржавын тэвхээс үзэхэд алдаа гарсан'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Даржавыг тэвхээс үзэхэд алдаа гарсан</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 даржавын тэвхээс үзэгдсэн'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 даржавын тэвхээс үзэх боломжтой</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Даржавыг тэвхээс үзэхэд сонгоно уу</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Драйвер хайрчлэгдэж байна...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Хайрчлэгдэх: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>хайрчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Драйверүүнд хүрээгүй болохын тулд %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Хураах замыг харах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Бүхийг Хураах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>хаанаас илгээх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Хийгүүй болохын тулдаа %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Бүхийг Барих</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Ханах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Цуцлах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Харилцаа хийж байна, байхад байх...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Ханах %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Ханах үзэгдсэн</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Хөтөч байхгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Холболтын хэрэгсэлд хялбарчлах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Ханах үзэгдсэн болоход %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Драйвер барих болоход түүнийг цуцлахад хүргэх боломжтой</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Та тухайн хэрэгсэлд цуцлахад итгэж байна?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Гарах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Цуцлах</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>(Хураах) Драйверүүдийг хураах болоход түүнийг цуцлахад хүргэх боломжтой</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>(Хайрчлэх) Драйверүүдийг хайрчлэх болоход түүнийг цуцлахад хүргэх боломжтой</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth хэрэгсэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Харилцаа хэрэгсэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Харуулах хэрэгсэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Гэрэлтээгүй хэрэгсэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Холболтын хэрэгсэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Холболтын хэрэгсэл</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Барих нь амжилттай</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Барилт хийгдсээ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Татаж бүтээгдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Барилт хийгдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Барилтгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Хаалтгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Үйлдэл хийгдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Хурааж болсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Хурааж бүтээгдээ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Хурааж болсонгүй</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Хурааж болсон</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Барилтад оруулах</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Хаа хүсэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Хэрэгслэлт хүсэлт</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Цуцалсан</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Хүчээ хүчээ ашиглан байх файлуудыг авахад алдаа гарлаа</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Шинчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Хурааж бүтээх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Барилтад оруулах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Барилт хийх</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Дээгүүлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Шинэчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Экспортлох</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Хүчээ хүчээ ашиглан байх шинэчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Хүчээ хүчээ ашиглан байх барилтлах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Хөнгөн хэлбэрийг компьютерийг сонсох болгох</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Хөөрөх</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Шинэчлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Экспортлох</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Хуваах</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Дээгүүлэх</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Хүрээгүй</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Хүнсний хоёрдогчыг сонго</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Хүргэлт...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_mr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_mr.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="mr">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>प्रतिक्रिया</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ओके</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>अधिक</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>नेटवर्क नोटिफिकेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>पुन्हा इंस्टॉल करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>अधिक</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>संकुचन</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>बंद करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नाही</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>उपकरण नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>चिप</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>सिसएफएस_पॅथ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>रिव्हिजन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>कर्नेल मोड ड्रायवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>मेमरी पत्ता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>आईआरक्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>बंद करा</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>मॉडेल</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>चिपसेट</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>एलियस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>स्पीड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>मेक्सिमम पॉवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ड्राइवर वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>कैपेबिलिटीज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>बस इन्फो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>लॉजिकल नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>एमएएच एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>अनलिसेबल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>डिसेबल</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>बस इन्फो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>कैपेबिलिटीज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>मेक्सिमम पॉवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>स्पीड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>अनलिसेबल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>डिसेबल</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>नाम</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>सीपीयू आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>कोर आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>थ्रेड्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>थ्रेड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>बोगोमिप्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>आर्किटेक्चर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>सीपीयू फॅमिली</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>प्रोसेसर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>कर्न (s)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>वर्चुअलाइजेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>फ़्लैग्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>एक्सटेंशन्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>एल3 कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>एल2 कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>एल1आई कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>एल1डी कैश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>स्टेपिंग</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>स्पीड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>मैक्स स्पीड</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>मॉडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ग्राफिक्स मेमरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>फिजिकल आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>मेमरी एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>आईओ पोर्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>बस इन्फो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>मॉक्सिमम रेज़ॉल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>कमीन रेझ़ोल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>करंट रेज़ॉल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>वर्णन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>આન્ડોર્ડ આઉટપુટ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>દૃશ્ય આઉટપુટ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>ક્ષમતાઓ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>ઇર્સ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>ઉપલબ્ધ નથી</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>નામ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>સપ્લાયર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>સંશોધન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>મોડેલ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>બસ માહિતી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>ઝીરો</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>મહત્તમ શક્તિ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>ડ્રાઇવર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ક્ષમતાઓ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>સિરિયલ નંબર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>ઉપલબ્ધ નથી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>નિષ્ક્રિય કરો</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>નામ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>સપ્લાયર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>મોડેલ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>સંપર્ક</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>બસ માહિતી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>ઝીરો</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>મહત્તમ વિદ્યુત</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ડ્રાઇવર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>बंद करा</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>ओवरव्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>सीपीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>सीपीयू क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>मदरबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>मेमरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>दिस्प्ले एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>साउंड एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>स्टोरेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>अ‍ॅलर PCI डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>बॅटरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>ब्लूटूथ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>नेटवर्क एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>माउस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>कीबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>मॉनिटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>सीडी-रोम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>प्रिंटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>कॅमेरा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>अ‍ॅलर डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ओएस</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>गती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>कुल चौडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>स्थानांतरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>सिरीअल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>सुविधापूर्वक वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>महत्तम वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>कम वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>सुविधापूर्वक गती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>डेटा चौडी</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>डिस्प्ले इनपुट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>इंटरफेस प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>समर्थन रेझोल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>वर्तमान रेझोल्यूशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>डिस्प्ले अनुपात</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>मुख्य डिस्प्ले</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>काचा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>सिरीअल नंबर</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>बस इन्फो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>कॅपेबिलिटीज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ड्राइवर संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>महत्तम दर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>अनुकूलन दर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>पोर्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>मल्टीकास्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>लिंक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>लेटेंसी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>आईपी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>फिर्मवेयर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ड्यूप्लेक्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>ब्रॉडकास्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ऑटो नेगोशिएशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>मेमरी एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>आईआरक्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>एमएएच एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>लॉजिकल नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>डिसेबल करा</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>मॉडेल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>बस इन्फो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>इनपुट/आउटपुट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>मेमरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>आईआरक्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>लेटेंसी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>कॅपेबिलिटीज</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>मॉडेल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>बस इन्फो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>कॅपेबिलिटीज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>मॉक्सिमम पॉवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>स्पीड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>सीरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>उपलब्ध नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>निष्पादित करा</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>मॉडेल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>सीरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>सॉट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>डिझाइन क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>डिझाइन वोल्टेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>एसबीडीएस वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>एसबीडीएस सीरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>एसबीडीएस निर्माण दिनांक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>एसबीडीएस रसायनशास्त्र</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>तापमान</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>मॉडेल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>सीरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>शेअर केलेले</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>यूआरआय</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>સંગ્રહણ પ્રકાર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>અક્ષમ કરો</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>નિર્માતા</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>મીડિયા પ્રકાર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>કદ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>સંશોધન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>ક્ષમતાઓ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>ફાયરવેર સંશોધન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>ઝડપ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>વર્ણન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>સિરિયલ નંબર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>સંગ્રહણ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>ઘડિયાળ દર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ઉપલબ્ધ નથી</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>અપડેટ માટે ડ્રાઇવર પસંદ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>આ ફોલ્ડરમાં કોઈ ડ્રાઇવર મળ્યો નથી</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>અભ્યાસ ડિવાઇસ માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>બિસ માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>સીડી-રોમ માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ઑપરેટિંગ સિસ્ટમ માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>સીપીયુ માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>અન્ય ડિવાઇસ માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ઊર્જા માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>છાપણી માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>માઉસ માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>નેટવર્ક એડેપ્ટર માહિતી લોડ કરી રહ્યું છે...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>અક્ષમ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ઉપલબ્ધ નથી</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>અક્ષમ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ઉપલબ્ધ નથી</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>માહિતી વિશે</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>શૉર્ટકટ દર્શાવો</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>બંધ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>મદદ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>કોપી કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>સિસ્ટમ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>નિકાસ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>અપડેટ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>ડીવાઇસ મેનેજર</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>હાર્ડવેર</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ડ્રાઇવર્સ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>મોનિટર</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>ઓવરવિઝ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>ડિસ્પ્લે એડેપ્ટર</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>સીપીયુ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>નેટવર્ક એડેપ્ટર</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>બેટરી</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>ઓછા</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ડ્રાઇવર પ્લેટફોર્મ વર્ઝન</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>બેકઅપ કરી શકાય તે ડ્રાઇવર્સ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>બેકઅપ કરેલ ડ્રાઇવર્સ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>અપડેટ કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>રદ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>પછીનું</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>ચેતવણી</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ડ્રાઇવર અનિસ્તાલેશન પછી ડીવાઇસ ઉપલબ્ધ નથી</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>અનિસ્તાલેશન કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>અનિસ્તાલેશન કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>અપડેટ સફળ થયો છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>અનિસ્તાલેશન સફળ થયો છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>अपडेट अयशस्वी</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>अनइंस्टॉलेशन अयशस्वी</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ओके</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>पुढे</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>चुनलेला फोल्डर अस्तित्व नाही, कृपया पुन्हा निवडा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>अपडेट</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>मागे</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>भेंगा पॅकेज</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>अयोग्य पॅकेज आर्किटेक्चर</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>चुनलेला फाइल अस्तित्व नाही, कृपया पुन्हा निवडा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>हे ड्रायव्हर नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>इंस्टॉल करता आले नाही - डिजिटल सांकेतिक नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>अज्ञात त्रुटी</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ड्रायव्हर मॉड्यूल आढळले नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>अमान्य मॉड्यूल फॉर्मेट</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ड्रायव्हर मॉड्यूलच्या अवलंबून असतात</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ड्रायव्हर इंस्टॉल करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ड्रायव्हर बॅकअप करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ड्रायव्हर पुन्हा सुरू करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>मतदान</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>आपल्याकडे कोणताही ड्रायव्हर पुन्हा सुरू करण्यासाठी नाही, कृपया पहिले बॅकअप करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>बॅकअप ड्रायव्हर येथे जा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>बॅकअप वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>पुन्हा सुरू करता येणारे ड्रायव्हर</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>रिफ्रेश</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>एक्सपोर्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>ओव्हरव्ह्यू</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ड्राइवर इंस्टॉल</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ड्राइवर बैकअप</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ड्राइवर रिस्टोर</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>उपकरण सक्रिय करण्यास फेल झाले</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>उपकरण अक्रिय करण्यास फेल झाले</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>त्याची अक्रिय करण्यास फेल झाले: उपकरण एसएन मिळवता आले नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ड्रायवर अपडेट करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ड्रायवर अनइंस्टॉल करा</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>अद्यतनित करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>eksport करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>कॉपी करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ओव्हरव्यू</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>अद्यतनित करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>eksport करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>कॉपी करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>सक्रिय करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ड्रायवर अपडेट करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ड्रायवर अनइंस्टॉल करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>कंप्यूटर जागे करण्यास परवानगी द्या</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>अक्रिय करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>त्याची अक्रिय करण्यास फेल झाले: उपकरण एसएन मिळवता आले नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>उपकरण अक्रिय करण्यास फेल झाले</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>उपकरण जागृत करतान अयशस्वी झाले</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ड्रायवर अपडेट करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ड्रायवर अनइंस्टॉल करा</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>उप वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>उप डिव्हाईस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ड्रायवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ड्रायवर स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ड्रायवर सक्रिय करण्याचे कमांड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>कॉन्फिग स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>लेटंसी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>फिजिकल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>سيسفس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>हॅंडलर्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>प्रॉप</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ईवी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>की</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>बस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>बायोस इंफॉर्मेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>बेस बोर्ड इंफॉर्मेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>सिस्टम इंफॉर्मेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>चैसिस इंफॉर्मेशन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>फिजिकल मेमरी एरे</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>रिलीज डेट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>एड्रेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>रनटाइम साइज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>रोम साइज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>चरित्र</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>बायोस रिव्हिजन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>फायरमेल सॉफ्टवेयर रिव्हिजन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>उत्पाद नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>सिरियल नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>एसेट टैग</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>फीचर्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>चैसिस मध्ये स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>चैसिस हॅंडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>सामग्री वाले ऑब्जेक्ट हॅंडल्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>यूयूआई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>वेक-अप प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>एसक्यू नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>परिवार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>loc</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>स्टार्टअप स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>बिजली पुरवठा स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>थर्मल स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>सुरक्षा स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ओईएम माहिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>उंची</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>बिजली तारांची संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>सामग्री घटक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>स्थळ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>त्रुटी निवारण प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>अधिकतम क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>त्रुटी माहिती हांडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>उपकरणांची संख्या</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>बिओस रोमसाइज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>प्रकाशन दिनांक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>बोर्ड नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>एसएमबीआयओस वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>भाषा वर्णन प्रारूप</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>स्थापन करता येई शकणारी भाषा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>वर्तमान स्थापित भाषा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>बीडी पत्ता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>एएल एमटीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>एसको एमटीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>पॅकेट प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>लिंक नीती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>लिंक मोड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>क्लास</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>सेवा क्लासेस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>क्लास डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>एचसी वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>एलएमपी वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>उपवर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>सिरियल आईडी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>उत्पाद</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>विवरण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>चालू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>खोजी शक्य</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>जोडी शक्य</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>मोड़लियस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>खोज रहे</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>ड्राइवर मॉड्यूल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>डिवाइस फाइल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>डिवाइस फाइल्स</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>डिवाइस नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>अनुप्रयोग</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>स्थिती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>तार्किक नाव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>एनएसआई वर्जन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>सीपीयू इम्प्लेमेंटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>सीपीयू आर्किटेक्चर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>सीपीयू वेरियंट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>सीपीयू पार्ट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>सीपीयू रिव्हिजन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>एक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>नौ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>दहा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>बारावी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>चौदह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>सोळा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>अठारावी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>विंटी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>विंटी दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>विंटी चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>विंटी छ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>विंटी आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>तीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>तीस दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>तीस चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>तीस छ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>तीस आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>चौतीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>चौतीस दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>चौतीस चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>चौतीस छ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>चौतीस आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>पंचाश</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>पंचाश दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>पंचाश चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>पंचाश छ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>पंचाश आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>छप्पन</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>छप्पन दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>छप्पन चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>साठ छिनी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>साठ आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>सत्तर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>सत्तर दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>सत्तर चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>सत्तर छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>सत्तर आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>अट्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>अट्टर दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>अट्टर चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>अट्टर छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>अट्टर आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>नव्वर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>नव्बर दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>नव्बर चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>नव्बर छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>नव्बर आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>एक सौ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>एक सौ आणि दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>एक सौ आणि चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>एक सौ आणि छह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>एक सौ आणि आठ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>एक सौ आणि दह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>एक सौ आणि बार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>एक सौ आणि चौदह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>एक सौ आणि सोळ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>एक सौ आणि अठाराव</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>एक सौ आणि विंती</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>एक सौ आणि विंती दो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>एक सौ आणि विंती चार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>एक सैकड़ा और बारहतीस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>एक सैकड़ा और बारहअठारह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>एक सैकड़ा और इकतीसदो</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>दो सैकड़ा और पचासछह</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>जीडीडीआर क्षमता</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>जीपीयू वेंडर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>जीपीयू प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>ईजीएल संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>ईजीएल क्लाइंट एपीआई</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>जीएल संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>जीएलएसएल संस्करण</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>अज्ञात</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>अद्वितीय</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>एमएससी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>हार्डवेयर क्लास</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>सीपीयू</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>कोई सीपीयू नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>मदरबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>कोई मदरबोर्ड नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>मेमोरी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>कोई मेमोरी नहीं मिली</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>स्टोरेज</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>कोई डिस्क नहीं मिली</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ड्राइवर बैकअप असफल रहा!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>कृपया फिर से प्रयास करें या हमें विवरण दें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ड्राइवर बैकअप असफल रहा!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>डिस्प्ले एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>कोई जीपीयू नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>मोनिटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>कोई मोनिटर नहीं मिला</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>नेटवर्क एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>कोणताही नेटवर्क एडाप्टर नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>सॉंड एडाप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>कोणताही आउडियो डिव्हाईस नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>ब्लूटूथ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>कोणताही ब्लूटूथ डिव्हाईस नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>अ‍ॅलर PCI डिव्हाईस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>कोणताही अ‍ॅलर PCI डिव्हाईस नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>पॉवर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>कोणतीही बॅटरी नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>कीबोर्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>कोणतीही कीबोर्ड नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>माऊस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>कोणतीही माऊस नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>प्रिंटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>कोणतीही प्रिंटर नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>कॅमेरा</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>कोणतीही कॅमेरा नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>सी-डी रोम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>कोणतीही सी-डी रोम नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>अ‍ॅलर डिव्हाईस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>कोणताही अ‍ॅलर डिव्हाईस नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>ॲरे हॅंडल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>फॉर्म फॅक्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>सेट</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>बॅंक लोकेटर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>टाइप डिटेल</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>पार्ट नंबर</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>रॅंक</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>मेमरी टेक्नॉलॉजी</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ક્ષમતા મેમરી ઑપરેટિંગ મોડ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ફાયરવર્સ વર્ઝન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>મોડ્યૂલ મેનુફેક્ચરર આઇડી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>મોડ્યૂલ પ્રોડક્ટ આઇડી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>મેમરી સબસિસ્ટમ કંટ્રોલર મેનુફેક્ચરર આઇડી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>સબસિસ્ટમ મેમરી કંટ્રોલર પ્રોડક્ટ આઇડી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>અનાદર્શ આયરી આયસિઝ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>સામાન્य આયરી આયીસિઝ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>કેશ આયરી આયીસિઝ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>લૉજિકલ આયરી આયીસિઝ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>ઇંચ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>તારીખ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>આઇઓપોર્ટ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>નેટવર્ક</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>બેટ્રી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>નેટિવ પાથ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>પવર સપ્લાય</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>અપડેટ કરેલ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>ઇતિહાસ છે</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>સ્ટેટિસ્ટિક્સ છે</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ચાર્જ કરી શકાય</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>સ્થિતિ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>ચેતવણી સ્તર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ઊર્જા</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ઊર્જા ખાલી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ઊર્જા પૂરી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ઊર્જા પૂરી ડિઝાઇન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ઊર્જા દર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>વોલ્ટેજ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>ટકાવારી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>તકનોલોજી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ઇકોન નામ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ઑનલાઇન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>ડેમોન વર્ઝન</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>બેટરી પર</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>લિડ બંધ છે</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>લિડ હાજર છે</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>ક્રિટિકલ ક્ષમતા</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>કોપીસ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>જોબ કેલેલ બાદ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>જોબ હોલ કરો સુધી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>જોબ પ્રિઓરિટી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>માર્કર ચેન્જ ટાઇમ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>નંબર અપ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>ઓરિએન્ટેશન રિક્વેસ્ટેડ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>પ્રિંટ કલર મોડ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>પ્રિંટર જોબ સ્વીકૃતિ કરી રહ્યો છે</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>પ્રિંટર શેર કરેલો છે</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>પ્રિંટર ટેમ્પરીરી છે</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>પ્રિંટર મેક અને મોડેલ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>પ્રિંટર સ્ટેટ ચેન્જ ટાઇમ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>પ્રિંટર સ્ટેટ કારણો</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>પ્રિંટર ટાઇપ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>પ્રિંટર યુઆરિ સપોર્ટેડ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>બાજુઓ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>એસએસડી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>એચડીડી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>બસ માહિતી</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>લોજિકલ સેક્ટર સાઇઝ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>સેક્ટર સાઇઝ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>هندس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>ज्योमेट्री (लॉजिकल)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>उपकरण प्रबंधक</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>उपकरण प्रबंधक हार्डवेयर जानकारी देखने और उपकरणों के प्रबंधन के लिए एक उपयोगी उपकरण है।</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>निर्माणकर्ता नए ड्राइवर उपलब्ध हैं! अब इन्स्टॉल या अपडेट करें।</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>देखें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>उप-फोल्डर शामिल करें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>इस पथ में ड्राइवर खोजें</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 ड्राइवर अपडेट उपलब्ध हैं'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'समय चेक किया गया: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 के लिए ड्राइवर डाउनलोड कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'डाउनलोड स्पीड: %1 डाउनलोड किया %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 के लिए ड्राइवर इंस्टॉल कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 ड्राइवर इंस्टॉल किए गए, %2 ड्राइवर विफल हुए'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 ड्राइवर इंस्टॉल किए गए'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ड्राइवर इंस्टॉल करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>नेटवर्क त्रुटि। पुनः सं连接 कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'डाउनलोड स्पीड: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>आपके ड्राइवर अपडेट किए गए हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>सभी ड्राइवर बैकअप कर लिए गए हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 ड्राइवर कुल, जिनमें से %2 बैकअप कर लिए गए हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 ड्राइवर बैकअप किए जा सकते हैं, इसे तुरंत करने की सलाह दी जाती है</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 ड्राइवर बैकअप किए जा सकते हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 ड्राइवर के बैकअप, कुल %2 ड्राइवर</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'बैकअप कर रहे हैं: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 ड्राइवर बैकअप किए गए, %2 ड्राइवर विफल हुए'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ड्राइवर बैकअप करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 ड्राइवर बैकअप किए गए'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 ड्राइवर बहाल किए जा सकते हैं</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>कृपया एक ड्राइवर चुनें जिसे बहाल किया जाए</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ड्रायवर रिस्टोर करत आहे...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>रिस्टोर करत आहे: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>रीबूट</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>मूळ ड्रायवर रिस्टोर करण्यासाठी दृष्टी द्या</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>बॅकअप पाथ पहा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>सर्व बॅकअप करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>परताभर द्या</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>मला पुन्हा प्रयत्न करा किंवा %1 आमच्यासोबत संपर्क साधा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>सर्व इंस्टॉल करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>पुन्हा स्कॅन करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>रद्द करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>हार्डवेअर डिव्हाइस ड्रायवर स्कॅन करत आहे, कृपया वेळ द्या...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>स्कॅन करत आहे %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>स्कॅन अयशस्वी ठरले</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>नेटवर्क उपलब्ध नाही</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>कृपया आपला नेटवर्क कनेक्शन तपासा</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>मला पुन्हा स्कॅन करा किंवा %1 आमच्यासोबत संपर्क साधा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>आपण एक ड्रायवर इंस्टॉल करत आहे, जे आपण बाहेर पडल्यास तो अडवला जाईल.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>आपण विचार करत आहे का बाहेर पडायचा?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>बाहेर पडा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>रद्द करा</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>आपण ड्रायवर बॅकअप करत आहे, जे आपण बाहेर पडल्यास तो अडवला जाईल.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>आपण ड्रायवर रिस्टोर करत आहे, जे आपण बाहेर पडल्यास तो अडवला जाईल.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>ब्लूटूथ एडॅप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>इमेजिंग डिव्हाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>डिस्प्ले एडॅप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>सॉंड कार्ड</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>नेटवर्क एडॅप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>वायरलेस नेटवर्क एडॅप्टर</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>इंस्टॉलेशन यशस्वी</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>સ્થાપના અસફળ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>ડાઉનલોડ કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>સ્થાપના કે માંગે છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>સ્થાપિત નથી</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>અપડેટ કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>અપેક્ષા કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>બેકઅપ કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>બેકઅપ કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>બેકઅપ અસફળ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>બેકઅપ સફળ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>પુનઃસ્થાપના કરી રહ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>ઓળખી શકાય નહીં થયેલો ત્રુટી</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>નેટવર્ક ત્રુટી</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>બંધ કરી દેવામાં આવ્યું છે</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ડ્રાઇવર ફાઇલો મેળવવામાં અસફળ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>અપડેટ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>બેકઅપ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>પુનઃસ્થાપના</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>સ્થાપના</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>નિષ્શ્વાસ આપો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>નવીનતમ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>નિકાસ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>ડ્રાઇવર અપેટ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ડ્રાઇવર અનસ્થાપના કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>કમ્પ્યુટરને જાગે તેને મંજૂરી આપો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>સક્ષમ કરો</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>નવીનતમ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>નિકાસ કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>કોપી કરો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>નિષ્શ્વાસ આપો</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>अपस्त</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>कृपया एक स्थानीय फोल्डर निर्वाचन करा</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>लोड होत आहे...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ms.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ms.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ms">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Maklumbalas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Lagi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Kuncup</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Lagi</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Lagi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Kuncup</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Lagi</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Kuncup</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nama Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Cip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Keterangan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Alamat Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Cipset</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Kuasa Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versi Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Maklumat Bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nama Logikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Alamat MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Maklumat Bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Kuasa Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID Teras</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Jaluran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Seni Bina</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Keluarga CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Pemproses</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Teras</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Pemayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Bendera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Sambungan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Cache L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Cache L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Cache L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Cache L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Tahap</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Kelajuan Maks.</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Ingatan Grafik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Alamat Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Port IO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Maklumat Bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Resolusi Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Resolusi Minimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Resolusi Semasa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Keterangan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>OutputDigital</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Output Paparan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Maklumat Bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Kuasa Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Nombor Siri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Antara Muka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Maklumat Bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Arus Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Selayang Pandang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Kuantiti CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Papan Induk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Penyesuai Paparan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Penyesuai Bunyi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Storan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Lain-lain Peranti PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Bateri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Penyesuai Rangkaian</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Tetikus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Papan Kekunci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Pencetak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Lain-lain Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Saiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Jumlah Lebar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Lokasi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Nombor Siri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Voltan Terkonfigur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Voltan Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Voltan Minimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Kelajuan Terkonfigur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Lebar Data</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Input Paparan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Jenis Antara Muka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Resolusi Disokong</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Resolusi Semasa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Nisbah Paparan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor Utama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Saiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Nombor Siri</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Pembekal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Jenis Media</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Saiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Keupayaan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versi Perisian Tegar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Kelajuan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Keterangan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Nombor Siri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Antara Muka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Kadar Putaran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Pilih satu pemacu untuk dikemas kini</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Tiada pemacu ditemui dalam folder ini</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Memuatkan Maklumat Peranti Audio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Memuatkan Maklumat BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Memuatkan Maklumat CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Memuatkan Maklumat Sistem Pengoperasian...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Memuatkan Maklumat CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Memuatkan Maklumat Peranti Lain...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Memuatkan Maklumat Kuasa...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Memuatkan Maklumat Pencetak...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Memuatkan Maklumat Tetikus...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Memuatkan Maklumat Penyesuai Rangkaian...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Maklumat Peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Papar pintasan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Tutup</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Segar Semula</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Pengurus Peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Perkakasan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Selayang Pandang</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Penyesuai Paparan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Penyesuai Rangkaian</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Bateri</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Lagi</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Versi Semasa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>Versi Platform Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Tindakan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Pemacu Boleh Sandar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Pemacu Sandar</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Mengemas kini</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Amaran</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Peranti menjadi tidak tersedia setelah menyahpasang pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Nyahpasang</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Menyahpasang</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Kemas kini berjaya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Penyahpasangan berjaya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Kemas kini gagal</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Penyahpasangan gagal</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Folder yang dipilih tidak wujud, sila pilih yang lain</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Kemas kini</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Pakej rosak</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Seni bina pakej tidak sepadan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Faild yang dipilih tidak wujud, sila pilih yang lain</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Ia bukan pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Gagal dipasang - tiada tandatangan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Ralat tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Modul pemacu tidak ditemui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Format modul tidak sah</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Modul pemacu mempunyai dependensi</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Nama Peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versi Tersedia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Saiz</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Tindakan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Versi Baharu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Versi Semasa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Pemacu hilang (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Pemacu lapuk (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Pemacu terkini (%1)</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>Pasang Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>Sandar Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>Pulih Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Maklumbalas</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Anda tiada pemacu yang perlu dipulihkan, sila sandar dahulu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Pergi ke Pemacu Sandar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nama</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Versi Semasa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Versi Sandar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Tindakan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Pemacu Boleh Pulih</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Segar Semula</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Selayang Pandang</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Pasang Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Sandar Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Pulih Pemacu</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Gagal membenarkan peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Gagal melumpuhkan peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Gagal melumpuhkannya: Gagal mendapatkan SN peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Kemas Kini Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Nyahpasang Pemacu</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Segar Semula</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Selayang Pandang</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Benarkan</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Dayakannya supaya komputer dapat dibangunkan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Gagal melumpuhkannya: Gagal mendapatkan SN peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Gagal melumpuhkan peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Gagal membenarkan peranti</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Kemas Kini Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Nyahpasang Pemacu</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>SubVendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>SubPeranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Status Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Cmd Pengaktifan Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Status Konfig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>kependaman</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Pemegang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Maklumat BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Maklumat Papan Utama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Maklumat Sistem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Maklumat Casis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Tatasusunan Ingatan Fizikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Tarikh Keluaran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Saiz Masa Jalan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Saiz ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Sifat-Sifat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revisi BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revisi Perisian Tegar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Nama Produk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Nombor Siri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Tag Aset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Fitur-Fitur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Lokasi Dalam Casis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Pemegang Casis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Pemegang Objek Terkandung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Jenis Bangun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>Nombor SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Keluarga</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Kunci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Keadaan But</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Keadaan Bekalan Kuasa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Keadaan Termal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Status Keselamatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Maklumat OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Tinggi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Bilangan Wayar Kuasa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elemen Terkandung</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Lokasi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Ralat Jenis Sambungan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Kapasiti Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Ralat Pemegang Maklumat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Bilangan Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Tarikh keluaran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nama papan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versi SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format Keterangan Bahasa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Bahasa Boleh Dipasang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Bahasa Terpasang Semasa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Alamat BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Jenis bingkisan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Dasar paut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Mod pautan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Kelas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Kelas Perkhidmatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Kelas Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versi HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versi LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>ID Serial</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>keterangan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Hidup</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Boleh Ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Boleh Pasang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Menemukan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Modul Pemacu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Fail Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Fail Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Nombor Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplikasi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>nama logikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Pelaksanan CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Seni bina CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Varian CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Bahagian CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revisi CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Satu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Sembilan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Sepuluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dua Belas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Empat Belas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Enam Belas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Lapan Belas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Dua Puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Dua Puluh Satu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Dua Puluh Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Dua Puluh Enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Dua Puluh Lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Tiga Puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Tiga Puluh Dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Tiga Puluh Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Tiga Puluh Enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Tiga Puluh Lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Empat Puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Empat Puluh Dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Empat Puluh Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Empat Puluh Enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Empat Puluh Lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Lima Puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Lima Puluh Dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Lima Puluh Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Lima Puluh Enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Lima Puluh Lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Enam Puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Enam Puluh Dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Enam Puluh Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Enam-puluh-enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Enam-puluh-lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Tujuh-puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Tujuh-puluh-dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Tujuh-puluh-empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Tujuh-puluh-enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Tujuh-puluh-lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Lapan-puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Lapan-puluh-dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Lapan-puluh-empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Lapan-puluh-enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Lapan-puluh-lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Sembilan-puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Sembilan-puluh-dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Sembilan-puluh-empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Sembilan-puluh-enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Sembilan-puluh-lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Seratus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Seratus Dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Seratus Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Seratus Enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Seratus Lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Seratus Sepuluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Seratus Sebelas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Seratus Empat Belas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Seratus Enam Belas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Seratus Lapan Belas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Seratus Dua Puluh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Seratus Dua Puluh Dua</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Seratus Dua Puluh Empat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Seratus Dua Puluh Enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Seratus Dua Puluh Lapan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Seratus Dua Puluh Sembilan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Dua ratus lima puluh enam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Kapasiti GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Pembekal GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Jenis GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versi EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>API klien EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versi GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versi GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Tidak diketahui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Kelas Perkakasan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Tiada CPU ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Papan Induk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Tiada papan induk ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Tiada ingatan ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Storan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Tiada cakera ditemui</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Pemulihan pemacu gagal!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>Cuba sekali lagi atau beri maklumbalas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Gagal menyandar pemacu!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Penyesuai Paparan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Tiada GPU ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Tiada monitor ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Penyesuai Rangkaian</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Tiada penyesuai rangkaian ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Penyesuai Bunyi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Tiada peranti audio ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Tiada pemacu Bluetooth ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Lain-lain Peranti PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Tiada peranti PCI lain ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Hidup</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Tiada bateri ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Papan Kekunci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Tiada papan kekunci ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Tetikus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Tiada tetikus ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Pencetak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Tiada pencetak ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Tiada kamera ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Tiada CD-ROM ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Lain-lain Peranti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Tiada peranti lain ditemui</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Pemegang Tatasusunan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Faktor Bentuk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Set</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Lokasi Bank</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Perincian Jenis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Nombor Bahagian</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Kedudukan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Teknologi Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Keupayaan Mod Pengoperasian Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versi Perisian Tegar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID Pengilang Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID Produk Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID Pengilang Pengawal Subsistem Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID Produk Pengawal Subsistem Ingatan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Saiz Tidak-Meruap</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Saiz Meruap</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Saiz Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Saiz Logikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>inci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Tarikh</translation>
     </message>
@@ -3692,313 +3453,294 @@
         <translation>sisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>maklumat bas</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>saizsektorlogikal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>saizsektor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometri (Logikal)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Pengurus Peranti</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Pengurus Peranti ialah sebuah alat mudah yang dapat melihat maklumat perkakasan dan mengurus peranti-peranti.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Pemacu baharu tersedia! Sila pasang atau kemas kini ia sekarang.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Lihat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Termasuk subfolder</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Gelintar pemacu dalam laluan ini</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 kemas kini pemacu telah tersedia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Masa diperiksa: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Memuat turun pemacu untuk %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Kelajuan muat turun: %1 Muat turun %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Memasang pemacu untuk %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 pemacu dipasang, %2 pemacu mengalami kegagalan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 pemacu dipasang</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Gagal memasang pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Ralat rangkaian. Menyambung semula...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Kelajuan muat turun: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Pemacu anda adalah yang terkini</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Semua pemacu telah disandarkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Sejumlah %1 buah pemacu, iaitu %2 telah disandarkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Anda memiliki %1 buah pemacu yang boleh disandarkan, disarankan melakukannya secepat yang mungkin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Anda mempunyai %1 buah pemacu yang boleh disandarkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Menyandar %1 buah pemacu, daripada sejumlah %2 buah pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Menyandar: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 buah pemacu disandar, %2 buah pemacu gagal</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Gagal menyandar pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 buah pemacu disandarkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Anda mempunyai %1 buah pemacu yang boleh dipulihkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Sila pilih sebuah pemacu untuk dipulihkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Pemacu dipulihkan...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Memulihkan: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>but semula</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Sila %1 supaya pemacu yang baru dipasang berkesan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Lihat laluan sandar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Sandar Semua</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>serah maklum balas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Cuba sekali lagi atau %1 kepada kami</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Pasang Semua</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Imbas Sekali Lagi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Mengimbas pemacu peranti perkakasan, tunggu sebentar...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Mengimbas %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Pengimbasan gagal</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Rangkaian tidak tersedia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Sila periksa sambungan rangkaian anda</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Sila imbas sekali lagi atau %1 kepada kami</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Anda sedang memasang sebuah pemacu, yang akan terganggu sekiranya anda keluar.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Anda pasti mahu keluar?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Keluar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Anda sedang menyandar pemacu, yang boleh disampuk jika anda keluar.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Anda sedang memulihkan pemacu, yang boleh disampuk jika anda keluar.</translation>
     </message>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Peranti pengimejan</translation>
     </message>
@@ -4114,22 +3855,22 @@
         <translation>Gagal mendapatkan fail pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Kemas kini</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Sandar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Pulih</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Pasang</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Segar Semula</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Kemas kini pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Nyahpasang pemacu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Dayakannya supaya komputer dapat dibangunkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Benarkan</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Segar Semula</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Lumpuhkan</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Tidak tersedia</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Sila pilih satu folder setempat</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Memuatkan...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_my.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_my.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="my">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>အကူအညီပေး</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>အကောင်းဆုံး</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>ပိုများ</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>အကြွေးအားများကိုအကြောင်းပြောပြီးနောက်</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>အကြွေးအားများကိုပြန်စွဲထား</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>ပိုများ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>ပိုများကိုပိတ်</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>အဆိုးမြောက်</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>အသုံးပြုနိုင်မှုမရှိ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>အထုတ်အမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>အမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>ရောင်းချသူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ပိုးကိုင်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>စွမ်းဆောင်နိုင်မှုများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ပြင်ဆင်မှု</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>အမှတ်မှာ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>အသုံးပြုနိုင်မှုမရှိ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>အဆိုးမြောက်</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>အမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>ရောင်းချသူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>မျိုးဆောင်း</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ရောင်းချသူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>အဆင့်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ပိုးကိုင်းအစီအစဉ်</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>အမည်ပေါင်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>အမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>โมเดล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>พลังงานสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>เวอร์ชันไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>ชื่อตรรกะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>ที่อยู่ MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>โมเดล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>พลังงานสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>รหัส CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>รหัสคอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>เส้นสัมผัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>လုပ်ဆောင်မှုများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>ਬੋਗੋਮਿਪਸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>ਅਰਕੀਟੈਕਚਰ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>ਸੀਪੀਯੂ ਪਰਿਵਾਰ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>ਮੋਡਲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>ਪ੍ਰੋਸੈਸਰ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>ਕੋਰ (ਕੋਰ)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ਵਿਰਤੁਆਲਾਈਜੇਸ਼ਨ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>ਫਲੈਗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>ਐਕਸਟੈਂਸ਼ਨਸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>ਐਲ3 ਕੈਸ਼</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>ਐਲ2 ਕੈਸ਼</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>ਐਲ1ਆਈ ਕੈਸ਼</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>ਐਲ1ਡ ਕੈਸ਼</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>ਸਟੀਪਿੰਗ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>ਸਪੀਡ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>ਮੈਕਸ ਸਪੀਡ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>ਨਾਮ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ਵੈਂਡਰ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>ਮੋਡਲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ਵਰਜਨ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ਗ੍ਰਾਫਿਕਸ ਮੈਮੋਰੀ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ਫਿਜ਼ਿਕਲ ਆਈਡੀ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>ਮੈਮੋਰੀ ਐਡਰੈਸ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>ਆਈਓ ਪੋਰਟ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>ਬਸ ਐਂਫੋ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>ਮੈਕਸਿਮਮ ਰੈਸੋਲੂਸ਼ਨ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>ਮਿਨਿਮਮ ਰੈਸੋਲੂਸ਼ਨ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>ਸੈਵਨ ਰੈਸੋਲੂਸ਼ਨ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ਡਰਾਈਵਰ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>ਵੇਰੇਵਨ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>เอาต์พุตดิจิทัล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>เอาต์พุตการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>อินทีร์พ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>โมเดล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>พลังงานสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>โมเดล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>อินเทอร์เฟซ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>กระแสไฟฟ้าสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>ภาพรวม</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>ซีพียู</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>จำนวนซีพียู</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>เมนบอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>หน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>แอดเปอร์เตอร์การแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>แอดเปอร์เตอร์เสียง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>การจัดเก็บ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>อุปกรณ์ PCI อื่น ๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>แบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>บลูทูธ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>แอดเปอร์เตอร์เครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>เมาส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>คีย์บอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>จอภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>ซีดีอาร์โอ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>เครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>กล้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>อุปกรณ์อื่น ๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>อุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ระบบปฏิบัติการ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>ขนาด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ความกว้างทั้งหมด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ตำแหน่ง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>เลขลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>แรงดันที่กำหนด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>แรงดันสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>แรงดันต่ำสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>ความเร็วที่กำหนด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ความกว้างข้อมูล</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>อินพุตการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ประเภทอินเตอร์เฟซ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>ความละเอียดที่รองรับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>ความละเอียดปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>อัตราส่วนการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>หน้าจอหลัก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ขนาด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>เลขลำดับ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลสายส่ง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>เวอร์ชันไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>อัตราสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>อัตราการต่อรอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>พอร์ต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto Negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Address Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logical Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Unavailable</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Disable</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Bus Info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Input/Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Capabilities</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Vendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Bus Info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>กำลังไฟฟ้าสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>สถานะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>กำลังจุ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>แรงดัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>สล็อต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>ความจุในการออกแบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>แรงดันในการออกแบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>เวอร์ชันของ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>เลขที่ลำดับของ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>วันที่ผลิตของ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>เคมีของ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>อุณหภูมิ</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>แบ่งปัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>สถานะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>ტიპ ინტერფეის</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>გააქტიურე</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>მწერალი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>მედია ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>ზორი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>ვეอรსიი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>უნარები</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>ფირმვერსიია ვერსიი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>აღწერა</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>სერიის ნომერი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>ინტერფეისი</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>მობრუნების სიჩქარე</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>არ ხელმისაწვდომია</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>ახალი აპდეიტისთვის არჩიე დრაივერი</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>ამ საქაღალდეში არ არის დრაივერი</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>აუდიო მოწყობილობის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>ბიოსის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>ჩატვირთვა სადისკეტო ინფორმაცია...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ოპერაციის სისტემის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>პიროვნების ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>სხვა მოწყობილობების ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ენერგიის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>პრინტერის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>მაუსის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>ქსელის ადაპტერის ინფორმაციის ჩატვირთვა...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>გააქტიურე</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>არ ხელმისაწვდომია</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>გააქტიურე</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>არ ხელმისაწვდომია</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>အချက်အလက်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>ပြသရုပ်သံ တံခွန်းများ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>ပိတ်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>ကူညီပေးချက်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>အမှန်ချက်ကူး</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>စနစ်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ထုတ်ယူ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>အသစ်ပြန်လည်တင်ဆောင်း</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>အကြိမ်ရုပ်သံ စီမံခန့်မှန်း</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>အသုံးပြုရုပ်သံ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>နှိပ်ကူးများ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>မှန်ပြင်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>အကြမ်းအားဖြင့် အကျဉ်းချက်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>ပြသရုပ်သံ အကြိမ်ရုပ်သံ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>စွမ်းဆောင်ရည်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>အကြိမ်ရုပ်သံ နှိပ်ကူး</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>အားအားများ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>ပိုများ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>နှိပ်ကူး ပိုင်းအားဖြင့် အက်ပ်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>အားဖြင့် အက်ပ်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>အက်ပ်များ အကြိမ်ရုပ်သံ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>တိုးတက်နေသည်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>အပ်ပြီး</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>နောက်တစ်ခု</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>အကြောင်းပြုချက်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>နှိပ်ကူး အပ်ပြီး နောက်တစ်ခု အကြိမ်ရုပ်သံ အသုံးပြုမှုမရှိတော့မည်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>အပ်ပြီး</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>အပ်ပြီးနေသည်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>တိုးတက်မှုအောင်မြင်ခဲ့သည်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>အပ်ပြီးမှုအောင်မြင်ခဲ့သည်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>ការស្ទើរបានបរាជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>ការដោះបានបរាជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>បាទ/លោក</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>បន្ទាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>ថ្នាក់ដែលបានជ្រើសរើសមិនមានទេ សូមជ្រើសរើសឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>ស្ទើរ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>មុន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>កញ្ចប់ខូច</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>ប្រវត្តិរូបមូលដ្ឋានមិនសមស្រើប</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>ឯកសារដែលបានជ្រើសរើសមិនមានទេ សូមជ្រើសរើសឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>វាមិនមែនជាកូដបម្លើសទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>មិនអាចដំឡើងបាន - គ្មានសញ្ញាបញ្ញានៃកូដបម្លើស</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>សំឡេងអាការ៍មិនស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>មូឌុលកូដបម្លើសមិនត្រូវបានរកឃើញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>រាងមូឌុលមិនត្រឹមត្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>មូឌុលកូដបម្លើសមានការប្រើប្រាស់ដែលប្រឈម</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ការដំឡើងកូដបម្លើស</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ការកែតម្រូវកូដបម្លើស</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ការស្ទើរកូដបម្លើស</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>ការផ្តល់មតិ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>អ្នកមិនមានកូដបម្លើសណាមួយដែលអាចស្ទើរបានទេ សូមកែតម្រូវសិនជាមុន</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>ទៅកាន់ការកែតម្រូវកូដបម្លើស</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>វ័រស៊ីអែនកែតម្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>កូដបម្លើសដែលអាចស្ទើរបាន</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>ធ្វើឱ្យថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ចែកចាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>សង្ខេប</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>နှိပ်သူကို ဖြစ်ပေါ်စေရန်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>နှိပ်သူကို အာမခံရန်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>နှိပ်သူကို ပြန်လည်ဖြစ်ပေါ်စေရန်</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>ไม่สามารถเปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>ไม่สามารถปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ไม่สามารถปิดใช้งานได้: ไม่สามารถดึงค่า SN ของอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>รีเฟรช</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ภาพรวม</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>รีเฟรช</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>เปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>อนุญาตให้อุปกรณ์ตื่นเครื่องได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ไม่สามารถปิดใช้งานได้: ไม่สามารถดึงค่า SN ของอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>ไม่สามารถปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>ไม่สามารถเปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>ผู้ผลิตย่อย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>อุปกรณ์ย่อย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>สถานะไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>คำสั่งการเปิดใช้งานไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>สถานะการตั้งค่า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>การส่งผ่านความล่าช้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>กายภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>ผู้จัดการ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>บัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ข้อมูล BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ข้อมูลแผ่นฐาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>ข้อมูลระบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ข้อมูลโครงกรอบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ชุดความจำทางกายภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>วันที่เผยแพร่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>ที่อยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>ขนาดการทำงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ขนาด ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>คุณลักษณะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>เวอร์ชัน BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>เวอร์ชันซอฟต์แวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ชื่อผลิตภัณฑ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ป้ายกำกับทรัพย์สิน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>คุณสมบัติ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ตำแหน่งในโครงกรอบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>อุปกรณ์โครงกรอบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>อุปกรณ์ที่บรรจุอยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>ประเภทการตื่นขึ้น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>เลขที่ SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>မိသားစု</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>တိုက်ခိုက်မှု</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>စတင်ပို့ချမှု</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>စွမ်းအင်ပံ့ပို့မှု</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>ပူနွေးမှု</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>လုံခြုံရေး အခြေအနေ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM အချက်အလက်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>အရွယ်အစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>စွမ်းအင် ပံ့ပို့ရေး လိုအပ်သော အရွယ်အစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>ပါဝင်သည့် အက်ပ်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>နေရာ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>အမှားကြောင်း အပြင်းအထိ အမျိုးအစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>အများဆုံး အရွယ်အစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>အမှားအက်ပ် အကြောင်း အကြိုက်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>အက်ပ်များ အရွယ်အစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROM အရွယ်အစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>ထုတ်ပြန်သည့် နေ့စွဲ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ကင်မရှင် အမည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS ထုတ်ကုန် အမျိုးအစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ဘာသာစကား အကြောင်း အကြံပြုချက်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>စွမ်းအင် အကြောင်း ဘာသာစကားများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>အချိန်အခြေအနေ အကြောင်း ဘာသာစကား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD လိပ်စာ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>ပို့စာ အမျိုးအစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>ဆက်သွယ်ရေး စီမံခန့်မှန်းချက်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>ဆက်သွယ်ရေး ပုံစံ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>အမျိုးအစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>ဝန်ဆောင်မှု အမျိုးအစားများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>ថ្នាក់ឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>ទំរង់ HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>ទំរង់ LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>សំណួរកម្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>ឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>លេខសម្គាល់សំណួរកម្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>ផលិតផល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>ការពិពណ៌នា</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>មានថាមពល</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>អាចស្គាល់បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>អាចតភ្ជាប់បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>កំពុងស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>មូឌុលអ្នកបម្លើក</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ឯកសារឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ឯកសារឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>លេខឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>កម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ស្ថានភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ឈ្មោះសម្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ទំរង់ ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>អ្នកអនុវត្ត CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>ស្ថានភាព​អារីតេក្តិ៍​CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>ប្រភេទ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>ផ្នែក CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>កំណែ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>មួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>ពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>បួន</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ប្រាំ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>แปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>เก้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>สิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>สิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>ยี่สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>ยี่สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>ยี่สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ยี่สิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ยี่สิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>สามสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>สามสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>สามสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>สามสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>สามสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>สี่สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>สี่สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>สี่สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>สี่สิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>สี่สิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>ห้าสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>ห้าสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>ห้าสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ห้าสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ห้าสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>หกสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>หกสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>หกสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>หกสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>หกสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>เจ็ดสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>เจ็ดสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>เจ็ดสิบสู้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>เจ็ดสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>เจ็ดสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>แปดสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>แปดสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>แปดสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>แปดสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>แปดสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>เก้าสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>เก้าสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>เก้าสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>เก้าสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>เก้าสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>หนึ่งร้อย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>หนึ่งร้อยสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>หนึ่งร้อยสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>หนึ่งร้อยหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>หนึ่งร้อยแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>หนึ่งร้อยสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>หนึ่งร้อยสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>หนึ่งร้อยสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>หนึ่งร้อยสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>หนึ่งร้อยสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>หนึ่งร้อยยี่สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>หนึ่งร้อยยี่สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>หนึ่งร้อยยี่สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>တစ်ရာနှင့် ၂၆</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>တစ်ရာနှင့် ၂၈</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>တစ်ရာနှင့် ၉၂</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>နှစ်ရာနှင့် ၅၆</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>ဂျီဒီအိုအား လျှော့ချ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>ဂျီပီး ပေးသွင်းသူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>ဂျီပီး အမျိုးအစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>အိုင်ဂျီ ဗားရျူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL သုံးသူ API များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>ဂျီအို ဗားရျူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>ဂျီအိုအော် ဗားရျူ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>မသိ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>တူညီများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>အမှားစာရင်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ထုတ်ကုန်အမျိုးအစား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>စွမ်းရည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>စွမ်းရည် မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>မိခင်ကင်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>မိခင်ကင်း မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>အမှတ်များ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>အမှတ်များ မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>သိမ်းဆည်းမှု</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>လေးချိုး မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ထုတ်ကုန် ပြန်လည်သိမ်းဆည်းမှု ကျော်လွန်ခဲ့ပါသည်</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>ကျော်လွန်ပြန်လည်ကြိုးစားပါ သို့မဟုတ် ကျွန်ုပ်တို့ကို အကြံပြုချက်ပေးပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ထုတ်ကုန် အားလုံး အမှတ်များ ကျော်လွန်ခဲ့ပါသည်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>ပြသမှု အကြိုက်ပြုချက်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>ဂျီပီး မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>မိုနီးကွန်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>မိုနီးကွန်း မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>အမှုဆောင်အမှုဆောင်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>အမှုဆောင်အမှုဆောင် မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>အသံအမှုဆောင်အမှုဆောင်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>အသံကိရိယာ မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>ဘောလ်စ်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>ဘောလ်စ်ကိရိယာ မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>အခြား PCI ကိရိယာများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>အခြား PCI ကိရိယာများ မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>အား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>ဘက်ထိန်း မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>ကျုံးကိရိယာ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>ကျုံးကိရိယာ မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>မိတ္တူကိရိယာ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>မိတ္တူကိရိယာ မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>အမှုဆောင်အမှုဆောင်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>အမှုဆောင်အမှုဆောင် မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>ကိုးကား</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>ကိုးကား မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>အခြားကိရိယာများ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>အခြားကိရိယာများ မတွေ့ပါ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>အရှုံးတွင်း အမှုဆောင်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>ပုံစံအမှုဆောင်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>စုစုပေါင်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>ဘဏ္ဍာ အမှုဆောင်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>အမျိုးအစား အမှုဆောင်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>ပိုင်းကိန်း</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>အဆင့်</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>အမှတ်အသား နည်းပညာ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ความสามารถในการทำงานโหมดความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>เวอร์ชันเฟิร์มแวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ไอดีผู้ผลิตโมดูล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ไอดีสินค้าโมดูล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ไอดีผู้ผลิตคอนโทรลเลอร์ระบบความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ไอดีสินค้าคอนโทรลเลอร์ระบบความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>ขนาดความจำที่ไม่เปลี่ยนแปลง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>ขนาดความจำที่เปลี่ยนแปลงได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>ขนาดแคช</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ขนาดตรรกะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>นิ้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>วันที่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>พอร์ต I/O</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>เครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>แบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>เส้นทางที่เป็นพื้นเมือง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>แหล่งจ่ายไฟ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>มีประวัติ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>มีสถิติ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>สามารถชาร์จได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>สถานะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>ระดับเตือนภัย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>พลังงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>พลังงานว่างเปล่า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>พลังงานเต็ม</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>พลังงานเต็มตามการออกแบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>อัตราพลังงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>แรงดัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>เปอร์เซ็นต์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>เทคโนโลยี</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ชื่อไอคอน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ออนไลน์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>เวอร์ชันดีมอน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>อยู่ในโหมดแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ฝาปิดอยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ฝาปิดมีอยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>การกระทำสำคัญ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>จำนวนสำเนา</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>ยกเลิกงานหลังจาก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>ถืองานจนถ้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>ความสำคัญของงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>เวลาที่เปลี่ยนเครื่องหมาย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>จำนวนหน้าต่อแผ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>การขอเปลี่ยนทิศทาง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>โหมดพิมพ์แบบสี</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>เครื่องพิมพ์กำลังรับงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>เครื่องพิมพ์ถูกแบ่งปัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>เครื่องพิมพ์ชั่วคราว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>เครื่องพิมพ์ยี่ห้อและรุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>เวลาที่เปลี่ยนสถานะเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>เหตุผลของสถานะเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>ประเภทเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI ที่รองรับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>ด้าน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ขนาดซีกเกตอัลที่กำหนด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>ขนาดซีกเกตอัล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ไคด์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>เรขาคณิต (ตรรกะ)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>จัดการอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>จัดการอุปกรณ์ เป็นเครื่องมือที่มีประโยชน์สำหรับการดูข้อมูลอุปกรณ์และจัดการอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>ไดรเวอร์ใหม่พร้อมใช้งาน! ติดตั้งหรืออัปเดตทันที</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>ดู</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>รวมโฟลเดอร์ย่อย</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ค้นหาไดรเวอร์ในเส้นทางนี้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'มีการอัปเดตไดรเวอร์ %1 ตัว'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'เวลาตรวจสอบ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>กำลังดาวน์โหลดไดรเวอร์สำหรับ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'ความเร็วการดาวน์โหลด: %1 ดาวน์โหลดแล้ว %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>กำลังติดตั้งไดรเวอร์สำหรับ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'ไดรเวอร์ %1 ตัวติดตั้งสำเร็จ, ไดรเวอร์ %2 ตัวล้มเหลว'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'ไดรเวอร์ %1 ตัวติดตั้งสำเร็จ'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ไม่สามารถติดตั้งไดรเวอร์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>ข้อผิดพลาดของเครือข่าย กำลังเชื่อมต่อใหม่...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'ความเร็วการดาวน์โหลด: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>ไดรเวอร์ของคณได้ทันสมัยแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>ไดรเวอร์ทั้งหมดถูกสำรองข้อมูลแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>รวมทั้งหมด %1 ไดรเวอร์ โดยมี %2 ไดรเวอร์ถูกสำรองข้อมูลแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>คุณมีไดรเวอร์ %1 ตัวที่สามารถสำรองข้อมูลได้ แนะนำให้ทำทันที</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>คุณมีไดรเวอร์ %1 ตัวที่สามารถสำรองข้อมูลได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>กำลังสำรองข้อมูลไดรเวอร์ %1 ตัว รวมทั้งหมด %2 ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'กำลังสำรองข้อมูล: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'ไดรเวอร์ %1 ตัวถูกสำรองข้อมูล, ไดรเวอร์ %2 ตัวล้มเหลว'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ไม่สามารถสำรองข้อมูลไดรเวอร์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'ไดรเวอร์ %1 ตัวถูกสำรองข้อมูล'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>คุณมีไดรเวอร์ %1 ตัวที่สามารถกู้คืนได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>กรุณาเลือกไดรเวอร์ที่ต้องการกู้คืน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver កំពុងស្តារ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>កំពុងស្តារ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>បើកឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>សូម %1 ដើម្បីឱ្យកម្មវិធីបញ្ជីត្រីក្រាមដែលបានបញ្ជីត្រីក្រាមមានប្រសិទ្ធភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>មើលផ្លូវការស្តារ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>ស្តារទាំងអស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>ផ្ញើការត្រឡប់ក្នុងការប្រតិបត្តិ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>សូមសាកល្បងម្តងទៀតឬ %1 ដល់យើង</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>បញ្ជីត្រីក្រាមទាំងអស់</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>ស្វែងរកម្តងទៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>កំពុងស្វែងរកកម្មវិធីបញ្ជីត្រីក្រាមការបញ្ជីត្រីក្រាមប្រព័ន្ធមើលងារដោយសុវត្ថិភាព...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>កំពុងស្វែងរក %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>ការស្វែងរកបានបរាជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>ប្រព័ន្ធអ៊ីនធឺណែតមិនមាន</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>សូមពិនិត្យមើលការតភ្ជាប់អ៊ីនធឺណែតរបស់អ្នក</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>សូមសាកល្បងម្តងទៀតឬ %1 ដល់យើង</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>អ្នកកំពុងបញ្ជីត្រីក្រាម ដែលនឹងត្រូវបានបញ្ឈប់ប្រសិនបើអ្នកចាកចេញ។</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>តើអ្នកជៀសវាងចាកចេញ?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ចាកចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>បិទ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>អ្នកកំពុងធ្វើការស្តារ ដែលនឹងត្រូវបានបញ្ឈប់ប្រសិនបើអ្នកចាកចេញ។</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>អ្នកកំពុងស្តារ ដែលនឹងត្រូវបានបញ្ឈប់ប្រសិនបើអ្នកចាកចេញ។</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>អ៊ីនធឺណែត Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ឧបករណ៍ការថតរូប</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>ឧបករណ៍បង្ហាញ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>ការស្តែងសំលេង</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>ឧបករណ៍អ៊ីនធឺណែត</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>ឧបករណ៍អ៊ីនធឺណែតឥតខ្សែ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>ការបញ្ជីត្រីក្រាមបានបញ្ចប់ដោយជោគជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>การติดตั้งล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>กำลังดาวน์โหลด</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>กำลังติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>ยังไม่ได้ติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>ล้าสมัย</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>รอ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>ยังไม่ได้สำรอง</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>กำลังสำรอง</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>การสำรองล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>สำรองสำเร็จ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>กำลังกู้คืน</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>ข้อผิดพลาดที่ไม่ทราบ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>ข้อผิดพลาดของเครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>ถูกยกเลิก</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ไม่สามารถดึงไฟล์ไดรเวอร์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>สำรอง</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>กู้คืน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>อนุญาตให้ปลุกคอมพิวเตอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>เปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>မရရှိနိုင်သည်</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>ကိုယ်ပိုင်ဖိုင်များကို ရွေးပါ</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>တင်ဆောင်းနေသည်...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_nb.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_nb.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nb">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Tilbakemelding</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Mer</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>EC_NOTIFY_NETWORK</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>EC_REINSTALL</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Mer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Kollapse</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Enhetsnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Produsent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Funksjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Hukommelsesadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Produsent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Produsent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Driver-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Evner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logisk navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC-adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Deaktivere</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Evner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Deaktivere</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Producent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Kjerne-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Tråder</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>CPU-familie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Processor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Kjerne(r)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualisering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Flagger</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Utvidelser</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Steg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Maks hastighet</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Grafisk hukommelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Fysisk ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Hukommelsesadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO-port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maksimal oppløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minste oppløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Nåværende oppløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Beskrivelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Utskatt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Visskatt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Evner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Businformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Styresprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Evner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interfase</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Businformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maksimal strøm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Styresprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Funksjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Oversikt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Antall CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Møtråbrett</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Minne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Videokort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Lydkort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Lagring</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Andre PCI-enhet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Nettverkkort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Tastatur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Andre enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Enhet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Totalbredde</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Lokator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Konfigurert spenning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Maksimal spenning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Minimumspenning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Konfigurert hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Databredde</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Produktionssted</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Viseinngang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Søyletype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Støtteoppløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Nåværende oppløsning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Viserforhold</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Hovedvise</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Produktionssted</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Businformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Funksjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Driverversjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Maksimal hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Forhandlingshastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Kanal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto-negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Minneadresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC-adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logiskt navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Utilgabel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Deaktivere</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Produsent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Businformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Inn/Ut</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Minne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Kapabiliteter</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Produsent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Businformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Funksjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maksimal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Deaktiv</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kapasitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Spenning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Slot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Design kapasitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Design spenning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS-serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS-tilverkningsdato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS-kjemi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Deling</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Søketype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Produsent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Medietype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Funksjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Firmware-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Beskrivelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Søketype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Roteringshastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Velg en drivere for oppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Ingen drivere funnet i denne mappen</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Laster inn lydtilfælsinfo...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Laster inn BIOS-info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Laster inn CD-ROM-info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Laster inn operativsysteminfo...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Laster inn CPU-info...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Laster inn andre enheterinfo...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Laster inn strømfunksjoner...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Laster inn printerinfo...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Laster inn musinfo...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Laster inn nettverksadapterinfo...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Utilgjengelig</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Enheter informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Vis hurtigstarter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Lukk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Hjelp</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopier</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Oppfrisk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Enheterhåndtering</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hårdvare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Oversikt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Skjermadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Nettverksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Mer</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Driver platform versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Backupable driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Backupet driver</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Oppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Neste</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Enheter blir ikke tilgjengelig etter driverdeinstallering</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Deinstallér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Deinstallerer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Oppdatering vellykket</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Deinstallering vellykket</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Oppdatering feilet</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Avinstallering feilet</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Neste</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Den valgte mappen eksisterer ikke, vennligst velg på nytt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Oppdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Forrige</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Korrupt pakke</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Ikke matchende pakkearkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Den valgte filen eksisterer ikke, vennligst velg på nytt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Det er ikke en drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Kan ikke installere - ingen digital signatur</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Ukjent feil</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Drivermodulen ble ikke funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Ugyldig modulformat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Drivermodulen har avhengigheter</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Installer drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Sikkerhetskopier drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Gjenopprett drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Tilbakemelding</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Du har ingen drivere å gjenopprett, vennligst sikkerhetskopier først</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Gå til sikkerhetskopiering av drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Sikkerhetskopiert versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Gjenopprettelige drivere</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Oppdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Oversikt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Installer drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Sikkerhetskopier drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Gjenoprettp drivere</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Klarte ikke å slå på enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Klarte ikke å slå av enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Klarte ikke å slå av det: kunne ikke hente enhetens serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Oppdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Avinstallere drivere</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Oppdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Eksportere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Oversikt</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Oppdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Eksportere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Slå på</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Oppdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Avinstallere drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Tillat det å våkne pc-en</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Slå av</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Klarte ikke å slå av det: kunne ikke hente enhetens serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Klarte ikke å slå av enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Klarte ikke å slå på enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Oppdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Avinstallere drivere</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Underleverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Underenheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Driver-status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Driver-aktivasjonskommando</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Konfigurasjonsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Fysisk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Håndterere</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>Tast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>BIOS-informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Baseboard-informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Systeminformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Chassisinformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fysisk hukommelsesarray</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Utgivelsesdato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Kjøringsstørrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM-størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Egenskaper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>BIOS-revisjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Firmware-revisjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Produktnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Eiendelsmarkør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Funksjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Plassering i chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Chassis-håndterer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Innkapslede objekthåndterere</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Vekketype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU-nummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Familie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Lås</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Starttilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Stekkerstrømstilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Termisk tilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Sikkerhetsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM-informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Høyde</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Antall stekkerkabler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Innholdsdel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Sted</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Feilkorrigeringsform</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maksimal kapasitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Feilinformasjonspeker</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Antall enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS-ROMSTØRRELSE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Utgivelsesdato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Brettnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Språkbeskrivelsesformat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Installerbare språk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Aktuelt installert språk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD-adresse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Pakketype</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Lenkemodus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Lenkemodus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klasse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Tjenesteklasser</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Enhetsklasse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Underversjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Enhetsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Seriell ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produkt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>beskrivelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Tilsluttet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Oppdagerbar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Parerbar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Oppdager</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Drivermoduler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Enhetsfil</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Enhetsfiler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Enhetsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Programvare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>tilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logisk navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU-implementer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU-arkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU-variant</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU-del</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU-revisjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>En</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>To</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Ni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Ti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Tolv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Femten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Seksten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>atten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Til</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Til to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Til fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Til seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Til åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Tretti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Tretti to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Tretti fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Tretti seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Tretti åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Forti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Forti to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Forti fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Forti seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Forti åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Femti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Femti to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Femti fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Femti seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Femti åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Seksti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Seksti to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Seksti fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Seksy seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Seksy atten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Syvty</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Syvty to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Syvty fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Syvty seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Syvty atten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Åtti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Åtti to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Åtti fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Åtti seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Åtti atten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Nittå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Nittå to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Nittå fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Nittå seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Nittå atten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>En hundre</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>En hundre og to</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>En hundre og fire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>En hundre og seks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>En hundre og åtte</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>En hundre og ti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>En hundre og tolv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>En hundre og fjorten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>En hundre og seksten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>En hundre ogatten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>En hundre og tjue</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>En hundre og tjuetto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>En hundre og tjuefire</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>En hundre og tjueseks</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>En hundre og tjeset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>En hundre og nittito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>To hundre og femtito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapasitet for GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU-leverandør</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU-type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL-klient-APIer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Ukjent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Unik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Hardverklasse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Ingen CPU funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Møtråbrett</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Ingen møtråbrett funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Hukommelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Ingen hukommelse funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Lagring</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Ingen disk funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Gjenopprettelse av drivere feilet!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Vennligst prøv igjen eller gi oss tilbakemelding</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Backup av drivere feilet!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Viseadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Ingen GPU funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Ingen monitor funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Nettverksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Ingen nettverksadapter funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Lydadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Ingen lydutstyr funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Ingen Bluetooth-enhet funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Andre PCI-enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Ingen andre PCI-enheter funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Kraft</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Ingen batteri funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Tastatur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Ingen tastatur funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Ingen mus funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Skriverskam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Ingen skriverskam funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Ingen kamera funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Ingen CD-ROM funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Andre enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Ingen andre enheter funnet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Formfaktor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Sett</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bankløser</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Typebeskrivelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Delnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Minneteknologi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Funksjonshåndtering for hukommelsesmodus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Firmware-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Modulprodusent-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Modulprodukt-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Hukommelsessystemstyringskontrollerprodusent-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Hukommelsessystemstyringskontrollerprodukt-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Ikke-volatile størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Volatile størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Cache-størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logisk størrelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>tomme</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Dato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>IO-port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>nettverk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>nativ-sti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>strømtilførsel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>oppdatert</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>har historikk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>har statistikk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>laddbar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>tilstand</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>advarselnivå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energi tom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energi full</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>energi full design</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>energirate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>spenning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>prosent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ikone-navn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon-versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>på batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>hvelv er lukket</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>hvelv er tilstede</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritisk handling</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>oppgave-avbryt-etter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>oppgave-pause-til</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>oppgave-prioritet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>markør-endringstid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>antall-opp</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientering-etterforsøkt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>trykk-farge-modus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer-accepterer-oppgaver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer-er-deelt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer-er-tiltjent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer-merke-og-modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>printer-status-endringstid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>printer-status-grunner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>printer-type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer-uri_støttet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>sider</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus-informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logiske-sektorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sektorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>id</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometri (Logisk)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Enhetsforvalter</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Enhetsforvalter er et nyttig verktøy for å vise hardvareinformasjon og administrere enhetene.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Nye drivere tilgjengelig! Installer eller oppdater dem nå.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Vis</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Inkluder undermapper</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Søk etter drivere i denne stien</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 oppdateringer for drivere tilgjengelig'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Tid sjekket: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Last ned drivere for %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Nedlastningshastighet: %1 Lastet ned %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Installerer drivere for %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 drivere installert, %2 drivere feilet'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 drivere installert'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Kunne ikke installere drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Nettverksfeil. Forbindelse på nytt...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Nedlastningshastighet: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Dine drivere er oppdatert</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Alle drivere er blitt sikret</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>En totalt på %1 drivere, hvorav %2 er blitt sikret</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Du har %1 drivere som kan sikres, det anbefales å gjøre det umiddelbart</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Du har %1 drivere som kan sikres</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Sikter opp %1 driver, totalt %2 drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Sikter opp: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 drivere sikret, %2 drivere feilet'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Kunne ikke sikre drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 drivere sikret'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Du har %1 drivere som kan gjenopprettes</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Vennligst velg en driver for å gjenopprett</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver er på vei tilbake...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Tilbakestillinger: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>oppstart</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Vennligst %1 for at de installerte drivrene skal bli aktivert</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Vis sikkerhetskopieringssti</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Sikkerhetskopier alt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>send tilbakemelding</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Vennligst prøv på nytt eller %1 til oss</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Installer alt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Scan på nytt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Skanning av hardvers drivere, vennligst vent...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Skanning %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Scan feilet</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Nettverk er utilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Vennligst sjekk din nettverksforbindelse</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Vennligst scan på nytt eller %1 til oss</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Du installerer et driver, som vil bli avbrutt hvis du forlater.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Er du sikker på at du vil avslutte?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Avslutt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Du gjør sikkerhetskopiering av drivere, som vil bli avbrutt hvis du forlater.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Du tilbakestillinger av drivere, som vil bli avbrutt hvis du forlater.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetoothadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Bildeutstyr</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Skjermadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Lydkort</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Nettverksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Trådløst nettverksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Installasjonen er fullført</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Installasjon feilet</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Lasting ned</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Installerer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Ikke installert</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Utdateret</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Venter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Ikke sikret</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Sikrer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Sikkerhetskopiering feilet</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Sikkerhetskopiering vellykket</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Gjenoppretter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Ukjent feil</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Nettverksfeil</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Avbrutt</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Feil ved henting av drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Oppdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Sikkerhetskopier</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Gjenopprett</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Installer</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Oppdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Oppdater drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Avinstaller drivere</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Tillat det å våkne computeren</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Aktiver</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Oppdater</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Eksportér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopier</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Deaktivér</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Utiliser</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Velg en lokal mappe, vennligst</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Laster...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ne.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ne.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ne">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>सही</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>प्रतिक्रिया</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>सही</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation>अधिक</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">सँकुचन</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>जान्दै थप</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>जान्दै थप</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>सँकुचन</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>जान्दै थप</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>सँकुचन</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>क्षेत्रकर्ताले बन्द गर्नुहोस्</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>अवसंच का</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>बिकासकारक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>चिप</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>क्षमताहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>मॗडल लिहाज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>भौतिक ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_पथ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>वर्णन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>परिवर्तन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>कर्नल मोड ड्राइवर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>स्यामेट्री पत्र</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>अवैध</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>अकार्यक्रम गर्नुहोस्</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>विकासकारक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>चिपसेट</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>निर्देशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>विकासकारक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>मॗड्युल निर्देशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>भौतिक ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>गति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>महत्तम शक्ति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>ड्राइवर संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>ड्राइवर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>क्षमताहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>बस जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>वैकल्पिक नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC पत्र</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>अवैध</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>अक्षम गर्नुहोस्</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>वेन्डर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>बस जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>क्षमताहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>ड्राइवर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>मौखिक शक्ति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>चाल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>मॗड्युल निर्नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>भौतिक ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>निरावेखित</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>अक्षम गर्नुहोस्</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>वेन्डर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>कोर आईडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>थ्रेडहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>राशिकार्टर्की</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>CPU फायमिली</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>प्रोसेसर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>कोर(हरू)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>वirtualization</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>लक्षण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>प्रसारण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 कश्चिमा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 कश्चिमा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 कश्चिमा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i कश्चिमा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d कश्चिमा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>विकस्त</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>गति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>मैक्समल गति</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>विक्रेता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>वर्षा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>ग्राफिक्स मेमोरी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>मॉड्युल अलियस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>भौतिक आईडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>मेमोरी ठाउँ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>I/O पोर्ट</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>बस जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>मैक्समल रिसॉल्युशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>मिनिमम रिसॉल्युशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>वर्तमान रिसॉल्युशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>ड्राइवर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>वर्णन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
-        <translation type="unfinished"/>
+        <translation>डीपी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
-        <translation type="unfinished"/>
+        <translation>ई-डीपी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
-        <translation type="unfinished"/>
+        <translation>एचडीएमआई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
-        <translation type="unfinished"/>
+        <translation>वीजीए</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
-        <translation type="unfinished"/>
+        <translation>डीवीआई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>डिजिटल आउटपुट</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
-        <translation type="unfinished"/>
+        <translation>दर्शन आउटपुट</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>क्षमताहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>अवैध</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>विक्रेता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>बस जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>मॗड्युल निर्देशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>भौतिक ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>चाल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>मaksिमुम पावर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>ड्राइवर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>क्षमताहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>क्रमांक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>अवैध</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>निष्क्रिय गर्नुहोस्</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>विकासकर्ता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>मॉडल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>आर्किटेक्चर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>बस जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>मॗड्युल अलियास</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>भौतिक ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>चाल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>मैक्सिमा मुदा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>ड्राइवर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>क्षमताहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>निष्पक्ष</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>निष्क्रिय गर्नुहोस्</translation>
     </message>
@@ -762,272 +753,234 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>परिच्छेद</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>केन्द्रीय प्रसारक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>केन्द्रीय प्रसारकहरूको संख्या</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>मातरबोर्ड</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>प्रतिबिम्बीकरण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>दर्शन योजक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>संगीत योजक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>विरामावस्था</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>अन्य PCI युक्तिहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>बैटरी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>ब्लूटूथ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>राउटिंग यन्त्रक्रियाकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>माउस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>क्याबिट्यूड</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>निरीक्षण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROME</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>प्रिन्टर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>कैमरा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>अन्य यन्त्र</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>उपकरण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
-        <translation type="unfinished"/>
+        <translation>ओएस</translation>
     </message>
 </context>
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>विक्रेता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>आकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>चाल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
-        <translation type="unfinished"/>
+        <translation>कुल चौड़ाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
-        <translation type="unfinished"/>
+        <translation>स्थानांतरक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>क्रमांक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
-        <translation type="unfinished"/>
+        <translation>संरचित वोल्टेज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
-        <translation type="unfinished"/>
+        <translation>अधिकतम वोल्टेज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
-        <translation type="unfinished"/>
+        <translation>न्यूनतम वोल्टेज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
-        <translation type="unfinished"/>
+        <translation>संरचित गति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
-        <translation type="unfinished"/>
+        <translation>डेटा चौड़ाई</translation>
     </message>
 </context>
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>विकासकारक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>प्रदर्शन इनपुट</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>अवलोकन प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>समर्थित समावेशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>वर्तमान समावेशन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>प्रदर्शन अनुपात</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>मुख्य दर्शक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>विस्तार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>क्रमांक</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>विकासकारक</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>प्रकार</translation>
     </message>
@@ -1115,32 +1065,32 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>काला समय</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
         <source>IP</source>
-        <translation type="unfinished"/>
+        <translation>आईपी</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
         <source>Firmware</source>
-        <translation type="unfinished"/>
+        <translation>फर्मवेयर</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
         <source>Duplex</source>
-        <translation type="unfinished"/>
+        <translation>ड्यूप्लेक्स</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
         <source>Broadcast</source>
-        <translation type="unfinished"/>
+        <translation>ब्रॉडकास्ट</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
         <source>Auto Negotiation</source>
-        <translation type="unfinished"/>
+        <translation>ऑटो नेगोशिएशन</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
@@ -1203,7 +1153,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
         <source>Input/Output</source>
-        <translation type="unfinished"/>
+        <translation>इनपुट/आउटपुट</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
@@ -1218,7 +1168,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>सक्षम गर्नु</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>विकासकर्ता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>सामग्री किसिम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>आकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>क्षमताहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>मॗड्युल नामकरण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>भौतिक ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>फारवर्डर संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>गति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>वर्णन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>क्रमांक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>निर्वाहक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>वापर्न दर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>सम्पन्न</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>अद्यतन गर्न एउटा ड्राइवर निवडे</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>यस मूल्यांकलाई फोल्डरमा कुनै ड्राइवर छैन</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>संगीत उपकरण जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>oprेटिंग सिस्टम जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>CPU जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>अन्य उपकरणहरू जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>बल जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>प्रिंटर जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>म्यास्केब जानकारी छान्छ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>नेटवर्क एडप्टर जानकारी छान्छ...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>अकार्यक्षम गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>नुकसानित</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>अकार्यक्षम गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>नुकसानित</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>उपकरण जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>क्षेत्रक्रम देखिनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>सहायता</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>क्लाप्याउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>सिस्टम</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>तस्करी गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>पुनरार्थोक्ति गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>उपकरण प्रबंधक</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>ardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>ड्राइवरहरू</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>निरीक्षण</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>परिचालन</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>निरीक्षण योजनाबद्धक</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>केन्द्रीय प्रसारण योजनाबद्धक</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>साइकिल योजनाबद्धक</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>बैटरी</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>जानकारी भएको दुई भन्दा अधिक</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>वर्तमान संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>ड्राइवर तलाकार संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>स्थिति</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>व्यवस्थापन</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>कैफियत दिएको ड्राइवरहरू</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>कैफियत दिएको ड्राइवरहरू</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>अपडेट गरी रहेको</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>अगाध जानुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>चिंता</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>ड्राइवर अन्यमार्को बाद इस यंत्र सेवाको लागि उपलब्ध भइनेछौं छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>अन्यमा गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>अन्यमा गरिरहेको</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>अपडेट सफल भयो</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>अन्यमा गरिने सफल भयो</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>@update फाइल गर्दा विफाल भयो</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>अन्यायोजन फाइल गर्दा विफाल भयो</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>सत्यापन</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>अगाध भागमा जानु</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>चयन गरिएको फोल्डर छैन, कृपया फिर्माउँदै चयन गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>अपडेट</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>पिछ्लो भागमा जानु</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>भित्ति वस्तु</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>मिलिन्छैन वस्तु कार्यक्रम संरचना</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>चयन गरिएको फाइल छैन, कृपया फिर्माउँदै चयन गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>यो ड्राइवर छैन</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>इन्स्टॉल गर्न असकेप - डिजिटल चिह्न छैन</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>ज्ञात छैन त्रुटि</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>ड्राइवर मॉड्युल छैन भएको छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>वैध छैन मॉड्युल फॉर्मेट</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>ड्राइवर मॉड्युल मल्ला आवश्यकताहरू छन्</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>सुवासित्रको नाम</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>उपलब्ध संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>आकार</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>अवस्था</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>कार्य</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>नयाँ संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>वर्तमान संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>मिस ड्राइवर (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>अदेखीय ड्राइवर (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>अद备用 ड्राइवर (%1</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>ड्राइवर इनस्टॉल</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>ड्राइवर बैकअप</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>ड्राइवर रिस्टोर</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>ठीक छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>सम्मर्थन दिनुहोस्</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>आपको रिस्टोर गर्ने कोई ड्राइवर छैन, पहिले बैकअप गर्नुपर्छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>बैकअप ड्राइवर गर्न जानुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>नाम</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>वर्तमान संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>बैकअप संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>काम</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>रिस्टोर गर्ने ड्राइवर</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>पुरा गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>आउटपुट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>परिचय</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>ड्राइवर इनस्टॉल</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>ड्राइवर बैकअप</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>ड्राइवर रिस्टोर</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>उपकरण व्यवस्थापन गर्न मित्र छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>उपकरण व्यवस्थापन बाट छुट्न मित्र छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>उपकरण व्यवस्थापन बाट छुट्न मित्र छ: उपकरण को SN छाडौ गर्न मित्र छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>ड्राइवर अपडेट</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>ड्राइवर निकाल्नुहोस्</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>पुरा गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>आउटपुट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>क्लाप्याउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>परिच्छेद</translation>
     </message>
@@ -2111,53 +2036,51 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइवर अपडेट गर्नु</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइवर अनइंस्टल गर्नु</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>यसलाई कम्प्यूटर जाग्रत गर्न अनुमति दिनु</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>उपसंस्थान</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>काम गर्न मिलेको भइनको</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>उपकरण व्यवस्थापन बाट छुट्न मित्र छ: उपकरण को SN छाडौ गर्न मित्र छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>उपकरण व्यवस्थापन बाट छुट्न मित्र छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>उपकरण व्यवस्थापन गर्न मित्र छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>ड्राइवर अपडेट</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>ड्राइवर निकाल्नुहोस्</translation>
     </message>
@@ -2165,1933 +2088,1751 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
-        <source>SubVendor</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
-        <source>SubDevice</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>उपसंस्थान</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>उप डिवाइस</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>ड्राइवर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर स्थिति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर सक्रियकरण कमांड</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
-        <translation type="unfinished"/>
+        <translation>कॉन्फिग स्थिति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
-        <translation type="unfinished"/>
+        <translation>लैटेंसी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
-        <translation type="unfinished"/>
+        <translation>भौतिक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
-        <translation type="unfinished"/>
+        <translation>सिस्फ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>हाउंडर्स</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>प्रपॉर्पर्टी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>ईव</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>केय</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>वर्जन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>बस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>आधार बोर्ड जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>सिस्टम जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>चार्ज़िस जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>भौतिक यामिनी अरे</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>ला�UNCH तारि�خ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>पत्राङ्क</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>रनटाइम साइज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM साइज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>रूपरेखा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS संशोधन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>फार्मवर्क संशोधन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>उत्पादक नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>श्रृंखलाव संख्या</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>संपत्ति टैग</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>फेचर्स</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>चार्ज़िस में स्थान</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>चार्ज़िस हन्डल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>तरिका</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>वापसी गरिएको वस्तुहरूको हाउलेस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>चाँदै उठाउनको प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU संख्या</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>परिवार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>लॉक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>आरम्भिक राउटरको अवस्था</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>विद्युत उपलब्धिको अवस्था</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>तापको अवस्था</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>सुरक्षाको स्थिति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>ऊंचाइ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>विद्युत तारको संख्या</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>वापसी गरिएको तत्वहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>स्थान</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>पात्रताको प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>मानक आकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>पात्रताको जानकारीको हाउलेस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>डेविस्को संख्या</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>लागि जारी राखिने तारिख</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>बोर्ड को नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>भाषाको वर्णन रूप</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>इनस्टॉल गर्ने भाषाहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>वर्तमान वास्तविक भाषा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD ठेका</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>पैकेट प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>संबध पॉलिकी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>संबध राखिनी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>श्रेणी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>सेवा श्रेणीहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>उपकरण श्रेणी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>विभाजन संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>उपकरण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>श्रृंखला आईडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>उत्पाद</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>वर्णन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>कार्यक्षम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>जानकारी प्रदान गर्ने</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>संयुक्त गर्ने</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>जानकारी प्राप्त गर्दै</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>ड्राइवर मॗड्युलहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>उपकरण फाइल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>उपकरण फाइलहरू</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>उपकरण संख्या</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>व्यवसाय</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>स्थिति</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>वैकल्पिक नाम</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU निर्माता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU शैली</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU भाग</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU संशोधन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>एक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>दो</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>चार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>छह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>आठ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>नौ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>दस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>बारह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>सोलह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>बीस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>बीस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>बीस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>बीस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>बीस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>बीस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>बीस अड्डा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>तिरेको</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>तिरेको दो बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>तिरेको चार बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>तिरेको छह बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>तिरेको आठ बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>सत्राइस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>सत्राइस दो बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>सत्राइस चार बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>सत्राइस छह बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>सत्राइस आठ बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>पाँचाइस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>पाँचाइस दो बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>पाँचाइस चार बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>पाँचाइस छह बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>पाँचाइस आठ बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>साठ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>साठ दो बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>साठ चार बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>साठ छह बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>साठ आठ बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>सत्ताइस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>सत्ताइस दो बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>सत्ताइस चार बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>सत्ताइस छह बेटा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>सत्तानवे बार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>अस्त्राइस बार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>अस्त्राइस तर्जि</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>अस्त्राइस चार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>अस्त्राइस छँटाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>अस्त्राइस अठाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>नैन्ताइस बार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>नैन्ताइस तर्जि</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>नैन्ताइस चार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>नैन्ताइस छँटाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>नैन्ताइस अठाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>एक सौ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>एक सौ दो</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>एक सौ चार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>एक सौ छँटाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>एक सौ अठाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>एक सौ दस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>एक सौ दुनिछाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>एक सौ चौदह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>एक सौ छहदह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>एक सौ अठाहत</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>एक सौ बारह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>एक सौ बारह दुनिछाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>एक सौ बारह चार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>एक सौ बारह छँटाई</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>एक सौ तथा बारह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>एक सौ तथा बारह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>दो सौ तथा पंद्रह</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR क्षमता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU विक्रेता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU प्रकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL क्लाइंट API</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL संस्करण</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>ज्ञात नाइको</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>अनियमित</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>सैद्धांतिक कक्षा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>CPU पाइनाइको</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>मातेरियलबोर्ड</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>मातेरियलबोर्ड पाइनाइको</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>प्रयोगको स्याम्बुक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>प्रयोगको स्याम्बुक पाइनाइको</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>स्टोरेज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>डिस्क पाइनाइको</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>ड्राइवर समावेश गर्न माफि भएको छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>कृपया फिर्माउन चाहेन भने वेबसाइटमा फीडबैक द्नुहोस</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>ड्राइवर बैकअप गर्न माफि भएको छ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>प्रदर्शन यन्त्रक्रियाकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>GPU खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>स्क्रीन खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>राउटिंग यन्त्रक्रियाकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>राउटिंग यन्त्रक्रियाकारी खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>संगीत यन्त्रक्रियाकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>संगीत यन्त्र खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>ब्लूटूथ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>ब्लूटूथ यन्त्र खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>अन्य PCI यन्त्र</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>अन्य PCI यन्त्र खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>संचालन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>बैटरी खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>क्याबिट्यूड</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>क्याबिट्यूड खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>माउस</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>माउस खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>प्रिन्टर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>प्रिन्टर खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>कैमरा</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>कैमरा खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROME</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>CD-ROME खोलिने प्रतिबिम्ब गरिले छैन</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>अन्य यन्त्र</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
-        <translation type="unfinished"/>
+        <translation>अन्य उपकरणहरू फाइन्ड गरिन नभएको</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
-        <translation type="unfinished"/>
+        <translation>अर्रे ह्यान्डल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
-        <translation type="unfinished"/>
+        <translation>फॉर्म फैक्टर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
-        <translation type="unfinished"/>
+        <translation>सेट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
-        <translation type="unfinished"/>
+        <translation>बङ्क लोकेटर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
-        <translation type="unfinished"/>
+        <translation>टाइप डिटेल</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
-        <translation type="unfinished"/>
+        <translation>पार्ट नंबर</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
-        <translation type="unfinished"/>
+        <translation>रेंक</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
-        <translation type="unfinished"/>
+        <translation>मेमरी टेक्नोलोजी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
-        <translation type="unfinished"/>
+        <translation>मेमरी संचालन मोड क्षमता</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>फारवर्डर संस्करण</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
-        <translation type="unfinished"/>
+        <translation>मॉड्यूल निर्माता आईडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
-        <translation type="unfinished"/>
+        <translation>मॉड्यूल उत्पाद आईडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
-        <translation type="unfinished"/>
+        <translation>मेमरी सबसिस्टम कन्ट्रोलर निर्माता आईडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
-        <translation type="unfinished"/>
+        <translation>मेमरी सबसिस्टम कन्ट्रोलर उत्पाद आईडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
-        <translation type="unfinished"/>
+        <translation>अस्थायी आकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
-        <translation type="unfinished"/>
+        <translation>स्थायी आकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
-        <translation type="unfinished"/>
+        <translation>केच आकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
-        <translation type="unfinished"/>
+        <translation>तार्किक आकार</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
-        <translation type="unfinished"/>
+        <translation>इंच</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
-        <translation type="unfinished"/>
+        <translation>तारिख</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
         <source>ioport</source>
-        <translation type="unfinished"/>
+        <translation>आईओपोर्ट</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
         <source>network</source>
-        <translation type="unfinished"/>
+        <translation>नेटवर्क</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
         <source>battery</source>
-        <translation type="unfinished"/>
+        <translation>बैटरी</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
         <source>native-path</source>
-        <translation type="unfinished"/>
+        <translation>नेटिव-पाथ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
         <source>power supply</source>
-        <translation type="unfinished"/>
+        <translation>ऊर्जा आपूर्जन</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
         <source>updated</source>
-        <translation type="unfinished"/>
+        <translation>अपडेट गरिएको</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
         <source>has history</source>
-        <translation type="unfinished"/>
+        <translation>तथ्याङ्क छ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
         <source>has statistics</source>
-        <translation type="unfinished"/>
+        <translation>सांख्यिकी छ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
         <source>rechargeable</source>
-        <translation type="unfinished"/>
+        <translation>पুনः चार्ज गर्न सकिने</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
         <source>state</source>
-        <translation type="unfinished"/>
+        <translation>स्थिति</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
         <source>warning-level</source>
-        <translation type="unfinished"/>
+        <translation>चेतावनी स्तर</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
         <source>energy</source>
-        <translation type="unfinished"/>
+        <translation>ऊर्जा</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
         <source>energy-empty</source>
-        <translation type="unfinished"/>
+        <translation>ऊर्जा खाली</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
         <source>energy-full</source>
-        <translation type="unfinished"/>
+        <translation>ऊर्जा पूर्ण</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
         <source>energy-full-design</source>
-        <translation type="unfinished"/>
+        <translation>ऊर्जा पूर्ण डिज़ाइन</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
         <source>energy-rate</source>
-        <translation type="unfinished"/>
+        <translation>ऊर्जा दर</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
         <source>voltage</source>
-        <translation type="unfinished"/>
+        <translation>वोल्टेज</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
         <source>percentage</source>
-        <translation type="unfinished"/>
+        <translation>प्रतिशत</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
         <source>technology</source>
-        <translation type="unfinished"/>
+        <translation>प्रौद्योगिकी</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
         <source>icon-name</source>
-        <translation type="unfinished"/>
+        <translation>इकन नाम</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
         <source>online</source>
-        <translation type="unfinished"/>
+        <translation>ओनलाइन</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
         <source>daemon-version</source>
-        <translation type="unfinished"/>
+        <translation>डेमन संस्करण</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
         <source>on-battery</source>
-        <translation type="unfinished"/>
+        <translation> बैटरी बाट</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
         <source>lid-is-closed</source>
-        <translation type="unfinished"/>
+        <translation>कवर बन्द छ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
         <source>lid-is-present</source>
-        <translation type="unfinished"/>
+        <translation>कवर उपलब्ध छ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
         <source>critical-action</source>
-        <translation type="unfinished"/>
+        <translation>महत्वपूर्ण कार्य</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
         <source>copies</source>
-        <translation type="unfinished"/>
+        <translation>कापी</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
         <source>job-cancel-after</source>
-        <translation type="unfinished"/>
+        <translation>काम रद्द गर्न अघि</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
         <source>job-hold-until</source>
-        <translation type="unfinished"/>
+        <translation>काम रोकिएको अघि</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
         <source>job-priority</source>
-        <translation type="unfinished"/>
+        <translation>काम प्राथमिकता</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
         <source>marker-change-time</source>
-        <translation type="unfinished"/>
+        <translation>मार्कर समय बदलिएको</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
         <source>number-up</source>
-        <translation type="unfinished"/>
+        <translation>संখ्या उपर</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
         <source>orientation-requested</source>
-        <translation type="unfinished"/>
+        <translation>अनुकूलन अपेक्षित</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
         <source>print-color-mode</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्ट रंग डिज़ाइन</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
         <source>printer-is-accepting-jobs</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर जब छाप लिन तयार छ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
         <source>printer-is-shared</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर साझा छ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
         <source>printer-is-temporary</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर अस्थायी छ</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
         <source>printer-make-and-model</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर ब्रङ्ड र मॉडल</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
         <source>printer-state-change-time</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर स्टेट चेन्ज टाइम</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
         <source>printer-state-reasons</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर स्टेट कारण</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
         <source>printer-type</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर प्रकार</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
         <source>printer-uri-supported</source>
-        <translation type="unfinished"/>
+        <translation>प्रिन्टर यूआरआई समर्थित</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
         <source>sides</source>
-        <translation type="unfinished"/>
+        <translation>पक्ष</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
-        <translation type="unfinished"/>
+        <translation>एसएसडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
-        <translation type="unfinished"/>
+        <translation>एचडीडी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
-        <translation type="unfinished"/>
+        <translation>बस जानकारी</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
-        <translation type="unfinished"/>
+        <translation>लोजिकल सेक्टर साइज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
-        <translation type="unfinished"/>
+        <translation>सेक्टर साइज</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
-        <translation type="unfinished"/>
+        <translation>ग्युआईड</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
-        <translation type="unfinished"/>
+        <translation>ज्योमेट्री (लोजिकल)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>यंत्र पालिका</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>यस्तो यार्को यंत्र सूचना देख्न र यंत्रहरूलाई नियमन गर्न लाईको एक उपकारी यंत्रपालिका।</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
-        <translation type="unfinished"/>
+        <translation>नयाँ ड्राइभरहरू उपलब्ध छन्! अब इन्स्टल वा अपडेट गर्नुहोस्।</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
-        <translation type="unfinished"/>
+        <translation>देख्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
-        <translation type="unfinished"/>
+        <translation>उप-फोल्डर समावेश गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
-        <translation type="unfinished"/>
+        <translation>यो पाथमा ड्राइभरहरू खोज्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
-        <translation type="unfinished"/>
+        <translation>“%1 ड्राइभर अपडेट उपलब्ध छ”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
-        <translation type="unfinished"/>
+        <translation>“समय चेक गरिएको: %1”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>“%1 लागि ड्राइभरहरू डाउनलोड गर्दैछ...”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation type="unfinished"/>
+        <translation>“डाउनलोड स्पीड: %1 डाउनलोड गरिएको %2/%3”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>“%1 लागि ड्राइभरहरू इन्स्टल गर्दैछ...”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>“%1 ड्राइभर इन्स्टल गरिएको, %2 ड्राइभर असफल छ”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
-        <translation type="unfinished"/>
+        <translation>“%1 ड्राइभर इन्स्टल गरिएको”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर इन्स्टल गर्न असफल</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
-        <translation type="unfinished"/>
+        <translation>नेटवर्क त्रुटि। पुनः सambandhan गर्दैछ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
-        <translation type="unfinished"/>
+        <translation>“डाउनलोड स्पीड: %1”</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
-        <translation type="unfinished"/>
+        <translation>तपाईँको ड्राइभर अपडेट गरिएको छ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>सबै ड्राइभर बैकअप गरिएको छ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 ड्राइभरको कुल, जसमा %2 बैकअप गरिएको छ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>%1 ड्राइभर बैकअप गर्न सकिन्छ, यो तुरुन्त गर्न अनुसार छ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 ड्राइभर बैकअप गर्न सकिन्छ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>%1 ड्राइभर बैकअप गर्दै, कुल %2 ड्राइभर</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>बैकअप गर्दै: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>%1 ड्राइभर बैकअप गरिएको, %2 ड्राइभर विफल</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर बैकअप गर्न सकिएन</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 ड्राइभर बैकअप गरिएको</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>%1 ड्राइभर फिर्ती गर्न सकिन्छ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>कृपया फिर्ती गर्ने ड्राइभर चयन गर्नुहोस</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर फिर्ती गर्दैछ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>फिर्ती गर्दै: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
-        <translation type="unfinished"/>
+        <translation>पुनः सुरु गर्नु</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
-        <translation type="unfinished"/>
+        <translation>कृपया %1 गर्नु भएमा स्थापित ड्राइभर असर गर्नेछ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>बैकअप पाइथ देख्नु</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
-        <source>submit feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
-        <source>Please try again or %1 to us</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
-        <source>Install All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
-        <source>Scan Again</source>
-        <translation type="unfinished"/>
+        <translation>सबै बैकअप गर्नु</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>प्रतिक्रिया दिनु</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>कृपया पुनः प्रयास गर्नु वा %1 हामीलाई</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>सबै स्थापित गर्नु</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>पुनः स्कन गर्नु</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>हार्डवेयर डिभिस ड्राइभर स्कन गर्दै, कृपया विराम गर्नु</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
-        <translation type="unfinished"/>
+        <translation>स्कन गर्दै %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
-        <translation type="unfinished"/>
+        <translation>स्कन विफल</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
-        <translation type="unfinished"/>
+        <translation>नेटवर्क उपलब्ध छैन</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
-        <translation type="unfinished"/>
+        <translation>कृपया आफ्नो नेटवर्क सংযोग चेक गर्नु</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
-        <translation type="unfinished"/>
+        <translation>कृपया पुनः स्कन गर्नु वा %1 हामीलाई</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>तपाईँ एउटा ड्राइभर स्थापित गर्दैछ, जुन तपाईँ बाहिर जाउ भने अवरोधित हुनेछ।</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"/>
+        <translation>तपाईँ बाहिर जाउ चाहानु भयो?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>बाहिर निस्को</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>तपाईँ ड्राइभर बैकअप गर्दैछिन, जुन तपाईँ बाहिर निस्को भएमा रोकिएको हुन सक्छ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>तपाईँ ड्राइभर फिर्ता ल्याउँदैछिन, जुन तपाईँ बाहिर निस्को भएमा रोकिएको हुन सक्छ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
         <source>Bluetooth adapter</source>
-        <translation type="unfinished"/>
+        <translation>ब्लूटूथ एडाप्टर</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
-        <translation type="unfinished"/>
+        <translation>छवि उपकरण</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="38"/>
         <source>Display adapter</source>
-        <translation type="unfinished"/>
+        <translation>प्रदर्शन एडाप्टर</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="40"/>
         <source>Sound card</source>
-        <translation type="unfinished"/>
+        <translation>साउन्ड कार्ड</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="42"/>
         <source>Network adapter</source>
-        <translation type="unfinished"/>
+        <translation>नेटवर्क एडाप्टर</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="46"/>
         <source>Wireless network adapter</source>
-        <translation type="unfinished"/>
+        <translation>वायरलेस नेटवर्क एडाप्टर</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="66"/>
         <source>Installation successful</source>
-        <translation type="unfinished"/>
+        <translation>इंस्टालेशन सफल</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="67"/>
         <source>Installation failed</source>
-        <translation type="unfinished"/>
+        <translation>इंस्टालेशन असफल</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="68"/>
         <source>Downloading</source>
-        <translation type="unfinished"/>
+        <translation>डाउनलोड गर्दैछ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="69"/>
         <source>Installing</source>
-        <translation type="unfinished"/>
+        <translation>इंस्टाल गर्दैछ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="70"/>
         <source>Not installed</source>
-        <translation type="unfinished"/>
+        <translation>इंस्टल गरेको छैन</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="71"/>
         <source>Out-of-date</source>
-        <translation type="unfinished"/>
+        <translation>अपडेट गरिएको छैन</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="72"/>
         <source>Waiting</source>
-        <translation type="unfinished"/>
+        <translation>इंतजार गर्दैछ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>बैकअप गरेको छैन</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>बैकअप गर्दैछ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>बैकअप असफल</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>बैकअप सफल</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>फिर्ता ल्याउँदैछ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4101,37 +3842,37 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Network error</source>
-        <translation type="unfinished"/>
+        <translation>नेटवर्क गल्ती</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Canceled</source>
-        <translation type="unfinished"/>
+        <translation>रद्द गरियो</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Failed to get driver files</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर फाइलहरू प्राप्त गर्न असफल</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>अपडेट</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>बैकअप</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>फिर्ता ल्याउ</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation>इंस्टाल</translation>
     </message>
     <message>
         <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
@@ -4142,67 +3883,65 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>काम गर्न मिलेको भइनको</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>पुनरार्थोक्ति गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>आउटपुट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर अपडेट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>ड्राइभर अनइंस्टल गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>यसलाई कम्प्युटर जाग्रात गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
-        <translation type="unfinished"/>
+        <translation>सक्षम गर्नुहोस्</translation>
     </message>
 </context>
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>पुनरार्थोक्ति गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>आउटपुट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>क्लाप्याउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>काम गर्न मिलेको भइनको</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>अवैध</translation>
     </message>
@@ -4210,17 +3949,17 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
-        <translation type="unfinished"/>
+        <translation>कृपया एउटा स्थानिय फोल्डर छान्नुहोस्</translation>
     </message>
 </context>
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
-        <translation type="unfinished"/>
+        <translation>लोड हुँदैछ...</translation>
     </message>
 </context>
 </TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_nl.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_nl.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Meer</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Inklappen</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Meer</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Meer</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Inklappen</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Meer</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Inklappen</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Apparaatnaam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Module-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fysieke id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS-locatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Omschrijving</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeStuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Aanspreekbaar geheugen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Module-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fysieke id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Maximale energie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Stuurprogrammaversie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Businformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logische naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC-adres</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Businformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maximale energie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Module-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fysieke id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>Processor-id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Kern-id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Architectuur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Processor-familie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation> Kern(en)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualisatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Vlaggen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Uitbreidingen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4-cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3-cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2-cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i-cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d-cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stappen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Max. snelheid</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Videokaartgeheugen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Module-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fysieke id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Aanspreekbaar geheugen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>I/O-poort</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Businformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Maximumresolutie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Minimumresolutie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Huidige resolutie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Omschrijving</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Digitale uitvoer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Schermuitvoer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Businformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Module-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fysieke id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maximale energie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Businformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Module-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fysieke id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Maximumvoltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Overzicht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Aantal cpu&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Moederbord</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Geheugen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Beeldschermadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Geluidsadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Opslag</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Overige PCI-apparaten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Accu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Netwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Muis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Toetsenbord</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Beeldscherm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Printer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Overige apparaten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Apparaat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>Besturingssysteem</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Totale breedte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Ingesteld voltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Maximumvoltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Minimumvoltage</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Ingestelde snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Databreedte</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Scherminvoer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Soort interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Ondersteunde resoluties</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Huidige resolutie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Beeldverhouding</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Primair beeldscherm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Serienummer</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Soort media</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Module-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fysieke id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Firmwareversie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Omschrijving</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Bewegingssnelheid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Kies een bij te werken stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Er zijn geen stuurprogramma&apos;s aangetroffen in deze map</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Bezig met laden van audio-apparaten...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Bezig met laden van BIOS-informatie...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Bezig met laden van cd-rominformatie...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Bezig met laden van besturingssysteeminformatie...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Bezig met laden van processorinformatie...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Bezig met laden van overige apparaten...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Bezig met laden van energie-informatie...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Bezig met laden van printers...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Bezig met laden van muisinformatie...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Bezig met laden van netwerkadapters...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Apparaatinformatie</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Systeem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Apparaatbeheer</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Stuurprogramma&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Overzicht</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Beeldschermadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Netwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Accu</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Meer</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Huidige versie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Stuurprogramma-platformversie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Actie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Stuurprogramma&apos;s met reservekopie-ondersteuning</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Reservekopieën van stuurprogramma&apos;s</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Bezig met bijwerken…</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Het apparaat is niet meer beschikbaar na het verwijderen van het stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Bezig met verwijderen…</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Het bijwerken is voltooid</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Het verwijderen is voltooid</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Het bijwerken is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Het verwijderen is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Volgende</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>De gekozen map bestaat niet - kies een andere</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Bijwerken</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Beschadigd pakket</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Niet-overeenkomende pakketarchitectuur</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Het gekozen bestand bestaat niet - kies een andere</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Dit is geen stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Het installeren is niet mogelijk omdat er een ondertekening ontbreekt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Onbekende fout</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>De stuurprogrammamodule is niet aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Ongeldig moduleformaat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>De stuurprogrammamodule kent vereisten</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Apparaatnaam</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versie beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Grootte</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Actie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nieuwe versie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Huidige versie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Ontbrekende stuurprogramma&apos;s (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Verouderde stuurprogramma&apos;s (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Actuele stuurprogramma&apos;s (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Stuurprogramma installeren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Reservekopie maken</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Stuurprogramma herstellen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Feedback</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Er zijn nog geen te herstellen stuurprogramma&apos;s - maak eerst een reservekopie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Ga naar stuurprogramma-reservekopie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Huidige versie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Reservekopieversie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Actie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Herstelbare stuurprogramma&apos;s</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Overzicht</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Stuurprogramma installeren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Reservekopie maken</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Stuurprogramma herstellen</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Het apparaat kan niet worden ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Het apparaat kan niet worden ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Het uitschakelen is mislukt: het serienummer van het apparaat kan niet worden opgevraagd</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Stuurprogramma&apos;s bijwerken</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Stuurprogramma&apos;s verwijderen</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Overzicht</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Inschakelen</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Toestemming geven om de computer te ontwaken</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Het uitschakelen is mislukt: het serienummer van het apparaat kan niet worden opgevraagd</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Het apparaat kan niet worden ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Het apparaat kan niet worden ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Stuurprogramma&apos;s bijwerken</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Stuurprogramma&apos;s verwijderen</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Submaker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Subapparaat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Stuurprogrammastatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Stuurprogramma-activatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Configuratiestatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>vertraging</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Behandeld door</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>BIOS-informatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Basisbordinformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Systeeminformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Chassis-informatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Fysieke geheugenreeks</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Uitgebracht op</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Runtimegrootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM-grootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS-revisie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Firmware-revisie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Productnaam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Asset-label</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Mogelijkheden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Locatie in chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Chassis-handgreep</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Inbegrepen objecthandgrepen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Soort ontwaking</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>SKU-nummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Familie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Vergrendeling</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Opstartstatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Voedingsstatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Temperatuurstatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Beveiligingsstatus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM-informatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Hoogte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Aantal stroomkabels</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Inbegrepen elementen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Locatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Foutieve correctie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Maximale capaciteit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Foutinformatiehandgreep</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Aantal apparaten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS-ROM-grootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Uitgebracht op</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Bordnaam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS-versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Taalomschrijvingsopmaak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Talen beschikbaar voor installatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Momenteel geïnstalleerde taal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD-adres</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Pakketsoort</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Koppelbeleid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Koppelmodus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Klasse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Dienstklassen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Apparaatklasse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI-versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP-versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Apparaat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Seriële id</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>product</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>omschrijving</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Vindbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Koppelbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Vindbaar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Stuurprogrammamodules</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Apparaatbestand</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Apparaatbestanden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Apparaatnummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Applicatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>logische naam</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ansiversie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Processorimplementaat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Processorarchitectuur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Processorvariant</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Processoronderdeel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Processorrevisie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Eén</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Twee</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Vier</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Zes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Acht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Negen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Tien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Twaalf</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Veertien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Zestien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Achttien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Twintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Tweeëntwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Vierentwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Zesentwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Achtentwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Dertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Tweeëndertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Vierendertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Zesendertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Achtendertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Veertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Tweeënveertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Vierendertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Zesendertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Achtendertig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Vijftig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Tweeënvijftig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Vierenvijftig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Zesenvijftig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Achtenvijftig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Zestig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Tweeënzestig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Vierenzestig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Zesenzestig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Zesentachtig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Zeventig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Tweeënzeventig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Vierenzeventig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Zesenzeventig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Achtenzeventig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Tachtig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Tweeëntachtig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Vierentachtig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Zesentachtig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Achtentachtig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Negentig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Tweeënnegentig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Vierennegentig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Zesennegentig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Achtennegentig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Honderd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Honderdtwee</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Honderdvier</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Honderdzes</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Honderdacht</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Honderdtien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Honderdtwaalf</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Honderdveertien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Honderdzestien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Honderdachttien</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Honderdtwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Honderdtweeëntwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Honderdvierentwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Honderdzesentwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Honderdachtentwintig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Honderdtweeënnegentig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Tweehonderdzesenvijftig</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR-capaciteit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU-maker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Soort GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL-versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL-client-API&apos;s</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL-versie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL-versie</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Onbekend</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Hardwareklasse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Geen processor aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Moederbord</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Geen moederbord aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Geheugen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Geen geheugen aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Opslag</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Geen schijf aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Het herstellen is mislukt!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Probeer het opnieuw of geef feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Het maken van de reservekopie is mislukt!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Beeldschermadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Geen videokaart aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Beeldscherm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Geen beeldscherm aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Netwerkadapter</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Geen netwerkadapter aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Geluidsadapter</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Geen audio-apparaat aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Geen Bluetooth-apparaat aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Overige PCI-apparaten</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Geen andere PCI-apparaten aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Energie</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Geen accu aangetroffen</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Geluidsadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Geen audio-apparaat aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Geen Bluetooth-apparaat aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Overige PCI-apparaten</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Geen andere PCI-apparaten aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Energie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Geen accu aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Toetsenbord</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Geen toetsenbord aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Muis</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Geen muis aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Printer</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Geen printer aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Camera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Geen camera aangetroffen</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>Geen cd-romspeler aangetroffen</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Muis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Geen muis aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Geen printer aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Geen camera aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>Geen cd-romspeler aangetroffen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Overige apparaten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Geen andere apparaten aangetroffen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Reekshandgreep</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Vormfactor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Instellen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Bank Locator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Type-informatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Onderdeelnummer</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Geheugentechnologie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Geheugenoperatiemodi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Firmwareversie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID van modulemaker</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Productnummer van module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID van maker van geheugensubsysteem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Productnummer van geheugensubsysteem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Niet-volatilegrootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Volatilegrootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Cachegrootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logische grootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>kanten</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>businformatie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>logische sectorgrootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sectorgrootte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Afmetingen (logisch)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Apparaatbeheer</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Apparaatbeheer is een programma dat hardware-informatie toont en apparaten kan beheren.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Er zijn nieuwe stuurprogramma&apos;s beschikbaar! Installeer of werk ze nu bij.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Bekijken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Inclusief onderliggende mappen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Deze locatie doorzoeken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>Er zijn %1 stuurprogramma-updates beschikbaar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Gecontroleerd om %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Bezig met downloaden van stuurprogramma&apos;s…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Downloadsnelheid: %1 - Gedownload: %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Bezig met installeren van stuurprogramma&apos;s…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 stuurprogramma&apos;s geïnstalleerd; %2 mislukt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 stuurprogramma&apos;s geïnstalleerd</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>De stuurprogramma&apos;s kunnen niet worden geïnstalleerd</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Netwerfout - bezig met opnieuw verbinden…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Downloadsnelheid: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Alle stuurprogramma&apos;s zijn actueel</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Er is een reservekopie van alle stuurprogramma&apos;s gemaakt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Er zijn %1 stuurprogramma&apos;s, waarvan %2 over een reservekopie beschikken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Je beschikt over %1 stuurprogramma&apos;s met reservekopie-ondersteuning. Het maken hiervan is aanbevolen.</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Je beschikt over %1 stuurprogramma&apos;s met reservekopie-ondersteuning</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Bezig met maken van reservekopie van %1 van %2…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Bezig met maken van reservekopie van %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 stuurprogramma&apos;s met reservekopie; %2 mislukt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Er kan geen reservekopie worden gemaakt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 stuurprogramma&apos;s bevatten een reservekopie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Je beschikt over %1 stuurprogramma&apos;s die kunnen worden hersteld</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Kies een te herstellen stuurprogramma</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Bezig met herstellen…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Bezig met herstellen van %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>Start de computer opnieuw op</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>%1 om de geïnstalleerde stuurprogramma&apos;s in gebruik te nemen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Reservekopielocatie openen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Reservekopieën maken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>verstuur feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Probeer het opnieuw of %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Alles installeren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Opnieuw zoeken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Bezig met zoeken naar stuurprogramma&apos;s…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Bezig met zoeken naar %1…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Het zoeken is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Netwerkfout</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Controleer je internetverbinding</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Probeer het opnieuw of %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Er wordt nog een stuurprogramma geïnstalleerd. Als je nu afsluit, wordt het proces afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet je zeker dat je wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Er worden nog reservekopieën gemaakt. Als je nu afsluit, wordt het proces afgebroken.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Er worden nog stuurprogramma&apos;s hersteld. Als je nu afsluit, wordt het proces afgebroken.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>De bestanden kunnen niet worden opgehaald</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Bijwerken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Reservekopie maken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Herstellen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Installeren</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Stuurprogramma&apos;s bijwerken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Stuurprogramma&apos;s verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Toestemming geven om de computer te ontwaken</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Inschakelen</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Niet beschikbaar</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Kies een lokale map</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Bezig met laden...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_pam.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_pam.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pam">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Panahon</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Mga</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Pangunguna sa Network</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Pangunguna sa Reinstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Mga</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Ibalewala</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Ibalewala</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Walay</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Pangalan sa Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Mga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Kabugusan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Address sa Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Walay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Ibalewala</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Mga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Mg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Mga tagapagtala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Kasaysayan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Mga modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Pinakamataas na kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Kasaysayan ng driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Kabatiran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Mga pangalan ng logikal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>Address ng MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Hindi magagamit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Mga tagapagtala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Mga modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Kasaysayan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Kabatiran</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Pinakamataas na kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Hindi magagamit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Mga tagapagtala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>ID ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ID ng core</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Mga thread</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Mga thread</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arapayetura</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Pamilya CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Porsesador</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Core (s)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Pangangalakal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Pangalawang Ginti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Pangalawang Pansakop</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Pangalawang Ugnayan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Pangalawang Pabilog</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Mga Pabilog</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Mga Nagbibigay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Memorya Graphics</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Address Memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>Port IO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Mga Resolusyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Mga Resolusyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Mga Resolusyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Pangungusap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>DigitalOutput</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Display Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Capabilities</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Diwalay</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Nararato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Pamumuno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Sersiyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Pinakamataas na Kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Capabilities</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Numero ng Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Diwalay</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Iwawas</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Nararato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Pamumuno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Interfeys</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Pinakamataas na Kasalukuyan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Pangungusap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Sersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Di mapanginom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Iwala</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Panimula</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Kantidad ng CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Adapter para sa Pagpapakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Adapter para sa Buhok</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Pamamahala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Mga iba pang PCI Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Batis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Adapter para sa Network</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Mga iba pang mga device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Laki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Lakas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Panapudan nga lapad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Mga taga-pangungusap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Seryal nga numero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Nakakonektad nga voltaje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Mga pinakamataas nga voltaje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Mga pinakamababa nga voltaje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Nakakonektad nga bilis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Lapad nga data</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Mga taga-pangungusap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Input nga pagpapakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Uri nga interface</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Nagmamaneho nga resolusyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Kasalukuyan nga resolusyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Porsyento nga pagpapakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Pangunahing monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Laki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Seryal nga numero</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Mga taga-pangungusap</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Sersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon nga bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Kakayahan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Sersyon nga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Pinakamataas nga antas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Antas nga pagtatala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto Negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Memory Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logical Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Wala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Ibalang</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Nararang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Sersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Input/Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Kabugtang</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Nararang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Sersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Impormasyon ng Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kabalyidad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Mgaun Power</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Pangalawang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Di mapagkakatiyaga</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Nangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Sikat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kabug-osan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Voltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Slot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Disenyo Capacity</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Disenyo Voltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS Paggawa Date</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS Chemistry</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Temperatura</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Nangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Supplier</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serial Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Nagmumuo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Sikat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Uripan Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Ibali</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Mga Manggagawa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Uripan Type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Lahi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Sersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Kabugtang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Sersyon ng Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Lahat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Pangalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Numero ng Seriyal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Uripan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Rate ng Pag-ugat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Di Makukuha</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Piliin ang isang driver para i-update</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Walang driver na nakita sa folder na ito</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Naglalagda ng Impormasyon ng Audio Device...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Naglalagda ng Impormasyon ng BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Naglalagda ng Impormasyon ng CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Naglalagda ng Impormasyon ng Sistema ng Pag-Operate...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Naglalagda ng Impormasyon ng CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Naglalagda ng Impormasyon ng Mga Iba Pang Kagamitan...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Naglalagda ng Impormasyon ng Kapangyarihan...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Naglalagda ng Impormasyon ng Printer...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Naglalagda ng Impormasyon ng Mouse...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Naglalagda ng Impormasyon ng Network Adapter...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Ibali</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Di Makukuha</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Ibali</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Di Makukuha</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Impormasyon han Dispositibo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Makikita nga mga shortcut</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>I-close</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Pamangkot</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopyahon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Managad han Dispositibo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Mga Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Mga Pangkabug-os</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Adapter han Display</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Adapter han Network</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Batre</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Mas</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Versyon han Platform han Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Mga Driver nga makakabackup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Mga Driver nga naka-backup</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Nag-uupdate</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>I-cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Sunod</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Pangungusap</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>An dispositivo magkakalabot nga magkakadto nga wala na magagamit tapos han uninstallation han driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>I-uninstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Nag-uuninstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Nag-uupdate nga maayos</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Nag-uuninstall nga maayos</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Nag-update nga di mapasikat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Nag-uninstall nga di mapasikat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Susunod</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Ang napiling folder ay di makita, mangalap muli</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Update</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Mga nakaraan</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Nabubulok nga package</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Di kumakatawan nga package architecture</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Ang napiling file ay di makita, mangalap muli</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Di ito isang driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Di makaka-install - walay digital signature</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Di kilala nga error</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Ang driver module ay di makita</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Di wastong format ng module</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>May mga dependency ang driver module</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Install Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Backup Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Restore Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Mga komento</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Wala kang anumang driver na maaaring i-restore, mangalap muna</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Pumunta sa Backup Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Backup Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Mga driver na maaaring i-restore</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Overview</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Install Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Backup Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Restore Driver</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Nagkakasala nga makakapag-enable ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Nagkakasala nga makakapag-disable ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Nagkakasala nga makakapag-disable: hindi maaaring makuha ang device SN</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>I-update ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>I-copy</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Panimula</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>I-copy</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Paganahon</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>I-update ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Pahintulotan ito para makatulog ang computer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>I-disable</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Nagkakasala nga makakapag-disable: hindi maaaring makuha ang device SN</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Nagkakasala nga makakapag-disable ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Nagkakasala nga makakapag-enable ng device</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>I-update ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>SubVendor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>SubDevice</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Status ng Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Driver Activation Cmd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Status ng Config</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>latency</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Phys</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Mga Handler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Impormasyon ng BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Impormasyon ng Base Board</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Impormasyon ng Sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Impormasyon ng Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Mga Array ng Physical Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Petsa ng Paglilinaw</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Laki ng Runtime</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Laki ng ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Mga Katangian</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Revisyon ng BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Revisyon ng Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Pangalan ng Produkto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Numero ng Serisyal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Tag ng Asset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Mga Katangian</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Lokasyon sa Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Handle ng Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Mga Handle ng Naglalaman na Obje</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Uri ng Wake-up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Numero ng SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Pamilya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Kilat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Kasukat nga Pagsugod</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Kasukat nga Pagpapadala han Enerhiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Kasukat nga Termal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Kasukat nga Seguridad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Impormasyon han OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Kahambung</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Kadaot han mga Kable han Enerhiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Mga elemento nga Nakalatag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Kadaot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Uri han Pagkorreksyon han Error</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Mga Pabilang han Kapasidad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Handle han Impormasyon han Error</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Kadaot han mga Dispositibo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>Mga sukat han BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Tanggal han Pagpapalabas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Nararangon nga ngalan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>Versyon han SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Format han Pagpapadulong han Wika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Mga Wika nga Makakabat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Kasukat nga Nakakabat nga Wika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>Nararangon nga Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Uri han Datagram</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Policies han Pagkabat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Mode han Pagkabat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klas</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Mga Klas han Serbisyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Klase han Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Versyon han HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Versyon han LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Serial ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>produkto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>panglalarawan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Nagpapower</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Nagmamarka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Nagpapare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Nagmamarka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Modyul han Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>File han Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Mga File han Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Numero han Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Aplikasyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>estado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>pangalang logikal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Implementador han CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Araldika han CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Variant han CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Bahagi han CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Revisyon han CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Una</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Dos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Siyam</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Sumpete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Dalawa't walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Dalawa't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Dalawa't sumpete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Dalawa't walo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Limang pulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Limang pulo't walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Limang pulo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Limang pulo't sumpete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Limang pulo't walo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Tatlumpo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Tatlumpo't walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Tatlumpo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Tatlumpo't sumpete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Tatlumpo't walo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Apatnapulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Apatnapulo't walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Apatnapulo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Apatnapulo't sumpete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Apatnapulo't walo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Limangnapulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Limangnapulo't walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Limangnapulo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Limangnapulo't sumpete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Limangnapulo't walo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Apatnapulo't walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Apatnapulo't walo't walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Apatnapulo't walo't siyete</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Siksitan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Siksatan duha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Pitumpit</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Pitumpit duha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Pitumpit apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Pitumpit unom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Pitumpit walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Walo'twalo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Walo'twalo duha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Walo'twalo apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Walo'twalo unom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Walo'twalo walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Walo'twalo pito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Walo'twalo pito duha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Walo'twalo pito apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Walo'twalo pito unom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Walo'twalo pito walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Sangkapan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Sangkapan at duha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Sangkapan at apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Sangkapan at unom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Sangkapan at walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Sangkapan at pito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Sangkapan at walo'twalo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Sangkapan at walo'twalo pito</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Sangkapan at walo'twalo apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Sangkapan at walo'twalo unom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Sangkapan at walo'twalo walo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Sangkapan at walo'twalo walo duha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Sangkapan at walo'twalo walo apat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Isumpa kagawa na iilawo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Isumpa kagawa na iilawo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Isumpa kagawa na iilawo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Isumpa kagawa na iilawo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapasidad han GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Mga nangunguna han GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Uri han GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Version han EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL Client APIs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Version han GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Version han GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Diin kilala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Klas han Hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Wala nakit-an CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Wala nakit-an motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Wala nakit-an memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Pangalagad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Wala nakit-an disk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Nagka-ulo an pag-ulo han driver!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Palihog gamita na balangon o magbigay hin feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Nagka-ulo an pag-ulo han driver!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Adapter han Display</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Wala nakit-an GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Wala nakit-an monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Pangalawang Adapater</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Wala pangalawang adapater na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Adapater ng Buhok</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Wala audio device na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Wala Bluetooth device na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Mga iba pang PCI Device</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Wala iba pang PCI device na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Kuryente</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Wala baterya na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Keyboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Wala keyboard na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Wala mouse na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Wala printer na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Camera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Wala camera na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Wala CD-ROM na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Mga iba pang mga Kagamitan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Wala iba pang mga kagamitan na nakita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Form Factor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Set</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bank Locator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Type Detail</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Part Number</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Memory Technology</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Kakayahan sa Pagpapatakbo sa Mode ng Memorya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Versyon ng Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ID ng Tagagawa ng Modulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID ng Produkto ng Modulo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ID ng Tagagawa ng Memory Subsystem Controller</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ID ng Produkto ng Memory Subsystem Controller</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Laki ng Non-Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Laki ng Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Laki ng Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Laki ng Logical</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>inches</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Tanggal</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>network</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>supply ng kapangyarihan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>naimodify</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>may kasaysayan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>may estadistika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>maaring i-charge</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>estado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>antas ng palatandaan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>enerhiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>enerhiya na walang kahulugan</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>enerhiya na puno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>enerhiya na puno sa disenyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>tasa ng enerhiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>voltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>porsyento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknolohiya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>pangalan ng ikon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>panimula ng bersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>sa batis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ang kape ay nasa bisaya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ang kape ay nasa lugar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>mga kritikal na aksyon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>pang-cancel ng trabaho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>pang-panatili ng trabaho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>prioridad ng trabaho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>oras ng pagbabago ng marker</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>bilang ng up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>oras ng pagkakaayos</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>mga naka-color na mode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>ang printer ay nasa pagtanggap ng mga trabaho</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>ang printer ay nasa pamamahagi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>ang printer ay nasa panahon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>mga gawa at modelo ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>oras ng pagbabago ng estado ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>mga kadahilanan ng estado ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>mga uri ng printer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>mga URI ng printer na suportado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>mga gilid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>mga impormasyon ng bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>mga logicalsectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>mga sectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>gid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometriya (Pangkabug-os)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Pamamahala han mga Device</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>An Device Manager usa nga mapasagana nga tool para makita an impormasyon han hardware ngan pamamahala han mga device.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>May bag-o nga mga driver! Mag-install o mag-update na karon.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Panonot</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Ilako an mga subfolder</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Hanap an mga driver ha nangunguna nga path</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 mga update han driver'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Nagcheck han oras: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Nag-downloading han mga driver para ha %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Speed han download: %1 Nalagda %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Nag-install han mga driver para ha %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 mga driver gin-install, %2 mga driver nagsusugad'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 mga driver gin-install'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Nagsusugad an pag-install han mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Error han network. Nagreconnect...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Speed han download: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>An imo mga driver naghahatag han pinakabago nga bersyon</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>An tanan nga mga driver naghahatag han backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>An kabug-osan nga %1 mga driver, diin %2 naghahatag han backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>An imo may %1 mga driver nga pwede mag-backup, kinahanglan nga gawas karon</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>An imo may %1 mga driver nga pwede mag-backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Nag-backup han %1 driver, kabug-osan nga %2 mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Nag-backup: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 mga driver naghahatag han backup, %2 mga driver nagsusugad'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Nagsusugad an pag-backup han mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 mga driver naghahatag han backup'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>An imo may %1 mga driver nga pwede mag-restore</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Pakliha an driver nga gusto mo mag-restore</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Ang driver ay nagrerestore...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Nagrerestore: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>reboot</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Palihug %1 aron ang mga naka-install nga driver magamit</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Panonood ng backup path</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Backup lahat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>mag-submit ng feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Palihug subukan muli o %1 para sa aming</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Install lahat</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>I-scan muli</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Bumoto</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Nag-scan ng mga hardware device drivers, palihug wait...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Nag-scan %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Napansin ang scan</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Wala pang network</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Palihug suriin ang iyong network connection</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Palihug i-scan muli o %1 para sa aming</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Ikaw ay nag-iinstall ng driver, ang magiging interrupted kung ikaw ay mag-exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Sigurado ka ba na gusto mo ang mag-exit?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Exit</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Bumoto</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Ikaw ay nag-backup ng drivers, ang magiging interrupted kung ikaw ay mag-exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Ikaw ay nagrerestore ng drivers, ang magiging interrupted kung ikaw ay mag-exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Imaging device</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Display adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Sound card</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Wireless network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Installation successful</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Pag-installasyon ay naging mali</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Nagdudownload</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Nag-iinstall</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Hindi nakakatag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Naging madalang</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Naghihintay</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Hindi nakakatag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Nagtatag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Nagkaroon ng mali sa pagtatag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Nagkaroon ng tag</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Nagpapalikas</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Di malinaw na error</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Error sa network</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Nakasakop</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Nagkaroon ng mali sa pagkuha ng mga file ng driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Pangunawa</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Tag</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Palikas</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Iinstall</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Iwala</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Pangunawa ng mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>I-uninstall ang mga driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Pahintuloyin ang pag-ikot ng kompyuter</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Paganahon</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>I-refresh</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>I-export</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopyahon</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Iwala</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Diwala</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Pili an nangunguna nga folder</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Nag-load...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_pl.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_pl.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Opinia użytkownika</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Więcej</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Zwiń</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Więcej</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Więcej</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Zwiń</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Więcej</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Zwiń</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nazwa urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Czip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Identyfikator fizyczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Rewizja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Adres pamięci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Identyfikator fizyczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Moc maksymalna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Wersja sterownika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Informacje o szynie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nazwa logiczna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Adres MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Informacje o szynie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Moc maksymalna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Identyfikator fizyczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID procesora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID rdzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Wątków</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Architektura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Rodzina procesorów</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Rdzeń(ie)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Wirtualizacja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Flagi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Rozszerzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Rewizja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Prędkość maksymalna</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Pamięć wideo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Identyfikator fizyczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Adres pamięci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Port IO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Informacje o szynie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Rozdzielczość maksymalna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Rozdzielczość minimalna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Rozdzielczość aktualna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Wyjście ekranu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Informacje o szynie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Identyfikator fizyczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Moc maksymalna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interfejs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Informacje o szynie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Identyfikator fizyczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Prąd maksymalny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Podgląd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Rodzina procesorów</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Płyta główna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Karta graficzna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Adapter dźwięku</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Magazyn danych</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Inne urządzenia PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Adapter sieciowy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Mysz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Klawiatura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Drukarka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Aparat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Inne urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Urządzenie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>System</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Szerokość całkowita</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Lokalizator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Napięcie skonfigurowane</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Napięcie maksymalne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Napięcie minimalne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Prędkość skonfigurowana</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Szerokość danych</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Wyświetl wejście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Typ interfejsu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Wspierane rozdzielczości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Rozdzielczość aktualna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Współczynnik wyświetlania</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Główny monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Numer seryjny</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Producent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Typ nośnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Możliwości</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Identyfikator fizyczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Wersja firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Prędkość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interfejs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Szybkość rotacji</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Wybierz sterownik do zaktualizowania</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Nie znaleziono sterowników w tym folderze</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Wczytywanie informacji o urządzeniu dźwiękowym...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Wczytywanie informacji o systemie BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Wczytywanie informacji o płycie CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Wczytywanie informacji o systemie operacyjnym...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Wczytywanie informacji o procesorze...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Wczytywanie informacji o innych urządzeniach...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Wczytywanie informacji o zasilaniu...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Wczytywanie informacji o drukarce...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Wczytywanie informacji o myszce...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Wczytywanie informacji o adapterze sieciowym...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Informacje o urządzeniu</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Menedżer urządzeń</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Sprzęt</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Sterowniki</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Podgląd</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Karta graficzna</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Adapter sieciowy</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Więcej</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Bieżąca wersja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Wersja sterownika platformy</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Działanie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Sterowniki do backupu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Sterowniki z backupem</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Aktualizowanie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Dalej</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Urządzenie nie będzie dostępne po usunięciu sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Odinstaluj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Odinstalowuję</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Zaktualizowano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Usunięto pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Aktualizacja zakończona niepowodzeniem</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Odinstalowanie nie powiodło się</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Dalej</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Zaznaczony folder nie istnieje, spróbuj wybrać inny</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Aktualizuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Wstecz</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Uszkodzony pakiet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Niezgodna architektura pakietu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Zaznaczony plik nie istnieje, spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>To nie jest sterownik</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Nie można zainstalować - brak cyfrowej sygnatury</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Nieznany błąd</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Moduł sterownika nie został znaleziony</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Nieprawidłowy format modułu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Moduł sterownika posiada zależności</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Nazwa urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Wersja dostępna</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Rozmiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Działanie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nowa wersja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Bieżąca wersja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Brakujące sterowniki (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Sterowniki nieaktualne (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Sterowniki aktualne (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Instalacja sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Backup sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Przywracanie sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Opinia użytkownika</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Brak sterowników do przywrócenia, najpierw utwórz backup</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Przejdź do Backupu sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Bieżąca wersja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Wersja backupu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Działanie</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Sterowniki do przywrócenia</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Podgląd</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Instalacja sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Backup sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Przywracanie sterownika</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Nie udało się włączyć urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Nie udało się wyłączyć urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Nie udało się wyłączyć: nie można uzyskać numeru seryjnego</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Aktualizuj sterowniki</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Odinstaluj sterowniki</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Podgląd</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Włącz</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Zezwól urządzeniu na wybudzenie komputera</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Nie udało się wyłączyć: nie można uzyskać numeru seryjnego</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Nie udało się wyłączyć urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Nie udało się włączyć urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Aktualizuj sterowniki</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Odinstaluj sterowniki</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Podproducent</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Podurządzenie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Status sterownika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Aktywacja sterownika Cmd</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Stan konfiguracji</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>opóźnienie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Uchwyty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KLUCZ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Wersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Szyna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Informacje o BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Informacje o płycie głównej</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Informacje o systemie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Informacje o obudowie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Tablica pamięci fizycznej</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Data wydania</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Rozmiar Runtime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Rozmiar ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Charakterystyka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Rewizja BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Rewizja firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Nazwa produktu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Znacznik zasobu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Funkcje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Miejsce w obudowie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Uchwyt obudowy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Uchwyty zawartych obiektów</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Typ wybudzania</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Numer SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Rodzina</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Zablokuj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Stan rozruchu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Stan zasilania</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Stan termiczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Status bezpieczeństwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Informacje OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Wysokość</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Liczba kabli zasilających</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Zawarte elementy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Położenie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Typ korekcji błędów</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Pojemność maksymalna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Uchwyt informacji o błędzie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Liczba urządzeń</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Data wydania</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nazwa płyty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Wersja SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format opisu języka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Języki do zainstalowania</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Aktualnie zainstalowany język</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Adres BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Typ pakietu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Polityka połączenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Tryb połączenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Klasa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Klasy usług</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Klasa urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Wersja HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Wersja LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Podwersja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Urządzenie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Numer seryjny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produkt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Zasilany</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Wykrywalne</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Parowanie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Odkrywanie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Moduły sterowników</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Plik urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Pliki urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Numer urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplikacja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>Nazwa logiczna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>Wersja ANSI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Realizator CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Architektura CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Wariant CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Część CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Rewizja CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Jeden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Dziewięć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dziesięć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dwanaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Czternaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Szesnaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Osiemnaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Dwadzieścia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Dwadzieścia dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Dwadzieścia cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Dwadzieścia sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Dwadzieścia osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trzydzieści</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trzydzieści dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trzydzieści cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Trzydzieści sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trzydzieści osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Czterdzieści</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Czterdzieści dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Czterdzieści cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Czterdzieści sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Czterdzieści osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Pięćdziesiąt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Pięćdziesiąt dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Pięćdziesiąt cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Pięćdziesiąt sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Pięćdziesiąt osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sześćdziesiąt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sześćdziesiąt dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sześćdziesiąt cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sześćdziesiąt sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sześćdziesiąt osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Siedemdziesiąt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Siedemdziesiąt dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Siedemdziesiąt cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Siedemdziesiąt sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Siedemdziesiąt osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Osiemdziesiąt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Osiemdziesiąt-dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Osiemdziesiąt-cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Osiemdziesiąt-cześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Osiemdziesiąt-osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Dziewięćdziesiąt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Dziewięćdziesiąt dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Dziewięćdziesiąt cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Dziewięćdziesiąt sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Dziewięćdziesiąt osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Sto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Sto dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Sto cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Sto sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Sto osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Sto dziesięć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Sto dwanaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Sto czernaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Sto szesnaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Sto osiemnaście</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Sto dwadzieścia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Sto dwadzieścia-dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Sto dwadzieścia-cztery</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Sto dwadzieścia-sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Sto dwadzieścia-osiem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Sto dziewięćdziesiąt-dwa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Dwieście pięćdziesiąt-sześć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Pojemność GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Producent GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Typ GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Wersja EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>API klienta EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Wersja GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Wersja GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Nieznany</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Klasa sprzętu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Nie znaleziono procesora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Płyta główna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Nie znaleziono płyty głównej</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Nie znaleziono pamięci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Magazyn danych</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Nie znaleziono dysku</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Błąd przywracania sterownika!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Spróbuj ponownie lub przekaż nam opinię</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Błąd backupu sterownika!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Karta graficzna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Nie znaleziono GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Nie znaleziono monitora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Adapter sieciowy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Nie znaleziono adaptera sieciowego</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Adapter dźwięku</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Nie znaleziono urządzenia audio</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Nie znaleziono urządzenia Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Inne urządzenia PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Nie znaleziono innych urządzeń PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Zasilanie</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Nie znaleziono baterii</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Adapter dźwięku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Nie znaleziono urządzenia audio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Nie znaleziono urządzenia Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Inne urządzenia PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Nie znaleziono innych urządzeń PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Zasilanie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Nie znaleziono baterii</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Klawiatura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Nie znaleziono klawiatury</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Mysz</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Nie znaleziono myszy</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Drukarka</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Nie znaleziono drukarki</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Aparat</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Nie znaleziono aparatu</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>Nie znaleziono dysku CD-ROM</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Mysz</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Nie znaleziono myszy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Drukarka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Nie znaleziono drukarki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Aparat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Nie znaleziono aparatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>Nie znaleziono dysku CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Inne urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Nie znaleziono innych urządzeń</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Uchwyt tablicy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Specyfikacja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Ustaw</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Położenie banku</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Szczegóły typu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Numer części</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Ranga</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Technologia pamięci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Możliwości trybu pracy pamięci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Wersja firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID producenta modułu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID modułu produktu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID producenta kontrolera pamięci podsystemu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID kontrolera pamięci podsystemu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Rozmiar pamięci nieulotnej</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Rozmiar pamięci ulotnej</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Rozmiar pamięci podręcznej</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Rozmiar logiczny</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>cal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>strony</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>Informacje o szynie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>Rozmiar sektora logicznego</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>Rozmiar sektora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>GUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometria (logiczna)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Menedżer urządzeń</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Menedżer urządzeń to przydatne narzędzie do przeglądania informacji o sprzęcie i zarządzania urządzeniami.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Nowe sterowniki są dostępne do pobrania! Zaktualizuj lub zainstaluj je teraz.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Wyświetl</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Włącznie z podkatalogami</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Szukaj sterowników w tej ścieżce</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 sterowników może zostać zaktualizowanych</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Data sprawdzania: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Pobieranie sterowników dla %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Prędkość pobierania: %1 Pobrano %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Instalowanie sterowników dla %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 sterowników zainstalowano, %2 napotkało błąd</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>Zainstalowano %1 sterowników</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Nie udało się zainstalować sterowników</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Błąd sieci. Próba ponownego połączenia...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Prędkość pobierania %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Wszystkie sterowniki są aktualne</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Utworzono backup wszystkich sterowników</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Łącznie %1 sterowników, z których %2 utworzono backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Posiadasz %1 sterowników, którym można utworzyć backup, zaleca się zrobić to natychmiast</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Posiadasz %1 sterowników, którym można utworzyć backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Tworzenie backupu sterownika %1, łącznie %2</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Tworzenie backupu: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>Utworzono backup %1 sterowników, %2 napotkało błąd</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Nie udało się utworzyć backupu sterowników</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>Utworzono backup %1 sterowników</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Posiadasz %1 sterowników, które można przywrócić</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Wybierz sterownik do przywrócenia</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Przywracanie sterownika...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Przywracanie: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>uruchom ponownie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Prosimy %1, aby zastosować zmiany</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Wyświetl ścieżkę backupu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Backupuj wszystko</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>prześlij opinię</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Spróbuj ponownie lub %1 do nas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Zainstaluj wszystko</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Skanuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Skanowanie sterowników urządzeń, proszę czekać...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Skanowanie %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Skanowanie nie powiodło się</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Sieć niedostępna</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Sprawdź swoje połączenie sieciowe</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Zeskanuj ponownie lub %1 do nas</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Wyjście przerwie instalację sterownika.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Czy na pewno chcesz wyjść?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Wyjdź</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Wyjście przerwie proces tworzenia backupu sterowników.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Wyjście przerwie proces przywracania sterowników.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Nie udało się zdobyć plików sterownika</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Aktualizuj</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Przywracanie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Zainstaluj</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Aktualizuj sterowniki</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Odinstaluj sterowniki</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Zezwól urządzeniu na wybudzenie komputera</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Włącz</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Eksportuj</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Niedostępne</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Wybierz folder lokalny</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Wczytywanie...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_pt.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_pt.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>Feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Mais</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Recolher</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Recolher</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Mais</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Recolher</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nome do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Módulo Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Endereço de memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Pseudónimo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Módulo Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Energia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versão do controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nome lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Endereço MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Energia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Módulo Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID do núcleo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Arquitetura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Família da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Processador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Núcleo(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualização</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Flags</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensões</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>Cache L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Cache L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Cache L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Cache L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Cache L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Velocidade máxima</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Memória gráfica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Módulo Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Endereço de memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Porta IO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Resolução máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Resolução mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Resolução atual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Saída do monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Módulo Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Energia máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Bus Info</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Módulo Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Corrente máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Quantidade de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Motherboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Adaptador gráfico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Adaptador de som</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Armazenamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Outros dispositivos PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Rato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Impressora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Câmara</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Outros dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>SO</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Largura Total</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Localizador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Voltagem configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Voltagem máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Voltagem mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Velocidade configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Largura dos dados</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Entrada do monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Tipo de interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Resolução de suporte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Resolução atual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Formato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor principal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Número de série</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Tipo de suporte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Módulo Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versão do firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Taxa de rotação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Selecione um controlador para atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Nenhum controlador encontrado nesta pasta</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>A carregar informações do dispositivo de áudio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>A carregar informações do BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>A carregar informações do CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>A carregar informações do sistema operativo...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>A carregar informações da CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>A carregar informações de outros dispositivos...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>A carregar informação de energia...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>A carregar informações da impressora...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>A carregar informações do rato...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>A carregar informações do adaptador de rede...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Info dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Gestor de Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Adaptador gráfico</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
@@ -1702,178 +1645,171 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Versão atual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>Versão da Plataforma do Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Ação</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Drivers Restauráveis</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Drivers Backupados</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>A atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>O dispositivo ficará indisponível depois da desinstalação do controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>A desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Atualização bem sucedida</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Desinstalação bem sucedida</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Falha ao atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Falha ao desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>A pasta selecionada não existe, selecione novamente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Pacote quebrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Arquitetura do pacote não correspondente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>O ficheiro selecionado não existe, selecione novamente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Não é um controlador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Não foi possível instalar - sem assinatura digital</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Erro desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>O controlador não foi encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Formato de módulo inválido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>O módulo do controlador têm dependências</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Nome do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versão disponível</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Ação</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nova versão</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Versão atual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Controladores em falta (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Controladores desatualizados (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Controladores atualizados (%1)</translation>
     </message>
@@ -1939,132 +1870,126 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Instalar Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Backup de Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Restaurar Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>Aceitar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>Feedback</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>Você não tem nenhum driver para restaurar, por favor faça um backup primeiro</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>Ir para Backup de Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Versão atual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>Versão de Backup</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Ação</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Drivers Restauráveis</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Instalar Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Backup de Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Restaurar Driver</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Falha ao ativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Falha ao desativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Falha ao desativar: não foi possível obter o SN do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Atualizar Controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar Controladores</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Permitir que ative o computador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Falha ao desativar: não foi possível obter o SN do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Falha ao desativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Falha ao ativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Atualizar Controladores</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar Controladores</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>SubFabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>SubDispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Estado do controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Cmd de ativação do controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Estado de configuração</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>latência</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Manipuladores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Informação do BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Informação da placa base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Informação do Sistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Informação do chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Conjunto de memória física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Data de lançamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Tamanho do tempo de execução</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Tamanho da ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Características</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revisão do BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revisão do Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Nome do produto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Número de série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Etiqueta de identificação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Localização no chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Identificador do chassis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Identificadores de objetos contidos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Tipo de retomar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>Número SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Família</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Bloquear</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Estado do arranque</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Estado da fonte de alimentação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Estado térmico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Estado da segurança</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Informação OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Número de cabos de alimentação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elementos contidos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Localização</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Tipo de correcção de erro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacidade máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Identificador de informações de erro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Número de dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>TAMANHO ROM BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Data de lançamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nome da placa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versão da SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Formato da descrição do idioma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Idiomas instaláveis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Idioma atualmente instalado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Endereço BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Tipo de pacote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Política de ligação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Modo de ligação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Classe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Classes de serviço</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Classe do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versão de HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versão de LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>ID série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Alimentado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Detetável</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Emparelhável</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Descobrindo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Módulos de controlador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Ficheiro do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Ficheiros do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Número do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplicação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>estado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>nome lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>versãoansi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementador da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arquitetura da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variante da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Peça de CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revisão da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Um</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Nove</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dez</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Doze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Catorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Dezasseis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Dezoito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Vinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Vinte e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Vinte e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Vinte e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Vinte e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trinta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trinta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trinta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Trinta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trinta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Quarenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Quarenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Quarenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Quarenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Quarenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cinquenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cinquenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cinquenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cinquenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cinquenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sessenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sessenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sessenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sessenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sessenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Setenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Setenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Setenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Setenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Setenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Oitenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Oitenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Oitenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Oitenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Oitenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Noventa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Noventa e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Noventa e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Noventa e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Noventa e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Cem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Cento e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Cento e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Cento e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Cento e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Cento e dez</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Cento e doze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Cento e catorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Cento e dezasseis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Cento e dezoito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Cento e vinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Cento e vinte e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Cento e vinte e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Cento e vinte e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Cento e vinte e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Cento e noventa e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Duzentos e cinquenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacidade da GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Fabricante da GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Tipo de GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versão da EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>APIs do cliente EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versão da GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versão da GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Classe de hardware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Nenhuma CPU encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Motherboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Nenhuma motherboard encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Nenhuma memória encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Armazenamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Nenhum disco encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>Falha no backup do driver!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>Por favor tente novamente ou nos forneça feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>Falha no backup do driver!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Adaptador gráfico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Nenhuma GPU encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Nenhum monitor encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Adaptador de rede</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Nenhum adaptador de rede encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Adaptador de som</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Nenhum dispositivo áudio encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Nenhum dispositivo Bluetooth encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Outros dispositivos PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Nenhum dispositivo PCI encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Energia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Nenhuma bateria encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Nenhum teclado encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Rato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Nenhum rato encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Impressora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Nenhuma impressora encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Câmara</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Nenhuma câmara encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Nenhum CD-ROM encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Outros dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Nenhum dispositivo encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Identificador matriz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Fator de forma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Conjunto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Localizador de bancos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Detalhes do tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Número da peça</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Classificação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Tecnologia de memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Capacidade do modo de funcionamento da memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versão do firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID do fabricante do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID do produto do módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID do fabricante do controlador do subsistema da memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID do produto controlador do subsistema da memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Tamanho não volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Tamanho volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Tamanho da cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Tamanho lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>pol</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -3692,315 +3453,297 @@
         <translation>lados</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>info bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>tamanhosectorlógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>tamanhosector</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometria(Lógica)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Gestor de Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>O Gestor de Dispositivos é uma ferramenta útil para visualizar informações do equipamento e gerir os dispositivos.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Novos controladores disponíveis! Instale-os ou atualize-os agora.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Incluir subpastas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Procurar por controladores neste local</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 atualizações de controladores disponíveis</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Hora da verificação: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>A transferir controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocidade de transferência: %1 Transferido %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>A instalar controladores para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 controladores instalados, %2 controladores com falhas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 controladores instalados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Falha ao instalar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Erro de rede. A restabelecer a ligação...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Velocidade de transferência: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Os controladores estão atualizados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Todos os drivers foram backupados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Um total de %1 drivers, dos quais %2 foram backupados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>Você tem %1 drivers que podem ser backupados, é recomendado fazer isso
+imediatamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>Você tem %1 drivers que podem ser backupados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>Backupando o driver %1, um total de %2 drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>Backupando: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>%1 drivers backupados, %2 drivers falharam</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>Falha no backup de drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 drivers backupados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>Você tem %1 drivers que podem ser restaurados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>Por favor, selecione um driver para restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>O driver está sendo restaurado...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>Restaurando: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>reinicie</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Por favor %1 para que os condutores instalados tenham efeito</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>Visualizar caminho de backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
+        <translation>Backup de tudo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>envie-nos o feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Tente novamente ou %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Instalar tudo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Analisar novamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>A analisar controladores de dispositivos de hardware, aguarde...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>A analisar %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Falha ao analisar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Rede não disponível</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Verifique a sua ligação à Internet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Analise novamente ou %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Está a instalar um controlador, que será interrompido se sair.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Pretende sair?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Você está fazendo backup de drivers, que será interrompido se você sair.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Você está restaurando drivers, que será interrompido se você sair.</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
@@ -4009,7 +3752,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Dispositivo de imagem</translation>
     </message>
@@ -4071,27 +3813,27 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>Não foi feito backup</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>Fazendo backup</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>Backup falhou</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>Backup bem-sucedido</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>Restaurando</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4114,22 +3856,22 @@
         <translation>Falha ao obter ficheiros dos controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Restaurar</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
@@ -4142,39 +3884,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Atualizar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Desinstalar controladores</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Permitir que ative o computador</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
@@ -4182,27 +3922,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -4210,7 +3950,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Selecione uma pasta local</translation>
     </message>
@@ -4218,7 +3958,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>A carregar...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_pt_BR.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_pt_BR.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Mais</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Recolher</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Recolher</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Mais</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Recolher</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nome do Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Pseudônimo do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID Físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Endereço de Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Pseudônimo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Pseudônimo do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID Físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Potência Máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versão do Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Informações do Barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nome lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Endereço MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Informações do Barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Potência Máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Pseudônimo do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID Físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID do Núcleo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Threads</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Arquitetura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Família da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Processador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Núcleo(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualização</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Bandeiras</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensões</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>Cache L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Cache L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Cache L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Cache L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Cache L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Velocidade máxima</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Memória Gráfica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Pseudônimo do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID Físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Endereço de Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Porta de E/S</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Informações do Barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Resolução Máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Resolução Mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Resolução Atual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Saída Digital</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Exibir Saída</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Informações do Barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Pseudônimo do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID Físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Potência Máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Número de Série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Informações do Barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Pseudônimo do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID Físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Corrente máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Número de CPUs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Placa-mãe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Placa de Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Placa de Som</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Armazenamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Outros Dispositivos PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Placa de Rede</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Impressora</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Câmera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Outros Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>SO</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Largura Total</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Localizador</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Número de Série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Tensão Configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Tensão Máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Tensão Mínima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Velocidade Configurada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Largura de Dados</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Exibir Entrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Tipo de Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Resolução de Suporte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Resolução Atual</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Formato</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor Principal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Número de Série</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Fabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Tipo de Mídia</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Pseudônimo do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID Físico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versão do firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Número de Série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Taxa de Rotação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Selecione um driver para atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Não há drivers nesta pasta</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Carregando as Informações do Dispositivo de Áudio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Carregando as Informações da BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Carregando as Informações do CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Carregando as Informações do Sistema Operacional...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Carregando as Informações da CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Carregando as Informações de Outros Dispositivos...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Carregando as Informações de Energia...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Carregando as Informações da Impressora...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Carregando as Informações do Mouse...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Carregando as Informações da Placa de Rede...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Informações do Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Exibir atalhos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Gerenciador de Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Máquina</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Placa de Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Placa de Rede</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Mais</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Versão Atual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Versão da plataforma do driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Ações</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Drivers com backup</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Drivers com backup</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Atualizando</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>O dispositivo ficará indisponível depois da desinstalação do driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Desinstalar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Desinstalando</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Atualizado com sucesso</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Desinstalado com sucesso</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>A atualização falhou</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>A desinstalação falhou</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>A pasta selecionada não existe, por favor, selecione novamente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Pacote corrompido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Arquitetura do pacote não correspondente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>O arquivo selecionado não existe, por favor, selecione novamente</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Não é um driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Não é possível instalar - assinatura digital não encontrada</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Erro desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>O módulo do driver não foi encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Formato de módulo inválido</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>O módulo do driver tem dependências</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Nome do Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Versão Disponível</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Tamanho</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Ações</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Nova versão</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Versão Atual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Drivers faltando (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Drivers desatualizados (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Drivers atualizados (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Instalar driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Backup do driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Restaurar driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Feedback</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Você não tem nenhum driver para restaurar, faça um backup primeiro</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Ir para backup do driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Versão Atual</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Versão de backup</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Ações</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Drivers restauráveis</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Instalar driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Backup do driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Restaurar driver</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Falha ao ativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Falha ao desativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Falha em desabilitar: não foi possível obter o SN do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Atualizar drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar drivers</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Visão Geral</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Permitir despertar o computador</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Falha em desabilitar: não foi possível obter o SN do dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Falha ao desativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Falha ao ativar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Atualizar drivers</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Desinstalar drivers</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Subfabricante</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Subdispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Status do Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Cmd de Ativação do Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Status da Configuração</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>latência</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Controladores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Informações da BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Informações da Placa de Base</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Informações do Sistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Informações do Chassi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Conjunto de Memória Física</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Data de Lançamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Tamanho do Tempo de Execução</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Tamanho da ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Características</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revisão da BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revisão do Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Nome do Produto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Número de Série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Etiqueta de Recurso</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Recursos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Localização no Chassi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Identificador do Chassi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Identificador de Objetos Contidos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Tipo de Despertar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Número SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Família</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Bloquear</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Estado de Inicialização</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Estado da Fonte de Alimentação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Estado Térmico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Status de Segurança</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Informações OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Número de Cabos de Alimentação</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elementos Contidos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Localização</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Tipo de Erro da Correção</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacidade Máxima</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Identificador das Informações de Erro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Número de Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>TAMANHO DA ROM DA BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Data de lançamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nome da placa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versão da SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Formato de Descrição do Idioma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Idiomas Instaláveis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Idioma Atualmente Instalado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Endereço BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Tipo de pacote</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Política de link</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Modo de link</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Classe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Classes de Serviço</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Classe de Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versão do HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versão do LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Subversão</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Identificação de Série</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>descrição</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Ligado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Detectável</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Pareável</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Procurando</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Módulos do Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Arquivo do Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Arquivos do Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Número do Dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplicativo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>nome lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementador da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arquitetura da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variante da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Peça da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revisão da CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Um</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Nove</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dez</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Doze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Quatorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Dezesseis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Dezoito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Vinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Vinte e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Vinte e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Vinte e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Vinte e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trinta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Trinta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Trinta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Trinta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Trinta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Quarenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Quarenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Quarenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Quarenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Quarenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cinquenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cinquenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cinquenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cinquenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cinquenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sessenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sessenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sessenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sessenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sessenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Setenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Setenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Setenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Setenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Setenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Oitenta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Oitenta e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Oitenta e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Oitenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Oitenta e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Noventa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Noventa e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Noventa e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Noventa e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Noventa e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Cem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Cento e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Cento e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Cento e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Cento e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Cento e dez</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Cento e doze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Cento e quatorze</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Cento e dezesseis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Cento e dezoito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Cento e vinte</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Cento e vinte e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Cento e vinte e quatro</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Cento e vinte e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Cento e vinte e oito</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Cento e noventa e dois</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Duzentos e cinquenta e seis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacidade da GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Fabricante da GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Tipo de GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versão do EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>APIs do cliente EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versão do GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versão do GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Desconhecido</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Classe do Hardware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Nenhuma CPU encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Placa-mãe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Nenhuma placa-mãe encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Nenhuma memória encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Armazenamento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Nenhum disco encontrado</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>A restauração do driver falhou!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Tente novamente ou envie-nos um feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>O backup do driver falhou!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Placa de Vídeo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Nenhuma GPU encontrada</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Nenhum monitor encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Placa de Rede</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Nenhuma placa de rede encontrada</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Placa de Som</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Nenhum dispositivo de áudio encontrado</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Nenhum dispositivo Bluetooth encontrado</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Outros Dispositivos PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Nenhum dispositivo PCI encontrado</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Energia</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Nenhuma bateria encontrada</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Placa de Som</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Nenhum dispositivo de áudio encontrado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Nenhum dispositivo Bluetooth encontrado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Outros Dispositivos PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Nenhum dispositivo PCI encontrado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Energia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Nenhuma bateria encontrada</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Nenhum teclado encontrado</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Mouse</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Nenhum mouse encontrado</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Impressora</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Nenhuma impressora encontrada</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Câmera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Nenhuma câmera encontrada</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>Nenhum CD-ROM encontrado</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Mouse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Nenhum mouse encontrado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Impressora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Nenhuma impressora encontrada</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Câmera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Nenhuma câmera encontrada</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>Nenhum CD-ROM encontrado</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Outros Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Nenhum dispositivo encontrado</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Controlador de Matriz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Fator de Forma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Definir</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Localizador de Banco</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Detalhes do Tipo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Número da Peça</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rank</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Tecnologia da Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Capacidade do Modo de Operação da Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versão do Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID do Fabricante do Módulo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID do Módulo de Produto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID do Fabricante do Controlador do Subsistema de Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID do Produto do Controlador do Subsistema de Memória</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Tamanho Não Volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Tamanho Volátil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Tamanho do Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Tamanho Lógico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>pol</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>sides</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>informações do barramento</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>logicalsectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sectorsize</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometria (lógica)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Gerenciador de Dispositivos</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>O Gerenciador de Dispositivos é uma ferramenta útil para visualizar as informações de hardware e gerenciar os dispositivos.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Novos drivers disponíveis! Instale-os ou atualize-os agora.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Visualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Incluir subpastas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Procurar por drivers neste local</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 atualizações de drivers disponíveis</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Tempo decorrido: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Baixando drivers %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Velocidade download: %1 Baixado %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Instalando drivers para %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 drivers instalados, %2 drivers falharam</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 Drivers instalados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Falha ao instalar drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Erro de conexão. Reconectando...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Velocidade download: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Os drivers estão atualizados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Todos os drivers foram salvos em backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Um total de %1 drivers, dos quais %2 foram salvos em backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Você tem %1 drivers que podem ser copiados, é recomendável fazer isso imediatamente</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Você tem %1 drivers que podem ser salvos em backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Fazendo backup do %1 driver, um total de %2 drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Fazendo backup: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 drivers com backup, %2 drivers falharam</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Falha no backup dos drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>Backup de %1 drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Você tem %1 drivers que podem ser restaurados</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Selecione um driver para restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>O driver está sendo restaurado...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Restaurando: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Por favor aguarde %1 para os drivers instalados surtirem efeito</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Exibir caminho do backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Backup de tudo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>Enviar feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Por favor tente novamente ou %1 para nós</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Instalar tudo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Verificar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Verificando drivers de dispositivos de hardware, aguarde...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Verificados %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Verificação falhou</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Conexão não disponível</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Por favor verifique sua conexão a internet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Por favor verifique novamente ou %1 para nós</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>O driver está sendo instalado, a instalação será cancelada se você sair.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Tem certeza que deseja sair?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Você está fazendo o backup de drivers, que será interrompido se você sair.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Você está restaurando drivers, que serão interrompidos se você sair.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Falha na obtenção dos arquivos de drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Restaurar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Atualizar drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Desinstalar drivers</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Permitir despertar o computador</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Ativar</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Desativar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Indisponível</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Por favor, selecione uma pasta local</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Carregando...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ro.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ro.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ro">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ro">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
-        <source>OK</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
+        <source>OK</source>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Mai mult</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Colaps</translation>
     </message>
 </context>
 <context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Mai mult</translation>
     </message>
@@ -31,44 +46,28 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>EC_NOTIFY_NETWORK</source>
-        <translation type="unfinished"/>
+        <translation>Notificare rețea</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>EC_REINSTALL</source>
-        <translation type="unfinished"/>
+        <translation>Reinstalare</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>EC_6</source>
-        <translation type="unfinished"/>
+        <translation>EC_6</translation>
     </message>
 </context>
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Mai mult</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Colaps</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Mai mult</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Colaps</translation>
     </message>
@@ -77,92 +76,89 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
 </context>
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Nume dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Cip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
-        <translation type="unfinished"/>
+        <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Descriere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
-        <translation type="unfinished"/>
+        <translation>Revizie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
-        <translation type="unfinished"/>
+        <translation>Driver în mod kernel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
-        <translation type="unfinished"/>
+        <translation>Adresă de memorie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
-        <translation type="unfinished"/>
+        <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Putere Maximă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Versiune Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Info Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Nume Logic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Adresă MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Info Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Putere Maximă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID Nucleu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Thread-uri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Arhitectură</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Familie CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Nucleu(e)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualizare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Steaguri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Extensii</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Cache L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Cache L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Cache L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Cache L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Pași</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Viteză Maximă</translation>
     </message>
@@ -488,200 +479,200 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Memorie Grafică</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
-        <translation type="unfinished"/>
+        <translation>Adresă de memorie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Port IO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Info Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Rezoluție Maximă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Rezoluție Minimă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Rezoluție curentă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Descriere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Ieșire Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
 </context>
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Info Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Putere Maximă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Numar Serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Interfață</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Info Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
-        <translation type="unfinished"/>
+        <translation>Curent maxim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Prezentare Generală</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Cantitate CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Placa de bază</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Memorie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Adaptor Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Adaptor Sunet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Stocare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Alte dispozitive PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Baterie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Adaptor Rețea</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Tastatură</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Imprimantă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Cameră</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Alte Dispozitive</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>SO</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Mărime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Lățime totală</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Localizator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Numar Serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Voltaj Configurat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Voltaj Maxim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Voltaj Minim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Viteză Configurată</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Lățime date</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Intrare Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Tip Interfață</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Rezoluție Suportată</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Rezoluție curentă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Rație Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor Principal</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Mărime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Numar Serie</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
@@ -1090,12 +1040,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
         <source>Maximum Rate</source>
-        <translation type="unfinished"/>
+        <translation>Rată maximă</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
         <source>Negotiation Rate</source>
-        <translation type="unfinished"/>
+        <translation>Rată negociere</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
@@ -1145,7 +1095,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
         <source>Memory Address</source>
-        <translation type="unfinished"/>
+        <translation>Adresă de memorie</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
@@ -1165,7 +1115,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
@@ -1286,7 +1236,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
@@ -1428,148 +1378,143 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Furnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Tip Media</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Mărime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Capabilități</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Module Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Versiune Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Viteză</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Descriere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Numar Serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Interfață</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Rată Rotație</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Selectați un driver pentru actualizare</translation>
     </message>
 </context>
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
-        <translation type="unfinished"/>
+        <translation>Nu s-au găsit driveruri în această carpeta</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
-        <translation type="unfinished"/>
+        <translation>Nu s-au găsit drivere în această carpeta</translation>
     </message>
 </context>
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Încărcare Informații Dispozitiv Audio...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Încărcare Informații BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Încărcare Informații CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Încărcare Informații Sistem de Operare...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Încărcare Informații CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Încărcare Informații Alte Dispozitive...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Încărcare Informații Alimentare...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Încărcare Informații Imprimantă...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Încărcare Informații Mouse...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Încărcare Informații Adaptor Rețea...</translation>
     </message>
@@ -1577,116 +1522,114 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
 </context>
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Neprezentabil</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Informații Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Scurtături Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Închide</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Ajutor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Copiază</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Exportare</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Reîmprospătare</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Manager Dispozitive</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
-        <translation type="unfinished"/>
+        <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Prezentare Generală</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Adaptor Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Adaptor Rețea</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Baterie</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Mai mult</translation>
     </message>
@@ -1702,392 +1645,374 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>Versiunea curentă</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>Versiunea platformei driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Stare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>Acțiune</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Driver-urile care pot fi salvate</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Driver-urile salvate</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
-        <translation type="unfinished"/>
+        <translation>Actualizare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>Warning</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>The device will be unavailable after the driver uninstallation</source>
-        <translation type="unfinished"/>
+        <translation>Următorul</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
-        <source>Uninstall</source>
-        <comment>button</comment>
-        <translation type="unfinished"/>
+        <source>Warning</source>
+        <translation>Avertizare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Dispozitivul va fi inaccesibil după dezinstalarea driverului</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Dezinstalare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
-        <translation type="unfinished"/>
+        <translation>Se dezinstalează</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
-        <translation type="unfinished"/>
+        <translation>Actualizarea a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
-        <translation type="unfinished"/>
+        <translation>Dezinstalarea a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
-        <translation type="unfinished"/>
+        <translation>Actualizarea a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
-        <translation type="unfinished"/>
+        <translation>Dezinstalarea a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
-        <source>The selected folder does not exist, please select again</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
-        <source>Update</source>
-        <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Următorul</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Dosarul selectat nu există, selectați din nou</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Actualizare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
-        <translation type="unfinished"/>
+        <translation>Pachet defect</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
-        <translation type="unfinished"/>
+        <translation>Arhitectura pachetului nu se potrivește</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
-        <translation type="unfinished"/>
+        <translation>Fișierul selectat nu există, selectați din nou</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
-        <translation type="unfinished"/>
+        <translation>Nu este un driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
-        <translation type="unfinished"/>
+        <translation>Nu se poate instala - lipsa semnăturii digitale</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
-        <translation type="unfinished"/>
+        <translation>Eroare necunoscută</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
-        <translation type="unfinished"/>
+        <translation>Modulul driver nu a fost găsit</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
-        <translation type="unfinished"/>
+        <translation>Formatul modulului este invalid</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
-        <translation type="unfinished"/>
+        <translation>Modulul driver are dependențe</translation>
     </message>
 </context>
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Nume dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
-        <translation type="unfinished"/>
+        <translation>Versiunea disponibilă</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Mărime</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Stare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>Acțiune</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
-        <translation type="unfinished"/>
+        <translation>Versiune nouă</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>Versiunea curentă</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>Driveruri lipsă (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>Driveruri arhivate (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>Driveruri actualizate (%1)</translation>
     </message>
 </context>
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Instalare driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Backup driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Restaurare driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>Feedback</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>Nu aveți niciun driver de restaurat, vă rugăm să faceți un backup înainte</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>Mergeți la Backup Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Nume</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>Versiunea curentă</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>Versiunea de backup</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>Acțiune</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Driveruri restorabile</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Reîmprospătare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Exportare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Prezentare Generală</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Instalare driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Backup driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Restaurare driver</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Activarea dispozitivului a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Dezactivarea dispozitivului a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>Eșec la dezactivare: imposibil de obținut seria dispozitivului</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Actualizare driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Dezinstalare driver</translation>
     </message>
 </context>
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Reîmprospătare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Exportare</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Copiază</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Prezentare Generală</translation>
     </message>
@@ -2111,1368 +2036,1204 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Activează</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>Actualizare driver</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>Dezinstalare driver</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>Permite-i să îl trezească pe computer</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>Eroare la dezactivare: nu se poate obține seria SN a dispozitivului</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Dezactivarea dispozitivului a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Activarea dispozitivului a eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Actualizează driverele</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Dezinstalează driverele</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>SubFurnizor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>SubDispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Stare Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Comandă Activare Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Stare Configurare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>Latență</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fizic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Manipulatori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>CHEIE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Versiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Informații BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Informații Placă de Bază</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Informații Sistem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Informații Șasiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Matrice Memorie Fizică</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Dată Emitere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Dimensiune Execuție</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Mărime ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Caracteristici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Revizie BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revizie Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Nume Produs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Numar Serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Etichetă Bun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Caracteristici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Locația in Șasiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Mâner Șasiu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Mânerele obiectelor conținute</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Tipul de trezire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>Număr SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Familie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Lacăt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Starea de pornire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Stare Sursa Alimentare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Stare Termică</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Status Securitate</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Informații OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Înalțime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Număr Cabluri Alimentare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elemente Conținute</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Locație</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Tip Corecție Erori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Capacitate Maximă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Manevrare Informații Erori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Număr De Dispozitive</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>MĂRIMEROM BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Dată Emitere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Nume Placa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Versiune SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format Limbă Descriere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Limbi instalabile</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Limba Curentă Instalată</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Adresă BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Tip Pachet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Politică Legătura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Mod Legătură</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Clasă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Clase Servicii</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Clasă Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Versiune HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Versiune LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>SubVersiune</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>ID Serie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>Produs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>Descriere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Alimentat</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Descoperibil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Împerecheabil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Descoperire</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Module Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Dosar Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Dosare Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Număr Dispozitiv</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplicație</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>Stare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>Nume Logic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>VersiuneAnsi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementator CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arhitectură CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Varianta CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Partea CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revizie CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Unul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Două</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Nouă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Zece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Doisprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Paisprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Şaisprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Optsprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Douăzeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Douăzeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Douăzeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Douăzeci și Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Douăzeci și Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Treizeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Treizeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Treizeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Treizeci și șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Treizeci și opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Patruzeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Patruzeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Patruzeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Patruzeci și Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Patruzeci și Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Cincizeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Cincizeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Cincizeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Cincizeci și Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Cincizeci și Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Şaizeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Şaizeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Şaizeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Şaizeci și Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Şaizeci și Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Șaptezeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Șaptezeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Șaptezeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Șaptezeci și Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Șaptezeci și Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Optzeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Optzeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Optzeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Optzeci și Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Optzeci și Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Nouăzeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Nouăzeci și Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Nouăzeci și Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Nouăzeci și Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Nouăzeci și Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>O sută</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>O sută Doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>O sută Patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>O sută Șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>O sută Opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>O sută Zece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>O sută doisprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>O sută paisprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>O sută șaisprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>O sută optsprezece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>O suta douazeci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>O sută douăzeci și doi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>O sută douăzeci și patru</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>O sută douăzeci și șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>O sută douăzeci și opt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
-        <translation type="unfinished"/>
+        <translation>Unul sută și nouăzeci și două</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
-        <translation type="unfinished"/>
+        <translation>Două sute și cincizeci și șase</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Capacitate GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Furnizor GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Tip GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Versiune EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>API client EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Versiune GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Versiune GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Necunoscut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Unic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Clasă Hardware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>CPU Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Placa de bază</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Placa de bază negăsită</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Memorie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Memorie Negăsită</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Stocare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Unitate disc negasită</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>Restaurarea driverele a eșuat!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>Vă rugăm încercați din nou sau oferiți-ne feedback</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>Backup-ul driverele a eșuat!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Adaptor Afișaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>GPU Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Monitor Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Adaptor Rețea</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Adaptor Rețea Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Adaptor Sunet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Dispozitiv Audio Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Bluetooth Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Alte dispozitive PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Alte dispozitive PCI Negăsite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Alimentare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Nu s-a găsit baterie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Tastatură</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Tastatură Negăsită</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Mouse</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Mouse negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Imprimantă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Imprimantă Negăsită</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Cameră</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Cameră Negăsită</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>CD-ROM Negăsit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Alte Dispozitive</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Alte dispozitive negăsite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Manipulare Matrice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Factor Formă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Set</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Locație Banc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Detalii Tip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Număr Piesă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rang</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Tehnologie Memorie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Capacitatea Modului de Operare a Memoriei</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Versiune Firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID Producător Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID Produs Modul</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID Producător al Controlerului Subsistemului de Memorie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID Controler Subsistem Memorie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Dimensiune Non-Volatilă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Dimensiune Volatilă</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Dimensiune Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Dimensiune Logică</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Dată</translation>
     </message>
@@ -3692,446 +3453,426 @@
         <translation>fețe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>Info Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>DimensiuneSectorLogic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>DimensiuneSector</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometrie (Logică)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Manager Dispozitive</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Manager Dispozitive este un instrument la îndemână pentru vizualizarea informațiilor hardware și gestionarea dispozitivelor.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
-        <translation type="unfinished"/>
+        <translation>Sunt disponibile drivere noi! Instalați-le sau actualizați-le acum.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
-        <translation type="unfinished"/>
+        <translation>Vizualizare</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
-        <translation type="unfinished"/>
+        <translation>Includeți subfoldere</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
-        <translation type="unfinished"/>
+        <translation>Căutați drivere în acest folder</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
-        <translation type="unfinished"/>
+        <translation>%1 actualizări de drivere disponibile</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
-        <translation type="unfinished"/>
+        <translation>Timp verificat: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>Descarcare drivere pentru %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation type="unfinished"/>
+        <translation>Viteza de descărcare: %1 Descărcat %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>Instalare drivere pentru %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>%1 drivere instalate, %2 drivere eșuate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
-        <translation type="unfinished"/>
+        <translation>%1 drivere instalate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
-        <translation type="unfinished"/>
+        <translation>Eșec instalarea drivere</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
-        <translation type="unfinished"/>
+        <translation>Eroare de rețea. Reconectare...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
-        <translation type="unfinished"/>
+        <translation>Viteza de descărcare: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
-        <translation type="unfinished"/>
+        <translation>Driverele dvs. sunt la zi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Toate driverele au fost salvate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Un total de %1 drivere, dintre care %2 au fost salvate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>Aveți %1 drivere care pot fi salvate; este recomandat să faceți acest lucru imediat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>Aveți %1 drivere care pot fi salvate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>Se salvează driverul %1, un total de %2 drivere</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>Se salvează: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>%1 drivere salvate, %2 drivere eșuate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>Eșecul backup-ului drivere</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 drivere salvate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>Ai %1 drivere care pot fi restaurate</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>Vă rugăm să selectați un driver pentru a-l restaura</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>Driverul se restaură...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>Restaurare: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
-        <translation type="unfinished"/>
+        <translation>reboot</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
-        <translation type="unfinished"/>
+        <translation>Vă rugăm să %1 pentru ca driverele instalate să fie active</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>Vizualizare cale de backup</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
-        <source>submit feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
-        <source>Please try again or %1 to us</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
-        <source>Install All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
-        <source>Scan Again</source>
-        <translation type="unfinished"/>
+        <translation>Backup Toate</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>trimiteți feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Vă rugăm să încercați din nou sau %1 ne</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Instalare Toate</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Scanează din nou</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Scanează driverele hardware, vă rugăm așteptați...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
-        <translation type="unfinished"/>
+        <translation>Scanează %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
-        <translation type="unfinished"/>
+        <translation>Scanează eșuat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Rețea inutilizabilă</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
-        <translation type="unfinished"/>
+        <translation>Vă rugăm să verificați conexiunea la rețea</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
-        <translation type="unfinished"/>
+        <translation>Vă rugăm să scanează din nou sau %1 ne</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Instalați un driver, care va fi întrerupt dacă ieșiți.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"/>
+        <translation>Sunteți sigur(ă) că doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Salvați drivere, care va fi întrerupt dacă ieșiți.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Restaurați drivere, care va fi întrerupt dacă ieșiți.</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
         <source>Bluetooth adapter</source>
-        <translation type="unfinished"/>
+        <translation>Adapter Bluetooth</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
-        <translation type="unfinished"/>
+        <translation>Dispozitiv de imagine</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="38"/>
         <source>Display adapter</source>
-        <translation type="unfinished"/>
+        <translation>Adapter de afișare</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="40"/>
         <source>Sound card</source>
-        <translation type="unfinished"/>
+        <translation>Placă de sunet</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="42"/>
         <source>Network adapter</source>
-        <translation type="unfinished"/>
+        <translation>Adapter de rețea</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="46"/>
         <source>Wireless network adapter</source>
-        <translation type="unfinished"/>
+        <translation>Adapter de rețea wireless</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="66"/>
         <source>Installation successful</source>
-        <translation type="unfinished"/>
+        <translation>Instalare reușită</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="67"/>
         <source>Installation failed</source>
-        <translation type="unfinished"/>
+        <translation>Instalare eșuată</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="68"/>
         <source>Downloading</source>
-        <translation type="unfinished"/>
+        <translation>Descărcare</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="69"/>
         <source>Installing</source>
-        <translation type="unfinished"/>
+        <translation>Instalare</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="70"/>
         <source>Not installed</source>
-        <translation type="unfinished"/>
+        <translation>Nu este instalat</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="71"/>
         <source>Out-of-date</source>
-        <translation type="unfinished"/>
+        <translation>Veche</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="72"/>
         <source>Waiting</source>
-        <translation type="unfinished"/>
+        <translation>Așteptare</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>Nu este salvat</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>Se salvează</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>Salvare eșuată</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>Salvare reușită</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>Restaurare</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
         <source>Unknown error</source>
-        <translation type="unfinished"/>
+        <translation>Eroare necunoscută</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Network error</source>
-        <translation type="unfinished"/>
+        <translation>Eroare de rețea</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Canceled</source>
-        <translation type="unfinished"/>
+        <translation>Anulat</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Failed to get driver files</source>
-        <translation type="unfinished"/>
+        <translation>Eșec la obținerea fișierelor de driver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
-        <translation type="unfinished"/>
+        <translation>Actualizare</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>Salvare</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Restaurare</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation>Instalare</translation>
     </message>
     <message>
         <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Reîmprospătare</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Exportare</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>Actualizează driverele</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>Dezinstalează driverele</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>Permite-i să-și trezească computerul</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Activează</translation>
     </message>
@@ -4182,43 +3921,43 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Reîmprospătare</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Exportare</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Copiază</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Dezactivează</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Nedispobil</translation>
     </message>
 </context>
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
-        <translation type="unfinished"/>
+        <translation>Selectați, vă rog, o carpeta locală</translation>
     </message>
 </context>
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Încărcare...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ru.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ru.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Обратная связь</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Ещё</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Свернуть</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Ещё</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Ещё</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Свернуть</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Ещё</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Свернуть</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Имя Устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Микросхема</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Псевдоним модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Физическая идентификация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Пересмотр</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Адрес памяти</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Чипсет</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Псевдоним</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Псевдоним модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Физическая идентификация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Максимальная мощность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Версия драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Информация о шине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Логическое название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC-адрес</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Информация о шине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Максимальная мощность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Псевдоним модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Физическая идентификация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>идентификатор ядра</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Потоки</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Архитектура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>семейство ЦП</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>ядро(а)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Виртуализация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Флаги</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Расширения</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>Кэш L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 кэш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 кэш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i кэш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d кэш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Степпинг</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Максимальная скорость</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Графическая память</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Псевдоним модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Физическая идентификация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Адрес памяти</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Порт ввода-вывода</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Информация о шине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Максимальное разрешение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Минимальное разрешение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Текущее разрешение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Цифровой выход</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Вывод на Дисплей</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Информация о шине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Псевдоним модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Физическая идентификация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Максимальная мощность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Интерфейс</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Информация о шине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Псевдоним модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Физическая идентификация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Максимальный ток</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Обзор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Количество ЦП</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Материнская плата</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Память</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Дисплейный адаптер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Звуковой Адаптер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Хранилище</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Другие PCI Устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Батарея</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Сетевой адаптер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Мышь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Клавиатура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Принтер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Остальные устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Устройство</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>ОС</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Общая ширина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Локатор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Текущее Напряжение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Максимальное Напряжение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Минимальное напряжение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Настроенная скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Ширина шины данных</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Вход дисплея</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Тип интерфейса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Поддерживаемое разрешение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Текущее разрешение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Соотношение сторон дисплея</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Основной Монитор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Серийный номер</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
@@ -1407,7 +1357,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
         <source>URI</source>
-        <translation type="unfinished"/>
+        <translation>URI</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Поставщик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Тип Носителя</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Способность</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Псевдоним модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Физическая идентификация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Версия ПО</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Интерфейс</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Частота вращения</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
@@ -1510,66 +1456,65 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
-        <translation type="unfinished"/>
+        <translation>Выберите драйвер для обновления</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
-        <translation type="unfinished"/>
+        <translation>В этой папке не найдены драйверы</translation>
     </message>
 </context>
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Загрузка информации об аудио устройствах</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Загрузка информации о BIOS</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Загрузка информации о CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Загрузка информации об операционной системе</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Загрузка информации о процессоре</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Загружаю информацию о Других Устройствах...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Загружаю информацию о Питании... </translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Загрузка информации о принтере</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Загружаю информацию о Мыши...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Загружаю информацию о Сетевом Адаптере...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Информация об устройстве</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Отобразить горячие клавиши</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Скопировать</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Диспетчер устройств</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Оборудование</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Обзор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Видеоадаптер</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Сетевой адаптер</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Батарея</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Ещё</translation>
     </message>
@@ -1702,178 +1645,171 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Текущая версия</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>Версия платформы драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Состояние</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Действие</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Драйверы, которые можно сохранить</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Сохраненные драйверы</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Обновление</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation>Далее</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Внимание</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
-        <translation type="unfinished"/>
+        <translation>После удаления драйвера устройство станет недоступным</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Удаление</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Обновление прошло успешно</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Удаление прошло успешно</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Обновление не удалось</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Удаление не удалось</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Далее</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
-        <translation type="unfinished"/>
+        <translation>Выбранная папка не существует, пожалуйста, выберите снова</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Нарушены зависимости</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Не совпадает архитектура пакета</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
-        <translation type="unfinished"/>
+        <translation>Выбранный файл не существует, пожалуйста, выберите снова</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Не является драйвером</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Установка невозможна: отсутствует цифровая подпись</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Неизвестная ошибка</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Модуль драйвера не найден</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Неверный формат модуля</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>У модуля есть зависимости</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Имя Устройства</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Доступная версия</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Состояние</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Действие</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Новая версия</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Текущая версия</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Отсутствующие драйверы (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Устаревшие драйверы (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Обновленные драйверы (%1)</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Установка драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Резервное копирование драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Восстановление драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Обратная связь</translation>
     </message>
@@ -1973,98 +1898,98 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>У вас нет драйверов для восстановления, сначала выполните резервное копирование</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>Перейти к резервному драйверу</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Текущая версия</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>Версия резервной копии</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Действие</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Восстанавливаемые драйверы</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Обзор</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Установка драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Резервное копирование драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Восстановление драйвера</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Не удалось включить устройство</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Не удалось отключить устройство</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>Не удалось отключить: невозможно получить серийный номер устройства</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Обновить драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Удалить драйверы</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Скопировать</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Обзор</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Включить</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Разрешать вывод компьютера из ждущего режима</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>Не удалось отключить: невозможно получить серийный номер устройства</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Не удалось отключить устройство</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Не удалось включить устройство</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Обновить драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Удалить драйверы</translation>
     </message>
@@ -2165,1316 +2088,1154 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
-        <source>SubVendor</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
-        <source>SubDevice</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Подпроизводитель</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Подустройство</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Состояние драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
-        <translation type="unfinished"/>
+        <translation>Команда активации драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
-        <translation type="unfinished"/>
+        <translation>Статус конфигурации</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>задержка</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
-        <translation type="unfinished"/>
+        <translation>Физ.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
-        <translation type="unfinished"/>
+        <translation>Обработчики</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
-        <translation type="unfinished"/>
+        <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
-        <translation type="unfinished"/>
+        <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
-        <translation type="unfinished"/>
+        <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Версия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Шина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Информация о BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Информация о материнской плате</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Информация о системе</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Информация о корпусе</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
-        <translation type="unfinished"/>
+        <translation>Физический массив памяти</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Дата выпуска</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Размер Времени Выполнения</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Размер диска </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Характеристики</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Ревизия BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Версия прошивки</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Наименование Продукта</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Инвентарный номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Особенности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
-        <translation type="unfinished"/>
+        <translation>Расположение в корпусе</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
-        <translation type="unfinished"/>
+        <translation>Ручка корпуса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
-        <translation type="unfinished"/>
+        <translation>Содержащиеся объекты-ручки</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Тип Пробуждения</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>Номер SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Семейство</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
-        <translation type="unfinished"/>
+        <translation>Замок</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
-        <translation type="unfinished"/>
+        <translation>Состояние при запуске</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
-        <translation type="unfinished"/>
+        <translation>Состояние питания</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
-        <translation type="unfinished"/>
+        <translation>Термальное состояние</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Состояние безопасности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM информация</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Число сетевых шнуров</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
-        <translation type="unfinished"/>
+        <translation>Содержащиеся элементы</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Расположение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Тип коррекции ошибок</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Максимальная вместимость</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
-        <translation type="unfinished"/>
+        <translation>Ручка информации об ошибке</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Число устройств</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
-        <translation type="unfinished"/>
+        <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Дата выпуска</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Название платы</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Версия SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Формат Описания Языка</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Устанавливаемые языки</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Текущий установленный язык</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
-        <translation type="unfinished"/>
+        <translation>BD Address</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
-        <translation type="unfinished"/>
+        <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
-        <translation type="unfinished"/>
+        <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Тип пакетов</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
-        <translation type="unfinished"/>
+        <translation>Политика связи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
-        <translation type="unfinished"/>
+        <translation>Режим связи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Класс</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
-        <translation type="unfinished"/>
+        <translation>Классы служб</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Класс устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Версия HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Версия LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
-        <translation type="unfinished"/>
+        <translation>Подверсия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Устройство</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Серийный номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>продукт</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>описание</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Работающий</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Обнаруженный</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Парный</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Обнаружение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Модули драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Файл устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Файлы устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Номер устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Приложение</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>Состояние</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>логическое название</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>антиверсия</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
-        <translation type="unfinished"/>
+        <translation>Исполнитель CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Архитектура ЦП</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Вариант ЦП</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Номер по каталогу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Версия ЦП</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Один</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Девять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Десять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Двенадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Четырнадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Шестнадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Восемнадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Двадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Двадцать два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Двадцать четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Двадцать шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Двадцать восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Тридцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Тридцать два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Тридцать четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Тридцать шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Тридцать восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Сорок</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Сорок два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Сорок четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Сорок шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Сорок восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Пятьдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Пятьдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Пятьдесят четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Пятьдесят шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Пятьдесят восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Шестьдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Шестьдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Шестьдесят четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Шестьдесят шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Шестьдесят восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Семьдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Семьдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Семьдесят четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Семьдесят шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
-        <translation type="unfinished"/>
+        <translation>Семьдесят восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Восемьдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Восемьдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
-        <translation type="unfinished"/>
+        <translation>Сорок восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
-        <translation type="unfinished"/>
+        <translation>Сорок шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
-        <translation type="unfinished"/>
+        <translation>Сорок восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Девяносто</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
-        <translation type="unfinished"/>
+        <translation>Девяносто два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
-        <translation type="unfinished"/>
+        <translation>Девяносто четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
-        <translation type="unfinished"/>
+        <translation>Девяносто шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Девяносто восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Сто</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Сто два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Сто четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Сто шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Сто восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Сто десять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Сто двенадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Сто четырнадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Сто шестнадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Сто восемнадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Сто двадцать</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Сто двадцать два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Сто двадцать четыре</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Сто двадцать шесть</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Сто двадцать восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Сто девяносто два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Сто пятьдесят восемь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
-        <translation type="unfinished"/>
+        <translation>Емкость GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
-        <translation type="unfinished"/>
+        <translation>Производитель GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
-        <translation type="unfinished"/>
+        <translation>Тип GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Версия EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
-        <translation type="unfinished"/>
+        <translation>API-клиент EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Версия GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>версия GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Неизвестный</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
-        <translation type="unfinished"/>
+        <translation>Уникальный</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
-        <translation type="unfinished"/>
+        <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
-        <translation type="unfinished"/>
+        <translation>Класс оборудования</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Процессор не найден</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Материнская плата</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Материнская плата не найдена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Память</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Память не найдена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Хранилище</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Диск не найден</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>Восстановление драйвера не удалось!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>Пожалуйста, попробуйте снова или оставьте отзыв</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>Резервное копирование драйвера не удалось!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Дисплейный адаптер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Графический процессор не найден</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
-        <translation type="unfinished"/>
+        <translation>Монитор не найден</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Сетевой адаптер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Сетевой адаптер не найден</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Звуковой Адаптер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Не найдено звуковое устройство</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Устройство Bluetooth не найдено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Другие PCI Устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Не найдено других PCI устройств</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Питание</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Батарея не найдена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Клавиатура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Клавиатура не найдена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Мышь</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Мышь не найдена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Принтер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Притер не найден</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Камера не найдена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>CD-ROM не найден</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Остальные устройства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Остальные устройства не найдены</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
-        <translation type="unfinished"/>
+        <translation>Ручка массива</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Форм-фактор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
-        <translation type="unfinished"/>
+        <translation>Сет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
-        <translation type="unfinished"/>
+        <translation>Локатор банка</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
-        <translation type="unfinished"/>
+        <translation>Детали типа</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Номер по каталогу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
-        <translation type="unfinished"/>
+        <translation>Ранг</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Технология памяти</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
-        <translation type="unfinished"/>
+        <translation>Возможности режима работы памяти</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Версия ПО</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
-        <translation type="unfinished"/>
+        <translation>Идентификатор производителя модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
-        <translation type="unfinished"/>
+        <translation>Идентификатор продукта модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
-        <translation type="unfinished"/>
+        <translation>Идентификатор производителя контроллера памяти</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
-        <translation type="unfinished"/>
+        <translation>Идентификатор продукта контроллера памяти</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
-        <translation type="unfinished"/>
+        <translation>Непротиворечивый размер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
-        <translation type="unfinished"/>
+        <translation>Временный размер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Размер кэша</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Логический размер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>дюйм</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
-        <translation type="unfinished"/>
+        <translation>Дата</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
@@ -3484,7 +3245,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
         <source>network</source>
-        <translation type="unfinished"/>
+        <translation>сеть</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
@@ -3499,7 +3260,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
         <source>power supply</source>
-        <translation type="unfinished"/>
+        <translation>питание</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
@@ -3509,62 +3270,62 @@
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
         <source>has history</source>
-        <translation type="unfinished"/>
+        <translation>имеет историю</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
         <source>has statistics</source>
-        <translation type="unfinished"/>
+        <translation>имеет статистику</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
         <source>rechargeable</source>
-        <translation type="unfinished"/>
+        <translation>перезаряжаемый</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
         <source>state</source>
-        <translation type="unfinished"/>
+        <translation>состояние</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
         <source>warning-level</source>
-        <translation type="unfinished"/>
+        <translation>уровень предупреждения</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
         <source>energy</source>
-        <translation type="unfinished"/>
+        <translation>энергия</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
         <source>energy-empty</source>
-        <translation type="unfinished"/>
+        <translation>энергия пустая</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
         <source>energy-full</source>
-        <translation type="unfinished"/>
+        <translation>энергия полная</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
         <source>energy-full-design</source>
-        <translation type="unfinished"/>
+        <translation>энергия полная (дизайн)</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
         <source>energy-rate</source>
-        <translation type="unfinished"/>
+        <translation>скорость энергии</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
         <source>voltage</source>
-        <translation type="unfinished"/>
+        <translation>напряжение</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
         <source>percentage</source>
-        <translation type="unfinished"/>
+        <translation>процент</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
@@ -3684,321 +3445,302 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
         <source>printer-uri-supported</source>
-        <translation type="unfinished"/>
+        <translation>URI принтера, поддерживаемый</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
         <source>sides</source>
-        <translation type="unfinished"/>
+        <translation>стороны</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>Информация о шине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>логический размер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>размер сектора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>руководство</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Геометрия (логическая)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Диспетчер устройств</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Диспетчер устройств - удобный инструмент для просмотра информации об оборудовании и управления устройствами.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Доступны новые драйверы! Установите или обновите их.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
-        <translation type="unfinished"/>
+        <translation>Просмотр</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Включая подпапки</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
-        <translation type="unfinished"/>
+        <translation>Искать драйверы по этому пути</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>Доступно обновленных драйверов: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Последняя проверка: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Загрузка драйверов для %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Скорость загрузки: %1 Загружено %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Установка драйверов для %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 драйверов установлено, %2 драйверов не удалось'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>Установлено драйверов: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Не удалось установить драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
-        <translation type="unfinished"/>
+        <translation>Ошибка сети. Перезапуск соединения...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Скорость загрузки: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Ваши драйверы обновлены</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Все драйверы были сохранены</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Всего %1 драйверов, из которых %2 были сохранены</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>У вас %1 драйверов, которые можно сохранить, рекомендуется сделать это немедленно</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>У вас %1 драйверов, которые можно сохранить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>Сохранение драйвера %1, всего драйверов %2</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>'Сохранение: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 драйверов сохранено, %2 драйверов не удалось'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>Не удалось сохранить драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>'%1 драйверов сохранено'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>У вас %1 драйверов, которые можно восстановить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>Пожалуйста, выберите драйвер для восстановления</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>Драйвер восстанавливается...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>'Восстановление: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>перезагрузите компьютер</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Чтобы задействовать установленные драйвера, %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>Просмотр пути резервного копирования</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Создайте резервную копию всех</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
-        <translation type="unfinished"/>
+        <translation>отправить отзыв</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
-        <translation type="unfinished"/>
+        <translation>Пожалуйста, попробуйте снова или %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Установить все</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Повторный поиск</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Сканирование драйверов аппаратных устройств, пожалуйста, подождите...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
-        <translation type="unfinished"/>
+        <translation>Сканирование %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
-        <translation type="unfinished"/>
+        <translation>Сканирование не удалось</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Сеть недоступна</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
-        <translation type="unfinished"/>
+        <translation>Пожалуйста, проверьте ваше сетевое соединение</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
-        <translation type="unfinished"/>
+        <translation>Пожалуйста, сканируйте снова или %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Вы устанавливаете драйвер, работа которого будет прервана, если вы выйдете из системы.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Вы уверены, что хотите выйти?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Выход</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Вы создаете резервную копию драйверов, которая будет прервана, если вы выйдете из системы.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Вы восстанавливаете драйверы, работа которых будет прервана, если вы выйдете из системы.</translation>
     </message>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Устройство для формирования изображения</translation>
     </message>
@@ -4114,22 +3855,22 @@
         <translation>Не удалось получить файлы драйверов</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Резервная копия</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Восстанавливать</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Установка</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Обновить драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Удалить драйверы</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Разрешать вывод компьютера из ждущего режима</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Включить</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Скопировать</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Отключить</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Недоступно</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Выберите локальную папку</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Загрузка...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sc.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sc.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sc">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>التعليق</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>موافق</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>أكثر</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>إشعار الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>إعادة التثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>أكثر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>الانكماش</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>اسم الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>الشريحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>مسار SysFS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>المحرك في وضعية النواة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>عنوان الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>مجموعة الشريحة</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>الاسم الم псود</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>نسخة برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>معلومات الطرف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>الاسم المنطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>عنوان MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>الغاء التفعيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>الشركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>معلومات الطرف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>الغاء التفعيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>هوية المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>هوية النواة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>الخيوط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Vrecka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجوميبس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>الهيكلية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>عائلة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>نواة(ات)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>الترميز الافتراضي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>العلميات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>التوسعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>الذاكرة L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>الذاكرة L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>الذاكرة L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>الذاكرة L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>الخطوة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>الشركة المصنعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ذاكرة الرسومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>الهوية الفيزيائية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>عنوان الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>منفذ I/O</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>الدقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>الدقة الدنيا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>البرنامج المُحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>واجهة DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>واجهة eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>واجهة HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>واجهة VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>واجهة DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>الإخراج الرقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>إخراج العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>الإصدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>معلومة الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>القوة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>معلومة الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>التيار القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>وحدة المعالجة المركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>عدد وحدات المعالجة المركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>لوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>بطاقة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>بطاقة الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>أجهزة PCI الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>بطاقة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>الماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>اللوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>الشاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>القرص الليزر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>الطباعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>الكاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>الأجهزة الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>نظام التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>العرض الكلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>الجهد المُحدد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>الجهد الأقصى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>الجهد الأدنى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>السرعة المُحددة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>عرض البيانات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>الإدخال العرضي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>نوع واجهة الاتصال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>الدقة المدعومة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>نسبة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>الشاشة الأساسية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحافلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>المُحرّك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>نسخة المُحرّك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>سرعة المفاوضة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>المنفذ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>البث المتعدد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>الوصل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>التأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>الزوجية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>البث العام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>التفاوض التلقائي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>عنوان الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>عنوان MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>الاسم المنطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>المورِّد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحافلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>المدخلات/المخرجات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>التأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>المحرّك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>المورِّد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحافلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>المحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>القدرة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>السعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>الشريحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>السعة المُصممة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>الجهد المُصمم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>إصدار SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>رقم سريال SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاريخ تصنيع SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>كيمياء SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>درجة الحرارة</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>المشاركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>نوع الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>نوع الوسيلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>نسخة البرمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>معدل الدوران</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>اختر مُحَدَّدًا للاستخدام</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>لا توجد مُحَدَّدات في هذا المجلد</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>جارٍ تحميل معلومات جهاز الصوت...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>جارٍ تحميل معلومات BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>جارٍ تحميل معلومات CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>جارٍ تحميل معلومات نظام التشغيل...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>جارٍ تحميل معلومات المعالج...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>جارٍ تحميل معلومات أجهزة أخرى...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>جارٍ تحميل معلومات الطاقة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>جارٍ تحميل معلومات الطابعة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>جارٍ تحميل معلومات فأرة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>جارٍ تحميل معلومات بطاقة الشبكة...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>معلومات الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>عرض المفاتيح</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>إغلاق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>مساعدة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>النظام</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>الهاردوير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>البرامج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>المُراقبة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>بطاقة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>الوحدة المركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>بطاقة الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>أكثر</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>نسخة منصة برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>برامج التشغيل قابلة للنسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>برامج التشغيل المُستنسخة</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>جارٍ التحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>تحذير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>سيصبح الجهاز غير متاح بعد إزالة برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>إزالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>جارٍ إزالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>تحديث ناجح</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>إزالة ناجحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>تحديث فشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>فشل إلغاء التثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>نعم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>الملف الذي تم اختياره لا موجود، يرجى اختياره مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>السابق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>حزمة تالفة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>هيكل الحزمة غير متوافق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>الملف الذي تم اختياره لا موجود، يرجى اختياره مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ليس مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>غير قادر على التثبيت - لا توقيع رقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>خطأ غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>لم يتم إيجاد وحدة مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>صيغة الوحدة غير صالحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>لدي وحدة مُثبت برمجيات اعتمادات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>تثبيت مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>نسخة احتياطية من مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>استعادة مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>التعليقات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>ليس لديك أي مُثبت برمجيات للاستعادة، يرجى إنشاء نسخة احتياطية أولاً</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>الانتقال إلى نسخة احتياطية من مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>نسخة احتياطية</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>مُثبتات برمجيات قابلة للإعادة</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>تثبيت مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>نسخة احتياطية من مُثبت برمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>استعادة مُثبت برمجيات</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>فشل في تمكين الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>فشل في تعطيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>فشل في تعطيله: لا يمكن الحصول على رقم التسلسل الخاص بالجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>تحديث برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>إزالة برامج التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>تمكين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>تحديث برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>إزالة برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>السماح له بتفريغ الكمبيوتر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>فشل في تعطيله: لا يمكن الحصول على رقم التسلسل الخاص بالجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>فشل في تعطيل الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>فشل في تمكين الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>تحديث برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>إزالة برامج التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>العميل الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>الجهاز الفرعي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>حالة برنامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>명령어 활성화</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>حالة التكوين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>التأخير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>الجسدي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>سيسفس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>المُعالِجات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>بروب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>إف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>كي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>الشِبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>معلومات BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>معلومات لوحة الأساس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>معلومات النظام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>معلومات الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>مصفوفة الذاكرة الفيزيائية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>تاريخ الإصدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>العنوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>حجم التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>حجم الـROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>الخصائص</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>مراجعة BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>مراجعة البرمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>اسم المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>مُلصق الأصول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>الموقع داخل الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>مقبض الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>مقبضات الكائنات المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>نوع الاستيقاظ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>رقم SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>العائلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>قفل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>حالة التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>حالة التيار الكهربائي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>حالة الحرارة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>حالة الأمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>معلومات المصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>الارتفاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>عدد أسلاك الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>العناصر المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نوع تصحيح الأخطاء</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>السعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>المرجع عن معلومات الخطأ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>عدد الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>حجم BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاريخ الإطلاق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>اسم اللوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>نسخة SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>تنسيق وصف اللغة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>اللغات القابلة للتركيب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>اللغة المثبتة حاليًا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>عنوان BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>حجم وحدة MTU ACL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>حجم وحدة MTU SCO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>نوع الحزمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>سياسة الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>وضع الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>الصنف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>أنواع الخدمات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>نوع الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>نسخة HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>نسخة LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>النسخة الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>مُمكّن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>قابل للاكتشاف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>قابل للربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>يتم الاكتشاف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>وحدات القيادة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ملف الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ملفات الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>رقم الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>التطبيق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>اسم المنطق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>نسخة ANSI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>مُطور المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>هيكل المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>نسخة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>جزء المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>نسخة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>واحد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>اثنين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>أربعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Osme</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Devet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Deset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Dvanáste</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Sedemnáste</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Sedmnáct</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Devätnáct</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Dvacet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Dvacet dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Dvacet čtyři</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Dvacet šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Dvacet osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Třicet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Třicet dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Třicet čtyři</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Třicet šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Třicet osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Čtyřicet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Čtyřicet dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Čtyřicet čtyři</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Čtyřicet šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Čtyřicet osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Padesát</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Padesát dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Padesát čtyři</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Padesát šest</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Padesát osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Šedesát</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Šedesát dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Šedesát čtyři</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ستين وستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ستين وثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>سبعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>سبعون واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>سبعون واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>سبعون وستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>سبعون وثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ثمانون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ثمانون واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ثمانون واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ثمانون وستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ثمانون وثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>تسعون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>تسعون واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>تسعون واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>تسعون وستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>تسعون وثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>مائة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>مائة واثنان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>مائة واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>مائة وستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>مائة وثمانية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>مائة وعشرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>مائة واثنى عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>مائة و١٤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>مائة و١٦</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>مائة و١٨</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>مائة و٢٠</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>مائة و٢٢</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>مائة و٢٤</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>مائة واثنان وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>مائة واثنان وثلاثون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>مائة وتسعة وعشرون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>مائتان وخمسة وخمسون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>سعة GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>مصنّع وحدة معالجة الرسوم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>نوع وحدة معالجة الرسوم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>نسخة EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>واجهات برمجة التطبيقات لـ EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>نسخة GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>نسخة GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>واحد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>فئة الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>وحدة المعالجة المركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>لم يتم العثور على وحدة معالجة مركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>لوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>لم يتم العثور على لوحة أم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>لم يتم العثور على ذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>لم يتم العثور على محرك أقراص</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>فشل استعادة الطرفية!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>يرجى المحاولة مرة أخرى أو تقديم ملاحظات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>فشل نسخ الطرفية!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>مُوصِل العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>لم يتم العثور على وحدة معالجة الرسوم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>شاشة عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>لم يتم العثور على شاشة عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>المحول الشبكي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>لم يتم العثور على محول شبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>محول الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>لم يتم العثور على جهاز صوتي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>لم يتم العثور على جهاز بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>أجهزة PCI الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>لم يتم العثور على أجهزة pci أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>لم يتم العثور على بطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>اللوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>لم يتم العثور على لوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>الماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>لم يتم العثور على ماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>المطبعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>لم يتم العثور على مطبعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>الكاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>لم يتم العثور على كاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>قرص CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>لم يتم العثور على قرص CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>الأجهزة الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>لم يتم العثور على أجهزة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>اليدعى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>الشكل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>مجموعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>تفاصيل النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>رقم الجزء</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>الترتيب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>تقنية الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>القدرة على وضعية تشغيل الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>نسخة البرنامج الثابت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>هوية مصنّع الوحدة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>هوية منتج الوحدة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>هوية مصنّع وحدة التحكم في نظام الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>هوية منتج وحدة التحكم في نظام الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>حجم الذاكرة غير القابلة للمسح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>حجم الذاكرة القابلة للمسح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>حجم ذاكرة التخزين المؤقت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>حجم الذاكرة المنطقية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>بوصة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>التاريخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>منفذ إدخال/إخراج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>شبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>بطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>مسار الأصل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>مصدر الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>تم تحديثه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>يحتوي على سجل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>يحتوي على إحصائيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>قابلة للشحن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>مستوى التحذير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>الطاقة فارغة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>الطاقة ممتلئة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>الطاقة الممتلئة بالتصميم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>معدل الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>النسبة المئوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تقنية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>اسم الرمز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>مُفعّل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>نسخة الديمون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>في البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>الغطاء مغلق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>الغطاء موجود</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>إجراء حرجة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>إلغاء المهمة بعد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>الاحتفاظ بالمهمة حتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>أولوية المهمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>وقت تغيير العلامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>عدد الصفحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>الاتجاه المطلوب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>وضع طباعة الألوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>الطابعة تقبل المهام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>الطابعة مشاركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>الطابعة مؤقتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>مصنوعة ونموذج الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>وقت تغيير حالة الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>أسباب حالة الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>نوع الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI الطابعة المدعومة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>الأضلاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>حجم القطاع المنطقي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>حجم القطاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>هوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>الهندسة (المنطقية)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير الأجهزة هو أداة مفيدة لعرض معلومات الأجهزة وإدارة الأجهزة.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>تحديثات جديدة لبرامج التشغيل! قم بتثبيتها أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>تضمين المجلدات الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>البحث عن برامج التشغيل في هذا المسار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 تحديثات لبرامج التشغيل متاحة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'وقت التحقق: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل برامج التشغيل لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تثبيت برامج التشغيل لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 برامج تشغيل تم تثبيتها، %2 برامج تشغيل فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 برامج تشغيل تم تثبيتها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تثبيت برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعة التنزيل: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>برامج التشغيل الخاصة بك محدثة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>إجمالي %1 برامج تشغيل، منها %2 تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 برامج تشغيل يمكن نسخها، يُنصح بالقيام بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 برامج تشغيل يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ %1 برنامج تشغيل، إجمالي %2 برامج تشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'النسخ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 برامج تشغيل تم نسخها، %2 برامج تشغيل فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ برامج التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 برامج تشغيل تم نسخها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 برامج تشغيل يمكن استعادةها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار برنامج تشغيل لاستعادته</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>المحرك يتم استعادة...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>الاستعادة: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>إعادة التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>يرجى %1 لكي تصبح مثبتات المحرك فعالة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>عرض مسار النسخ الاحتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>النسخ الاحتياطي الكل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>أرسل ملاحظات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>يرجى المحاولة مرة أخرى أو %1 لنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>تثبيت الكل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>مسح مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>التحقق من مثبتات أجهزة التجهيز الصلبة، يرجى الانتظار...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>التحقق من %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>فشل المسح</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>الشبكة غير متاحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>يرجى التحقق من اتصال الشبكة الخاص بك</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>يرجى مسح مرة أخرى أو %1 لنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>أنت تقوم بتثبيت محرك، وسيتم تعطيله إذا خرجت.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>هل أنت متأكد من رغبتك في الخروج؟</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>الخروج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>إلغاء</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>أنت تقوم بنسخ محركات، وسيتم تعطيله إذا خرجت.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>أنت تقوم باستعادة المحركات، وسيتم تعطيله إذا خرجت.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>مُستقبل البلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>جهاز التصوير</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>مُستقبل العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>بطاقة الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>مُستقبل الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>مُستقبل الشبكة اللاسلكية</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>تثبيت ناجح</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>التركيب فشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>يتم تنزيله</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>يتم تركيبه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>غير مثبت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>قدّم</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>في الانتظار</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>غير محفوظ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>يتم حفظه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>فشل النسخ الاحتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>النسخ الاحتياطي ناجح</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>يتم استعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>خطأ غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>خطأ في الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>تم إلغاؤه</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>فشل في الحصول على ملفات التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>نسخ احتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>استعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>تثبيت</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>تحديث ملفات التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>إلغاء تثبيت ملفات التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>السماح له بتشغيل الكمبيوتر</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>تمكين</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Začasno nedostupan</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Molimo izaberite lokalnu mapu</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Učitava se...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_si.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_si.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="si">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ප්‍රතිඵලය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ඇක්</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>ඇති</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>වින්‍යාසය විසින් අනුමානය කරන අවස්ථා</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>අනුමානය කරන අවස්ථා</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>ඇති</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>සම්පූර්ණ කරන්න</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>සක්‍රීය නොකරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රවේශය නොමැත</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>සිදුවීමේ නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>සේවාදායකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>චිප්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>කර්මාන්තර හැකියාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS ප්‍රවේශය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ප්‍රතිඵලය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>ක්‍රොනෙල් මෝඩ් ද්‍රව්‍යය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>ගැටළුවීමේ ප්‍රවේශය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රවේශය නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>සක්‍රීය නොකරන්න</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>සේවාදායකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>මෝඩල්</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>සේවාදායකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>අවස්ථා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>චිප්සෙට්</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>අනුරූපය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ප്രതിനിധി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>സംസ്ഥാനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>സംവിധാനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>വേഗത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>ഉയർന്ന ശക്തി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ഡ്രൈവർ സംസ്ഥാനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>കഴിവുകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ബസ് വിവരങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>സംവിധാന പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>മാക് വിലാസം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ലഭ്യമല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>നിരോധിക്കുക</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>പ്രതിനിധി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>സംവിധാനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>സംസ്ഥാനം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ബസ് വിലാസം</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>കഴിവുകൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ഡ്രൈവർ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>ഉയർന്ന ശക്തി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>വേഗത</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>ലഭ്യമല്ല</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>നിരോധിക്കുക</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>പേര്</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>പ്രതിനിധി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>സിപിയു ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>കോർ ഐഡി</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>തീരുമാനങ്ങൾ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>උස්සාන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>බොගෝමිප්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>අර්කිතෙක්ටර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>ස්‍යු අභියෝග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>මෝඩල්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>ප්‍රෝසෙසර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>කෝර් (ස්)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>විර්තුලිසේෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>ෆ්ලාග්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>ඇන්ඩ්‍ර්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>ජී අභියෝග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>ජී අභියෝග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>ජී අභියෝග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>ජී අභියෝග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>ස්ටෙපින්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>ස්පීඩ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>මාක්ස් ස්පීඩ්</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>නාමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>වේන්ඩර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>මෝඩල්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>වීර්ෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ග්‍රාෆික්ස් මේමෝරි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ෆ්‍යුසිකල් ඩී</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>මේමෝරි අභියෝග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>අයෝ පෝට්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>බස් ඉන්ෆෝ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>මාක්සිමම් රේසෝලූෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>මිනිමම් රේසෝලූෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>සැක්‍රුන් රේසෝලූෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ඩ්‍රයිවර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>ඩීස්ක්‍රිප්‍ෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>ප්‍රකාශන අවයවය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>ක්‍රියාත්මක ප්‍රකාශන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>ක්‍රමාවලිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රකාශන නොමැත</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>සටහන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>සේවකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>අනුමානය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>වීදිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>බස අවසන් දුර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>වේගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>මූල්‍ය බලය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>දිරිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ක්‍රමාවලිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>ස්වායත්ත අංකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රකාශන නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන්න</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>සටහන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>සේවකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>වීදිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>අනුවාදය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>බස අවසන් දුර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>වේගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>මූල්‍ය දිග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>දිරිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>අවධිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>අවයවය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>අනුපුර්වය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන්න</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>සිතුවා තිබූ සැකසූම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>ස්වීච් පුවරුව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>ස්වීච් පුවරුවේ ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>මාත්‍රිබොඩ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>ස්ත්‍රීය ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>දර්ශන අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>සෝන්ඩ් අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>ස්ථානීකරණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>අනෙකුත් PCI අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>බැටරිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>බ්‍රැට්ලූට්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>නෙට්වෝර්ක් අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>මැුස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>කීබෝඩ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>මිනිතර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>ස්ඩ්-රෝම්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>ප්‍රින්තර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>කැමරා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>අනෙකුත් අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>උපරිම ප්‍රමාණය</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>ස්වාමීය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>වේගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>සාධාරණ දිග</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ස්ථානය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>ස්වාභාවික නොමුණු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>සැකසුම් තරංගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>මාප්‍යා තරංගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>අවම තරංගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>සැකසුම් ස්පිଡ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ඩිටා දිග</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>මෙහෙයුම් නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>සේවකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>ක්‍රමාවලිය දෙන අංශු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>අනුබන්ධ වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>සහය ලබන ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>වැදගත් ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>ක්‍රමාවලිය ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>ප්‍රධාන ක්‍රමාවලිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>ස්වාභාවික නොමුණු</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>මෙහෙයුම් නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>සේවකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>අනුවාදය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>බස අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>අත්‍යාත්‍යතා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ඩ්‍රයිවර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ඩ්‍රයිවර් අනුවාදය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>මාපය ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>සම්බන්ධතා ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>පොට්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>මුල්ටිකාස්ට්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>ලින්ක්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>ලාටෙන්සි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>අය්ප්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>ෆිර්ම්වාර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ඩුප්ලෙක්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>බ්‍රොඩ්‍කාස්ට්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ෂුද්ධ නෙවියාෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>මෙමෝරි අඩ්‍රෙස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>අය්ර්ක්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>මාස් අඩ්‍රෙස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ලෝජිකාල් නාමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රස්ථාපිත නොවේ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන්න</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>නාමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>වෙන්ඩර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>මොඩල්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>බුස් අන්වේෂනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>අව්‍ර්ස්නය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>උළෙල්/අව්‍යාප්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>මෙමෝරි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>අය්ර්ක්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>ලාටෙන්සි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>ඩ්‍රයිවර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>කාබිලිතාව</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>නාමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>වෙන්ඩර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>මොඩල්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>අව්‍ර්ස්නය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>බුස් අන්වේෂනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>කාර්ය සමත්තා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ඩ්‍රයිවර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>මාඟිමා බලය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>වේගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>ස්වාභාවික නොම්බර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රමාණයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන්න</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>මෝඩල්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>වෙන්ඩර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>ස්වාභාවික නොම්බර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>ස්ථිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>කාර්ය අවමාන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>වෝල්ටියා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>ස්ලෝට්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>ඇඟිරියා කාර්ය අවමාන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>ඇඟිරියා වෝල්ටියා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>ස්බ්‍ර්ස් වීර්සන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>ස්බ්‍ර්ස් ස්වාභාවික නොම්බර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>ස්බ්‍ර්ස් ප්‍රාරම්භණ දිනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>ස්බ්‍ර්ස් සාංක්‍යාත්මකත්වය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>තාපත්වය</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>මෝඩල්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>වෙන්ඩර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>ස්වාභාවික නොම්බර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>සම්ප්‍රාප්තය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>ජ්‍යුරි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>ස්ථිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>අංශුවර්ෂය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන්න</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>සේවාදායකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>සේවා රෝපය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>ක්‍රමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>අනුමානය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>ක්‍රමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>සොෆ්ට්වාර් අනුමානය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>වේගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>විස්තරය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>ස්වායෝජිත නූම්‍රා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>අංශුවර්ෂය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>ජෝර් වේගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රමාණය නොමැත</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>යුප්ඩේට් සඳහා ද්‍රැයිවර් ගොඩනඟන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>මෙම පොකෙට්ටේ ද්‍රැයිවර් නොමැත</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ආඟු දෙව්‍යා විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>බයෝස් විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>ස්ඩ් රෝම් විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>ක්‍රමය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>සේපි විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>අනෙකුත් දෙව්‍යා විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>ක්‍රමය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>ප්‍රින්තර් විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>මෝස් විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>නොට්වර්ක් අභිරිමා විස්තරය ආයෙළි කරමින් තිබේ...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රමාණය නොමැත</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ප්‍රමාණය නොමැත</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ජෙන් තොරතුරු</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>සිතිය අදහස්</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>විවෘත කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>උපකාරය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>සිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>ස්යුස්ටීම්</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>අෂ්‍රිය කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>නවීනීකරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>ජෙන් අධිපති</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>හාර්ඩ්වෙයාර්</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ඩ්‍රයිවර්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>අභිරෝධනය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>අවලෝකනය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>සිතිය අභිරෝධනය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>සී.පී.යු.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>නෙට්වර්ක් අභිරෝධනය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>බෙටරි</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>අඳුරු</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ඩ්‍රයිවර් ප්‍රොලොග් වීර්ෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>ස්කන්ධයට අදාල ඩ්‍රයිවර්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>ස්කන්ධයට පත්වූ ඩ්‍රයිවර්ස්</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>නවීනීකරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>අවලංගු කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>පළමුව</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>අවධූතය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ඩ්‍රයිවර් අසාදනය පසුව ජෙන් මෙහෙයුම් සිතිය නොහැකි වෙයි</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>අසාදනය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>අසාදනය සිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>නවීනීකරණය සාර්ථක විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>අසාදනය සාර්ථක විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>பேருவர் வெற்றிக்கான</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>நிலுவை நிறுத்தல் வெற்றிக்கான</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>சரி</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>அடுத்தது</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>ඔබ තේරුණු ස්ථානය නොබැසිය යොතුමි, තේරුණු අනුමානය අවලඟන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>பேருவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>முன்னது</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>தொற்று பைக்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>மீண்டும் பைக்கு அமைப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>ඔබ තේරුණු අංශය නොබැසිය යොතුමි, තේරුණු අනුමානය අවලඟන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>එය ද්‍රව්‍ය නොවේ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>ස්ථාපනය කළ නොහැක - දිගිත අභිභාෂා නොම存在</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>විද්‍යුත් අසාමාන්‍ය අභිභාෂා</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ද්‍රව්‍ය මෝඩුල් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>අවලඟිත මෝඩුල් ආකාරය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ද්‍රව්‍ය මෝඩුල් දිගිත අභිභාෂා ඇත</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ද්‍රව්‍ය තේරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ද්‍රව්‍ය අවලඟිමානය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ද්‍රව්‍ය අභිභාෂා කළ නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>ප්‍රතිචාරය</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>ඔබට අභිභාෂා කළ නොහැකි ද්‍රව්‍ය නොමැත, අවලඟිමානය කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>අවලඟිමාන ද්‍රව්‍ය තිරස්සාන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>අවලඟිමාන වීජය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>අභිභාෂා කළ හැකි ද්‍රව්‍ය</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>නව කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>නිරිඟින්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>සිතුවීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ද්‍රව්‍ය තේරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ද්‍රව්‍ය අවලඟිමානය</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ද්‍රව්‍ය අභිභාෂා කළ නොහැක</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>වියත් කිරීමට සම්ප්‍රාප්ත විය නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>අක්‍රිය කිරීමට සම්ප්‍රාප්ත විය නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>අක්‍රිය කරන නොහැක: ඔබගේ ඔර්ගාන් අංකය ලබා නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ඩ්‍රයිවර්ස් අල්ලා ගනීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ඩ්‍රයිවර්ස් අල්ලා ගැනීම</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>නව කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>නිෂ්ප්‍රාප්ත කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>සිරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>සිතුවර්ෂය</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>නව කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>නිෂ්ප්‍රාප්ත කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>සිරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>ක්‍රියාත්මක කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ඩ්‍රයිවර්ස් අල්ලා ගනීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ඩ්‍රයිවර්ස් අල්ලා ගැනීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>මිනිත්තුව ප්‍රවර්ෂනය කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>අක්‍රිය කරන නොහැක: ඔබගේ ඔර්ගාන් අංකය ලබා නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>අක්‍රිය කිරීමට සම්ප්‍රාප්ත විය නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>වියත් කිරීමට සම්ප්‍රාප්ත විය නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ඩ්‍රයිවර්ස් අල්ලා ගනීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ඩ්‍රයිවර්ස් අල්ලා ගැනීම</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>ප්‍රාම්භාවික ප්‍රදේශය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>ප්‍රාම්භාවික අංශය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ඩ්‍රයිවර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ඩ්‍රයිවර් අයිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ඩ්‍රයිවර් සක්‍රිය කිරීමේ අවශ්‍යතා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>ක්‍රමය අයිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>අවකාශය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>විද්‍යුත් අංශය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>ස්යිඩ්‍ර්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>හැන්ඩල්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>ප්‍රොප්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ජීවිතය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>කේ අභියෝගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>වීර්ෂන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>බිස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>බියෝස් අන්වේෂණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>බ෇ස් බොඩ් අන්වේෂණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>ස්යුස්තම් අන්වේෂණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>චාස්සිස් අන්වේෂණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>උපරිම මෙමෝරි අර්ර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>ප්‍රකාශනය කරන දිනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>ලිපිනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>රුටින් මිලියනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>රෝම් මිලියනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>ස්වභාවය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>බියෝස් රීවිස්න්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ෆිර්ම්වාර් රීවිස්න්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ප්‍රෝඩූක්ට් නාමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>ස්ෙරියල් නූම්බර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>අස්ට් තාගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>ඇක්ස්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>චාස්සිස් වල ප්‍රස්ථාපනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>චාස්සිස් හැන්ඩල්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>සංවිධානය කරන ප්‍රස්ථාපනය හැන්ඩල්ස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>යුයුඩ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>වික්ස් අයිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>ස්කූ නූම්බර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>මිතුරු සමූහය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ස්ථාවරය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>ස්ථාපන අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>බල ආයෙළ් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>තාපීය අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>සිතියුම් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>බල ආයෙළ් අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>සංඛ්‍යා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ස්ථානය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>අභිලාෂා අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>මෙහෙයවීමේ අවම විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>අභිලාෂා අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>දේවයන් අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>බියෝස් රෝම් විශාලත්වය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>සිතියුම් දිනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ප්‍රමාණය විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>සම්බියෝස් වීරියා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>ජනප්‍රිය අවස්ථාව සඳහා තාර්කික අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>සිතියුම් අවස්ථාව සඳහා අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>වැනි අභියෝගයක් ඇති සිතියුම් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>බ්‍රේඩ් අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>අක්සෙළ් අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>ස්කෝ අභිලාෂා විසින් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>පැකේජ් විසිඳුම් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>සබ්බිල් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>සබ්බිල් අවස්ථාව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>සේවා වර්ගයන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>සාමාන්‍ය වීර්යාන්තර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>අභ්‍යන්තර වීර්යාන්තර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>අභ්‍යන්තර ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>උපාංගය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ස්‍රීරී ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>විස්තාරය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>උපාංගය ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>සොයා ගත හැකි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>සොයා ගැනීම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>උපාංග ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>උපාංග යොමුව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>උපාංග යොමුවන්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>උපාංග ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>අභ්‍යන්තරය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>ස්ථිතිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ලෝජිකාල් නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ANSI වීර්යාන්තර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU වීර්යාන්තර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU වීර්යාන්තර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>එක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>අවය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ජෙඟි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>නව</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>දහ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>පහිට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>ප්‍රිති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>අස්ති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>අට්ති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>රියිස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>රියිස් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>රියිස් පෙරහි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>රියිස් අඟි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>රියිස් අට්ති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>තුන්දහ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>තුන්දහ දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>තුන්දහ පෙරහි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>තුන්දහ අඟි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>තුන්දහ අට්ති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>චාරි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>චාරි දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>චාරි පෙරහි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>චාරි අඟි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>චාරි අට්ති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>පහිට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>පහිට දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>පහිට පෙරහි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>පහිට අඟි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>පහිට අට්ති</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>සීස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>සීස් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>සීස් පෙරහි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>සියයිස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>සියයිස් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>සියයිස් තුන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>සියයිස් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>සියයිස් පත්තේ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>සියයිස් දෙක් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>සියයිස් දෙක් තුන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>සියයිස් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>සියයිස් දෙක් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>සියයිස් දෙක් පත්තේ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>සියයිස් දෙක් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>සියයිස් දෙක් දෙක් තුන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>සියයිස් දෙක් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>සියයිස් දෙක් දෙක් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>සියයිස් දෙක් දෙක් පත්තේ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>සියයිස් දෙක් දෙක් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>සියයිස් දෙක් දෙක් දෙක් තුන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>එක් සියයිස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>එක් සියයිස් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>එක් සියයිස් පත්තේ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>එක් සියයිස් දෙක් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>එක් සියයිස් දෙක් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>එක් සියයිස් දෙක් දෙක් තුන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>එක් සියයිස් දෙක් දෙක් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>එක් සියයිස් දෙක් දෙක් පත්තේ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>එක් සියයිස් දෙක් දෙක් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>එක් සියයිස් දෙක් දෙක් දෙක් තුන</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>එක් සියයිස් දෙක් දෙක් දෙක් අට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>එක් සියයිස් දෙක් දෙක් දෙක් දෙක</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>එක් සියයිස් දෙක් දෙක් දෙක් පත්තේ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>126</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>128</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>192</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>256</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU වෙන්දර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU ගෙන්ටයිප්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL ක්ලීන්ට් අපියි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>විශේෂයෙන් නොදනී</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>නිර්ණය කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>හාඩ්වාර්ඩ් ක්ලාස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>සී.පී.යු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>සී.පී.යු නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>මැතර්බොඩ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>මැතර්බොඩ් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>මේමෝරි</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>මේමෝරි නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>ස්ටෝරිජ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>ඩිස්ක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ඩ්‍රයිවර් අවසන් කිරීම නතර විය!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>කරා ගන්නා හෝ අපට අදහසක් දක්වන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ඩ්‍රයිවර් අවසන් කිරීම නතර විය!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>දීප්ස් අභිරිශ්ටය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>GPU නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>මොනිටර්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>මොනිටර් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>බැස් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>බැස් අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>සිතිය අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>සිතිය අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>බ්ලූටූත්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>බ්ලූටූත් අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>අනෙකුත් PCI අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>අනෙකුත් PCI අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>කුලින් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>බැටරි නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>කුළින් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>කුළින් අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>මුස් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>මුස් අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>ප්‍රින්ටර් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>ප්‍රින්ටර් අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>කැමරා අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>කැමරා අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>ස්ඩ්-රෝම් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>ස්ඩ්-රෝම් අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>අනෙකුත් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>අනෙකුත් අභිරුඤ්ඡයක් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>අර්රේ අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>ස්වරූපය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>ස්ථාපනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>බැංක් අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>වර්ගය අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>පාර්ට් නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>රාන්ක්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>ස්ත්‍රිය අභිරුඤ්ඡය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ස්මේමෝරි අවයව අවම අතර ස්ථානය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ෆිර්ම්වෙර් ස්වර්ෂය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>මෝඩුල් මැනුෆැක්චර් ඩී</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>මෝඩුල් ප්‍රෝඩූක්ට් ඩී</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ස්මේමෝරි අවයව ස්ථානය අධිකරු මැනුෆැක්චර් ඩී</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ස්මේමෝරි අවයව ස්ථානය අධිකරු ප්‍රෝඩූක්ට් ඩී</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>අනෙකුත් විළක්ෂිත ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>විලක්ෂිත ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>ස්කෙඩ් ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ලෝජික් ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>උඳු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>දිනය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>අභියෝග් ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>නෙළුවා</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>බැටරිය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>නාටිව් පාත්‍රය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>ස්වර්ෂය ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>අල්ලාගත්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>අතින් පෙළ ඇත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>සංග්‍රහ ඇත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ස්වර්ෂය ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>ස්ථානය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>අවබෝධ අවම අතර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ස්වර්ෂය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ස්වර්ෂය අවම අතර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ස්වර්ෂය අවම අතර</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ස්වර්ෂය අවම අතර දීසින් පෙළ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ස්වර්ෂය ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>වෝල්ට්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>ප්‍රතිශතය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>උඩුරු නම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>උත්තර අතින්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>ඩෙමන් දැරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>බෙටරි අතින්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ලිඩ් අවලඟ විය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ලිඩ් ඇත</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>ක්‍රිතික ක්‍රමය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>කොපිස්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>ජොබ් අවලඟ කළ යුත් විට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>ජොබ් අවලඟ වීම අවසන් වීම අතින්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>ජොබ් ප්‍රමුභිත්වය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>මාර්කර් වෙනස් කළ විට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>උපරිම අංකය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>උත්තර අතින් ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>ප්‍රින්ට් කෝලර් මෝඩ්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>ප්‍රින්ටර් ජොබ් ප්‍රමාණය දැරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>ප්‍රින්ටර් ඇති අතර අතින්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>ප්‍රින්ටර් දිනේ අතින්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>ප්‍රින්ටර් නිෂ්චිත වීම සහ මෝඩලය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>ප්‍රින්ටර් නිලධාරිත්වය වෙනස් වීම සාමාන්‍ය විට</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>ප්‍රින්ටර් නිලධාරිත්වය වෙනස් වීම සඳහා ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>ප්‍රින්ටර් ස්වරූපය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>ප්‍රින්ටර් ඔරි අතින්</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>පාර්ශවය</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>බස අතින් තොරතුරු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ලෝගික් සෙක්ටර් දැරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>සෙක්ටර් දැරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>හිඳු</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>ජ්‍යෝමේට්‍රි (ලෝජිකාල්)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>උපාංග ප්‍රබන්ධකය</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>උපාංග ප්‍රබන්ධකය උපාංග තොරතුරු බලාපොරොත්තු සහ උපාංග අල්ලාගැනීම සඳහා සුපිරි ප්‍රමාණයකි</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>නව උපාංග ප්‍රබන්ධක තිබේ! ඒවා අද අල්ලාගැනීම හෝ අල්ලාගැනීමට නියමිත කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>සැලකීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>ප්‍රාථමික පාට්‍රිකා අඩංගු කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>මෙම මාර්ගයේ උපාංග ප්‍රබන්ධක අල්ලා ගැනීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 උපාංග ප්‍රබන්ධක අල්ලාගැනීම සිදු කළ හැක'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'කාලය අවලෝකනය කරන ලද්දේ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 සඳහා උපාංග ප්‍රබන්ධක අල්ලාගැනීම...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'අල්ලාගැනීමේ ස්පිඩ්: %1 අල්ලාගැනීම %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 සඳහා උපාංග ප්‍රබන්ධක අල්ලාගැනීම...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 උපාංග ප්‍රබන්ධක අල්ලාගැනීම, %2 උපාංග ප්‍රබන්ධක අසම්පූර්ණ විය'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 උපාංග ප්‍රබන්ධක අල්ලාගැනීම'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>උපාංග ප්‍රබන්ධක අල්ලාගැනීම සිදු කළ නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>'%1 උපාංග ප්‍රබන්ධක අල්ලාගැනීම'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>උපාංග ප්‍රබන්ධක අල්ලාගැනීම සිදු කළ නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>'%1 උපාංග ප්‍රබන්ධක අල්ලාගැනීම, %2 උපාංග ප්‍රබන්ධක අසම්පූර්ණ විය'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>'%1 උපාංග ප්‍රබන්ධක අල්ලාගැනීම'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>ඔබට %1 උපාංග ප්‍රබන්ධක අල්ලාගැනීමට අවම විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>කරුණාකර උපාංග ප්‍රබන්ධකයක් අල්ලාගැනීම සඳහා තෝරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>ඔබට %1 ද්‍රව්‍ය අවලඟිමානය කළ හැකි ය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 ද්‍රව්‍ය අවලඟිමානය කරමින්, අවලඟිමාන වීජය ප්‍රමාණය %2 ය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>අවලඟිමානය කරමින්: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>%1 ද්‍රව්‍ය අවලඟිමානය කරන ලදී, %2 ද්‍රව්‍ය අවලඟිමානය කරන නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ද්‍රව්‍ය අවලඟිමානය කරන ලදී</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 ද්‍රව්‍ය අවලඟිමානය කරන ලදී</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>ඔබට %1 ද්‍රව්‍ය අභිභාෂා කළ හැකි ය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>කරුණාකර අඟුරුවක් තවත් සැකසූ අතර තෝරා ගන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ඩ්‍රයිවර් අඩුපාඟි අයිත්</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>අයිත්: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>ප්‍රදීප්ති නියමිතය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>කරුණාකර %1 කරන්න යාමට අයිත් ඩ්‍රයිවර් අඩුපාඟි නියමිතය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>බ෍කාප් මාර්ගය බලන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>සියලුම බ෍කාප් කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>අදහස් අත්හරින්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>කරුණාකර අනෙකුත් අවදානම කරන්න හෝ %1 කරන්න අපට</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>සියලුම නියමිතය කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>අනෙකුත් අවදානම කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>අවලංගු කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>හාඩ්වර්ඩ් ඩ්‍රයිවර් අඩුපාඟි අවදානම කරමින් තිබේ, කරුණාකර පොදු කරන්න...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>අවදානම කරමින් තිබේ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>අවදානම අසාරු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>නිළියාම අසාරු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>කරුණාකර ඔබගේ නිළියාම සබ්බර් අවදානම කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>කරුණාකර අනෙකුත් අවදානම කරන්න හෝ %1 කරන්න අපට</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>ඔබ අඩුපාඟි නියමිතය කරමින් තිබේ, ඔබ අවලංගු කරන්න නම් අඩුපාඟි නියමිතය අසාරු විය හැකිය.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>ඔබ අවලංගු කරන්න ය෾වා තිබේද?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>අවලංගු කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>අවලංගු කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>ඔබ ඩ්‍රයිවර් බ෍කාප් කරමින් තිබේ, ඔබ අවලංගු කරන්න නම් බ෍කාප් අඩුපාඟි අසාරු විය හැකිය.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>ඔබ ඩ්‍රයිවර් අඩුපාඟි නියමිතය කරමින් තිබේ, ඔබ අවලංගු කරන්න නම් අඩුපාඟි නියමිතය අසාරු විය හැකිය.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>බ්‍රෙල්ට් අඩාප්තර්</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>අතර්ග් මාර්ගය අඩාප්තර්</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>ප්‍රදර්ෂන අඩාප්තර්</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>සෝන්ඩ් කාඩ්</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>නිළියාම අඩාප්තර්</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>වයර්ලේස් නිළියාම අඩාප්තර්</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>නියමිතය සාරු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>ආයුර්ණායි විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>ඇතුළුවීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>ආයුර්ණායි කිරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>ආයුර්ණායි නොවේ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>පිළිතුරු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>වියෝජනය කරමින් විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>සිතියුරු නොවේ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>සිතියුරු කරමින් විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>සිතියුරු අසාමාන්‍ය විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>සිතියුරු සාමාන්‍ය විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>ප්‍රතිස්ථාපනය කරමින් විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>විශේෂ අඩු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>වින්‍යාසය අඩු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>අවලංගු කරන විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ඩ්‍රයිවර් අංශු අවලංගු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>ලෝකය විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>සිතියුරු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>ප්‍රතිස්ථාපනය විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ආයුර්ණායි විය</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>නියෝජනය කරන විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>අත්හැරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>ඩ්‍රයිවර් අංශු අවලංගු විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ඩ්‍රයිවර් අංශු අක්‍රිය කරන විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>ක්‍රමානුකූලව එය පරිගණකය ප්‍රතිස්ථාපනය කරන ලැබේ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>සක්‍රිය කරන විය</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>නියෝජනය කරන විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>අත්හැරීම</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>තැන් දෙන විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>අක්‍රිය කරන විය</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>අනුපුර්වය</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>කරුණාකර ඔබගේ ලොක්කා පාඨම් තුළ තොරතුරු ලබා ගන්න</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>උපුටා ගැනීම...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sk.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sk.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sk">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Zpětná vazba</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Více</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Upozornenie na siet</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Znovu nainštalovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Více</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Zavrieť</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Vypnúť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Názov zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revízia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Adresa pamäti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Vypnúť</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maximálna výkon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Verzia ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Ovládač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Informácie o bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logické meno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Vypnutie</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Informácie o bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Ovládač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maximálna výkon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Vypnutie</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>ID procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ID jadra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Vlákna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Vřadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Architektúra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Rodina procesorov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Procesor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Jadra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualizácia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Výsledky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Rozšírenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Krok</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Maximálna rýchlosť</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Videopamäť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Fyzické ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Adresa pamäti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Informácie o busi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maximálna rozlíšenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minimálne rozlíšenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Aktuálne rozlíšenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Výkonné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Popis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Digitálne výstupy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Výstup obrazovky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Informácie o bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maximálna výkon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Vypnúť</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Rozhranie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Informácie o bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maximálny prúd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Nedostupný</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Vypnúť</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Prehľad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>Procesor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Počet procesorov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Materná deska</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Pamäť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Adaptér pre zobrazenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Adaptér pre zvuk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Ukladanie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Iné PCI zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Sietový adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Myš</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Klávesnica</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Tlačiareň</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Iné zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Zariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Veľkosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Celková šírka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Lokalizátor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Nastavené napätie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Maximálne napätie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Minimálne napätie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Nastavená rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Šírka dát</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Vstup pre zobrazenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Typ rozhrania</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Podporovaná rozlíšenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Aktuálne rozlíšenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Pomer zobrazenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Hlavný monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Veľkosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Informácie o busi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Verzia drivera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Maximálna rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Rýchlosť dohody</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Pripojenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Zdržanie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Automatická negotiacia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Adresa pamäti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logické meno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Vypnúť</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Meno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Informácie o bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Vstup/Výstup</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Pamäť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Zdržanie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Vývojár</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Meno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Informácie o bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Vodca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maximálna výkon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Zakázať</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Stav</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kapacita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Napätie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Slot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Navrhnutá kapacita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Navrhnuté napätie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>Verzia SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>Sériové číslo SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>Dátum výroby SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>Chemická zloženie SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Teplota</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Názov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Spoločný</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Stav</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Typ rozhrania</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Zakázať</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Výrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Typ média</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Veľkosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Schopnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Verzia firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Popis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Rozhranie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Rotačná rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Vyberte vývojára pre aktualizáciu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>V tomto priečinku sa nepájajú žiadne vývojáre</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Načítavanie informácií o zvukovom zariadení...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Načítavanie informácií o BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Načítavanie informácií o CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Načítavanie informácií o operačnom systéme...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Načítavanie informácií o procesore...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Načítavanie informácií o iných zariadeniach...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Načítavanie informácií o výkone...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Načítavanie informácií o tiskare...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Načítavanie informácií o myši...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Načítavanie informácií o sieti...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Zakázať</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Zakázať</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Informácie o zariadení</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Zobraz kľúčové tlačidlá</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Zatvoriť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Nápoveda</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopírovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Systém</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Správca zariadení</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hardvér</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Zariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Prehľad</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Zariadenie na zobrazenie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>Procesor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Sietové zariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Baterie</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Viac</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Verzia platformy pre zariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Zariadenia, ktoré je možné zarezerbovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Zarezerbované zariadenia</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Aktualizácia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Zrušiť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>ďalšie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Varovanie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Zariadenie bude neprístupné po odinštalovaní zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Odinštalovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Odinštalovanie</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Aktualizácia úspešná</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Odinštalovanie úspešné</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Aktualizácia selhala</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Odinštalácia selhala</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Ďalej</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Vybraná složka neexistuje, prosím, vyberte znovu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Aktualizácia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Späť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Zlomený balíček</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Nesúhlasná architektúra balíčku</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Vybraný súbor neexistuje, prosím, vyberte znovu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>To nie je ovládač</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Nemožno nainštalovať - chýba digitálny podpis</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Neznámy chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Ovládačový modul nebol nájdený</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Neplatný formát modulu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Ovládačový modul má závislosti</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Inštalácia ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Zálohovanie ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Obnovenie ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Spätná väzba</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Nemáte žiadne ovládače na obnovenie, najskôr zálohuje</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Prejdite na zálohovanie ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Verzia zálohy</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Obnoviteľné ovládače</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Export</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Prehľad</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Inštalácia ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Zálohovanie ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Obnovenie ovládača</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Zariadenie sa nepodarilo povoliť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Zariadenie sa nepodarilo zakázať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Zariadenie sa nepodarilo zakázať: nepodarilo sa získať sériové číslo zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Aktualizovať ovládače</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Odinštalovať ovládače</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Exportovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopírovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Prehľad</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Exportovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopírovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Povoliť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Aktualizovať ovládače</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Odinštalovať ovládače</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Povoliť mu probudziť počítač</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Zakázať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Zariadenie sa nepodarilo zakázať: nepodarilo sa získať sériové číslo zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Zariadenie sa nepodarilo zakázať</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Zariadenie sa nepodarilo povoliť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Aktualizovať ovládače</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Odinštalovať ovládače</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Podvýrobca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Podzariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Ovládač</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Stav ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Príkaz aktivácie ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Stav konfigurácie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>odklad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Fyzický</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Správca</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KLÁV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Verzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Informácie o BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Informácie o základnej doske</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Informácie o systéme</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Informácie o ráme</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fyzický pole pamäti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Dátum vydania</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Veľkosť v reálnom čase</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Veľkosť ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Vlastnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Revízia BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Revízia firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Názov produktu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Sériové číslo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Štítko majetku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Vlastnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Poloha v ráme</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Identifikátor rámu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Obsahované objekty</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Typ prebudenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Číslo SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Rodina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Zamknúť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Stav po zapnutí</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Stav napájania</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Teplotný stav</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Stav bezpečnosti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Informácie OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Výška</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Počet napájacích kábelov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Obsahujúce prvky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Poloha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Typ opravy chýb</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maximálna kapacita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Identifikátor informácie o chybe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Počet zariadení</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>Veľkosť BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Dátum vydania</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Názov plošnej dosky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>Verzia SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Formát popisu jazyka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Instalovateľné jazyky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Aktuálne inštalovaný jazyk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD Adresa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Typ paketu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Zásady odkazu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Režim odkazu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Trieda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Služby triedy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Třída zařízení</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Verzia HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Verzia LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Podverzia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Zariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Sériové ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>výrobok</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>popis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Zapnuté</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Vyhľadateľné</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Párované</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Vyhľadávanie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Moduly ovládača</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Súbor zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Súbory zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Číslo zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Aplikácia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>štátus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logické meno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>verzia ansi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Implementátor CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Architektúra CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Varianta CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Časť CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Revízia CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Jeden</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Deväť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Desať</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Dvanásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Štrnásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Sedemnásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Vosmnásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Dvacet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Dvacet dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Dvacet štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Dvacet šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Dvacet osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Tret' </translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Tret' dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Tret' štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Tret' šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Tret' osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Štyria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Štyria dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Štyria štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Štyria šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Štyria osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Päťdesiat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Päťdesiat dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Päťdesiat štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Päťdesiat šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Päťdesiat osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Šesťdesiat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Šesťdesiat dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Šesťdesiat štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Šesťdesiat šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Šesťdesiat osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Sedmdesiat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Sedmdesiat dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Sedmdesiat štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Sedmdesiat šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Sedmdesiat osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Osmdesiat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Osmdesiat dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Osmdesiat štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Osmdesiat šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Osmdesiat osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Devätdesiat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Devätdesiat dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Devätdesiat štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Devätdesiat šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Devätdesiat osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Sto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Sto a dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Sto a štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Sto a šesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Sto a osm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Sto a desať</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Sto a dvanásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Sto a štrnásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Sto a šestnásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Sto a osmnásť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Sto a dvadsať</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Sto a dvadsať dva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Sto a dvadsať štyri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Sto dvadsaťšesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Sto dvadsaťosm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Sto deväťdesaťdva</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Dva sto päťdesaťšesť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapacita GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Výrobca GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Typ GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Verzia EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL klientové API</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Verzia GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Verzia GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Neznámy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Trieda hardvéru</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Žiadna CPU sa nenachádza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Matematická doska</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Žiadna matematická doska sa nenachádza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Pamäť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Žiadna pamäť sa nenachádza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Ukladanie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Žiadny disk sa nenachádza</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Obnovenie vývojárskeho programu zlyhalo!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Skúste to znova alebo nám poskytnite spätnú väzbu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Zálohovanie vývojárskeho programu zlyhalo!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Zobrazenie adaptéru</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Žiadna GPU sa nenachádza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Žiadny monitor sa nenachádza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Sietový adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Nenašiel sa žiadny sietový adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Zvukový adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Žiadny zvukový zařízení nebyl nalezen</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Nenašiel sa žiadny Bluetooth zariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Iné PCI zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Nenašli sa žiadne iné PCI zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Elektrická energia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Žiadna batéria nebol nájdená</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Klávesnica</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Žiadna klávesnica nebol nájdená</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Myš</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Žiadna myš nebol nájdená</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Tiskárňa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Žiadna tiskárňa nebol nájdená</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Žiadna kamera nebol nájdená</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Žiadny CD-ROM nebol nájdený</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Iné zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Žiadne iné zariadenia nebol nájdené</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Zoznam správcov</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Formát</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Nastaviť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Lokátor banky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Podrobnosti typu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Číslo súčtu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Pořadí</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Technológia pamäti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Schopnost prevádzky pamäti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Verzia firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ID výrobca modulu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID výrobku modulu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ID výrobca riadiča pamäťového systému</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ID výrobku riadiča pamäťového systému</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Veľkosť nevytrvalého úložiska</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Veľkosť vytrvalého úložiska</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Veľkosť cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logická veľkosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>druh</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Dátum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>IO port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>siet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>baterie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>nativný cestový vektor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>zdroj energie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>aktualizovaný</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>ma históriu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>ma štatistiky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>nabiteľný</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>štát</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>úroveň varovania</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energia prázdna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energia plná</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>energia plná v návrhu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>energetická rýchlosť</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>napätie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>percento</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>technológia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>názov ikony</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>verzia daemonu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>na baterii</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>kryt je uzavretý</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>kryt je prítomný</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritická akcia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kópie</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>zrušiť úlohu po</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>držať úlohu do</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>priorita úlohy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>čas zmeny značky</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>počet na stránku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientácia žiadaná</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>režim tlačiacej farby</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>tlačiareň prijíma úlohy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>tlačiareň je spoločná</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>tlačiareň je dočasná</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>výrobca a model tlačiareň</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>čas zmeny stavu tlačiareň</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>dôvody stavu tlačiareň</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>typ tlačiareň</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI tlačiareň podporované</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>strany</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>informácie o busi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>veľkosť logického sektora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>veľkosť sektora</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>guid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometria (Logická)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Správca zariadení</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Správca zariadení je užitočný nástroj na zobrazenie informácií o hardvéri a správu zariadení.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Dostupné sú nové ovládače! Nainštalujte ich alebo aktualizujte ich teraz.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Zobraziť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Zahrnúť podpriečinky</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Hľadať ovládače v tomto ceste</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 aktualizácie ovládača dostupné'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Čas overený: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Stahujem ovládače pre %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Rýchlosť stahovania: %1 Stiahnuté %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Inštalujem ovládače pre %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 ovládačov inštalovaných, %2 ovládačov zlyhalo'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 ovládačov inštalovaných'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Nastala chyba pri inštalácii ovládačov</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Chyba siete. Opätovné pripojenie...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Rýchlosť stahovania: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Vaše ovládače sú aktuálne</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Všetky ovládače boli zálohované</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Celkovo %1 ovládačov, z ktorých %2 boli zálohované</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Máte %1 ovládačov, ktoré môžete zálohovať, odporúča sa to urobiť okamžite</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Máte %1 ovládačov, ktoré môžete zálohovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Zálohujem ovládač %1, celkovo %2 ovládačov</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Zálohujem: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 ovládačov zálohovaných, %2 ovládačov zlyhalo'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Nastala chyba pri zálohovaní ovládačov</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 ovládačov zálohovaných'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Máte %1 ovládačov, ktoré môžete obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Vyberte ovládač, ktorý chcete obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver sa prekladá...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Zotavovanie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>restart</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Prosím %1 pre to, aby sa inštalované výbavové adaptéry prejavili</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Zobraziť cestu k zálohe</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Zálohovať všetko</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>poslať zpätne súhlasy</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Prosím skúste znovu alebo %1 nám</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Inštalovať všetko</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Skúsiť znovu skenovanie</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Zrušiť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Skenovanie výbavových adaptérov hardvéru, prosím počkajte...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Skenovanie %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Skenovanie zlyhalo</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Siete nie je dostupná</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Prosím skontrolujte svoju sieťovú pripojenie</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Prosím skúste znovu skenovanie alebo %1 nám</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Inštalujete výbavový adaptér, ktorý sa zastaví, ak vyjdete.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Ste si istí, že chcete ukončiť?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Ukončiť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Zrušiť</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Zálohujete výbavové adaptéry, ktorý sa zastaví, ak vyjdete.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Zotavujete výbavové adaptéry, ktorý sa zastaví, ak vyjdete.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Zobrazovací zariadenie</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Zobrazovací adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Zvuková karta</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Sieťový adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Bezdrôtový sieťový adaptér</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Inštalácia úspešná</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Inštalácia selhala</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Stiahnutie</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Inštalácia</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Nie je inštalované</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Zastarané</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Čakanie</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Nie je zálohované</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Zálohovanie</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Zálohovanie selhala</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Zálohovanie prebeholo úspešne</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Obnovenie</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Neznáma chyba</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Chyba siete</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Zrušené</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Nepodarilo sa získať súbor prenosov</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Aktualizácia</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Záloha</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Inštalovať</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Vypnúť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Exportovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Aktualizovať prenosy</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Odinštalovať prenosy</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Umožniť mu prebudiť počítač</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Povoliť</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Obnoviť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Exportovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopírovať</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Vypnúť</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Nedostupné</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Vyberte prosím lokálny priečinok</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Načítavanie...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sl.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sl.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Zaupanje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Več</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Zloži</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Več</translation>
     </message>
@@ -31,44 +46,28 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>EC_NOTIFY_NETWORK</source>
-        <translation type="unfinished"/>
+        <translation>Obvesti o omrežju</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>EC_REINSTALL</source>
-        <translation type="unfinished"/>
+        <translation>Ponovno namestiti</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>EC_6</source>
-        <translation type="unfinished"/>
+        <translation>EC_6</translation>
     </message>
 </context>
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Več</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Zloži</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Več</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Zloži</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Ime naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Čip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fizični ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
-        <translation type="unfinished"/>
+        <translation>Pot do SysFS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
-        <translation type="unfinished"/>
+        <translation>Revisions</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
-        <translation type="unfinished"/>
+        <translation>Kernelski način vodilca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Pomnilniški naslov</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Nabor vezja</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
-        <translation type="unfinished"/>
+        <translation>Pseudonim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fizični ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Največja moč</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Različica gonilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Gonilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Podatki o vodilu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Logično ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC naslov</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Podatki o vodilu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Gonilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Največja moč</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fizični ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID procesorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID jedra</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Niti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Arhitektura</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Družina procesorjev</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Jeder</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualizacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Zastavice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Razširitve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 predpomnilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 predpomnilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i predpomnilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d predpomnilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Revizija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Največja hitrost</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Grafični pomnilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fizični ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Pomnilniški naslov</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>V/I vrata</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Podatki o vodilu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Največja ločljivost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Najmanjša ločljivost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Trenutna ločljivost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Gonilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>Digitalni izhod</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Display Output</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Podatki o vodilu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fizični ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Največja moč</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Gonilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Serijska številka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Podatki o vodilu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fizični ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
-        <translation type="unfinished"/>
+        <translation>Največji tok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Gonilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Pregled</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Število procesorjev</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Matična plošča</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Pomnilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Grafični vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Zvočni vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Shramba</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Druge PCI naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Akumulator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Omrežni vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Miška</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Tipkovnica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Tiskalnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Druge naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Naprava</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>VrstaVrsta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Celotna širina</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Lokator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Serijska številka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Nastavljena napetost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Največja napetost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Najmanjša napetost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Nastavljena hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Podatkovna širina</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>VrstaVrsta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Vhod zaslona</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Vrsta vmesnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Podprta ločljivost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Trenutna ločljivost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Razmerje slike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Glavni monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Serijska številka</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>VrstaVrsta</translation>
     </message>
@@ -1090,12 +1040,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
         <source>Maximum Rate</source>
-        <translation type="unfinished"/>
+        <translation>Največji stopnjev</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
         <source>Negotiation Rate</source>
-        <translation type="unfinished"/>
+        <translation>Stopnjev pogovora</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Proizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Vrsta nosilca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Zmogljivosti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fizični ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Različica strojnega programa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Hitrost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Serijska številka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Hitrost vrtenja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Izberi voditelja za posodobitev</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>V tej mapi ni najdenih vodilnikov</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Nalaganje podatkov o zvočni napravi...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Nalaganje podatkov o BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Nalaganje podatkov o CD-ROM pogonu</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Nalaganje podatkov o operacijskem sistemu...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Nalaganje podatkov o procesorju...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Nalaganje podatkov o drugih napravah...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Nalaganje podatkov o napajanju...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Nalaganje podatkov o tiskalniku...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Nalaganje podatkov o miški...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Nalaganje podatkov o omrežnem vmesniku...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Podatki o napravi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Bližnjice zaslona</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Zapri</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Pomoč</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Osveži</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Upravitelj naprav</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Opremo</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Vodilniki</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Pregled</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Grafični vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Omrežni vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Akumulator</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Več</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Trenutna različica</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>Različica platforme vodilnika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Dejanje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Vodilniki v zgradi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Zgrajeni vodilniki</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Posodabljanje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Opozorilo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>UREJALNIK bo neodpren po odinstalaciji vodilnika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Odinstaliraj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Odinstaliranje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Posodobitev je uspešna</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Odinstaliranje je uspešno</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Posodobitev je spodletela</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Odinstaliranje je spodletelo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Izbrana mape ne obstaja, izberite jo ponovno</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Posodobi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Predhodno</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Kovajsko paketo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Neprispevna arhitektura paketa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Izbrani datotekni ne obstajajo, izberite znova</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>To ni voditelj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Nemogoče namestiti - brez digitalne izdaje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Neznana napaka</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Vodilnik modul ni bil najden</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Neveljaven format modula</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Vodilnik modul ima odvisnosti</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Ime naprave</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Dostopna različica</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Velikost</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Dejanje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Novi izbor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Trenutna različica</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Manjkajoči vodilniki (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Prestarjeli vodilniki (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Vzgojeni vodilniki (%1</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>Namestitev vodilnika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation>Vodilniški odznamek</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>Vračanje vodilnika</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>V redu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Zaupanje</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Niste imeli vodilnikov za obnoviti, prosimo, najprej naredite odznamek</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Idite na vodilniški odznamek</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Trenutna različica</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation> Varčevna različica</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Dejanje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Vrata za vrnitev v-operacinsko vrednost</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Osveži</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Pregled</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation> Namestitev vodilca</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Ustvarjanje varnostne kopije vodilca</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Vrnitev v-operacinskega vrednosti vodilca</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Neuspešen vklop naprave</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Neuspešen izklop naprave</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Ni bilo mogoče onemogočiti: ni mogoče prebrati SN-niza za uravnoteževalno orodje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Nadgradnja vodilcev</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Odstranitev vodilcev</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Osveži</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Pregled</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Omogoči</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>Dozvoli, da ga začne vzbuditi računalnik</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Ni bilo mogoče onemogočiti: ni mogoče prebrati SN-niza za uravnoteževalno orodje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Neuspešen izklop naprave</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Neuspešen vklop naprave</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Nadgradnja vodilcev</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Odstranitev vodilcev</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>Podizvajalec</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>Pod-naprava</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Gonilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Status gonilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Ukaz za aktivacijo gonilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Status nastavitev</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>latenca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fiz.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Ročice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KLJUČ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Vodilo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Podatki o BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Osnovni podatki o plošči</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Podatki o sistemu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Podatki o ohišju</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Polje fizičnega pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Datum izdaje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Naslov</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Velikost ob zagonu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Velikost ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Karakteristike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS revizija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Revizija strojnega programa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Ime izdelka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Serijska številka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Oznaka dobrine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Funkcionalnost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Lokacija v ohišju</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Ročica ohišja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>VrstaVrsta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Vsebovane ročice objekta</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Vrsta bujenja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU številka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Rod</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Zaklep</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Zagonsko stanje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Stanje napajanja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Termalno stanje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Varnostni status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM podatki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Višina</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Število napajalnih kablov</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Vsebovani predmeti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Lokacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Vrsta popravljanja napak</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Največja zmogljivost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Ročica podatkov ob napakah</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Število naprav</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS velikost ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Datum izdaje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Ime plošče</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format opisa jezika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Jeziki za namestitev</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Trenutno nameščen jezik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD naslov</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Vrsta paketa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Pravila povezovanja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Vrsta povezave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Razred</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Razred storitve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Razred naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI različice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Pod-različica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Naprava</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Serijski ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>proizvod</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>opis</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Napajan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Viden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Se lahko pari</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Mod-alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Odkrivanje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Moduli gonilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Datoteka naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Datoteke naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Številka naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplikacija</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>status</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>logično ime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansir-azličica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Implementacija procesorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arhitektura procesorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Izvedba procesorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Del procesorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revizija procesorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Ena</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Štiri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Šest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Osem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Devet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Deset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dvanajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Štirinajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Šestnajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Osemnajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Dvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Dvaindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Štiriindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Šestindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Osemindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Trideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Dvaintrideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Štirintrideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Šestintrideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Osemintrideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Štirideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Dvainštirideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Štiriinštirideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Šestinštirideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Oseminštirideset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Petdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Dvainpetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Štiriinpetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Šestinpetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Oseminpetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Šestdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Dvainšestdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Štiriinšestdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Šestinšestdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Oseminšestdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Sedemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Dvainsedemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Štiriinsedemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Šestinsedemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Oseminsedemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Osemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Dvainosemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Štiriinosemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Šestinosemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Oseminosemdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Devetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Dvaindevetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Štiriindevetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Šestindevetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Osemindevetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Sto</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Stodve</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Stoštiri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Stošest</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Stoosem</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Stodeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Stodvanajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Stoštirinajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Stošestnajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Stoosemnajst</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Stodvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Stodvaindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Stoštiriindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Stošestindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Stoosemindvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation> sto devetdvajset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Dvestošestinpetdeset</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Zmogljivost GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Proizvajalec GPE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Vrsta GPE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Različica EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>API knjižnice EGL odjemalca</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Različica GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Različica GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Neznano</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Razred strojne opreme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Procesor ni bil najden</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Matična plošča</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Ni najdene osnovne plošče</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Pomnilnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Ni najdenega pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Shramba</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Ni najdenega diska</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Pritisnil se napak pri vrni v-operacinskega vrednosti vodilca</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>Poskusi znova ali nam dajte odziv</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Ustvarjanje varnostne kopije vodilca je spodletelo</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Grafični vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Ni najdene GPE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Ni najdenega monitorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Omrežni vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Ni najdenega omrežnega vmesnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Zvočni vmesnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Ni najdene zvočne naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Ni najdene bluetooth naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Druge PCI naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Ni najdenih drugih PCI naprav</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Napajanje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Ni najdenega akumulatorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Tipkovnica</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Ni najdene tipkovnice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Miška</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Ni najdene miške</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Tiskalnik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Ni najdenega tiskalnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Ni najdene kamere</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Ni najdenega CD-ROM pogona</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Druge naprave</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Ni najdenih drugih naprav</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Ročica polja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Oblikovni faktor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Nabor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Lokator banke</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Podrobnosti o vrsti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Številka dela</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Uvrstitev</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Tehnologija pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Zmožnosti načina delovanja pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Različica strojnega programa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID proizvajalca modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID izdelka modula</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID proizvajalca kontrolerja pomnilniškega podsistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID izdelka  kontrolerja pomnilniškega podsistema</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Ohlapna velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Obstojna velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Velikost medpomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Logična velikost</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>palcev</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
@@ -3692,314 +3453,295 @@
         <translation>strani</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>podatki vodila</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>velikostlogičnegasektorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>velikostsektorja</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometrija (logična)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Upravitelj naprav</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Upravitelj naprav je priročno orodje za prikaz podatkov o strojni opremi in upravljanje naprav.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Novi vodilci so na voljo! Namestite lepo ali nadgradnje jih zdaj.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Pogled</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Vključi podmappe</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Iskanje vodilcev v tej poti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 posodobitev vodilca so na voljo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Ustavljeno časovno: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Prenosi vodilne mreže za %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Hitrost prenosa: %1 Preneheno %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Nameščam vodilne mreže za %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 vodilnih mrež nameščeno, %2 vodilnih mrež je zgodila napaka</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 vodilnih mrež nameščeno</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Nameščanje vodilnih mrež je spodletelo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Omrežna napaka. Ponovno povezovanje...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Hitrost prenosa: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Vaše vodilne mreže so na voljo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Vse vodilne mreže so bili varnostno kopirane</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Skupno %1 vodilnih mrež, od katerega %2 je bilo varnostno kopirano</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Imate %1 vodilnih mrež, ki jih je mogoče varnostno kopirati, je priporočljivo to narediti meden čas</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Imate %1 vodilnih mrež, ki jih je mogoče varnostno kopirati</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Varnostno kopiranje vodilne mreže %1, skupno %2 vodilnih mrež</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Varnostno kopiranje: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 vodilnih mrež je bilo varnostno kopirano, %2 vodilnih mrež je zgodila napaka</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Varnostno kopiranje vodilnih mrež je spodletelo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 vodilnih mrež je bilo varnostno kopirano</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Imate %1 vodilnih mrež, ki jih je mogoče obnoviti</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Izberite vodilno mrežo za obnovo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Vodilna mreža se obnovuje...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Obnava: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>ponovno zagon</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Prosim %1, da so nameščene vodilne mreže vplivalne</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Pogledaj pot za varnostno kopijo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Varnostno kopiraj vse</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>posreduj opinijo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Prosim poskusite znova ali %1 nam</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Namesti vse</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Ispreverni skeniranje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Skeneiranje vrtilkov za opremnike, prosim počakajte...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Skeneiranje %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Skeneiranje je spodletelo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Omrežje ni na voljo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Prosim preverite povezavo s omrežjem</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Prosim ispreverite skeniranje ali %1 nam</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Namestiti ste vrtilko, ki bo prekinjena, če se izklopite.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ste сигурни, da želite izkloniti?
 </translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Izhod</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Varnostno kopirate vrtike, ki bo prekinjeno, če se izklopite.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Vrnitev vrtilkov bo prekinjena, če se izklopite.</translation>
     </message>
@@ -4010,7 +3752,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Opremnik za snimanje slik</translation>
     </message>
@@ -4115,22 +3856,22 @@
         <translation>Napaka pri prenosu datotek za operacijsko sistem</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Posodobitev</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Varnostna kopija</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Ponovno namestevanje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Namestitev</translation>
     </message>
@@ -4143,39 +3884,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Osveži</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Posodobitev vodilnikov</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Odinstaliranje vodilnikov</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Dozvoli, da ga vzbudi računalnik</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Omogoči</translation>
     </message>
@@ -4183,27 +3922,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Osveži</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Izvozi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Onemogoči</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Nedostopno</translation>
     </message>
@@ -4211,7 +3950,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Izberi, molim, varno mapo</translation>
     </message>
@@ -4219,7 +3958,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Nalaganje...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sq.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sq.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Feedbajt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Më tepër</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Tkurre</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Më tepër</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Më tepër</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Tkurre</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Më tepër</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Tkurre</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Emër Pajisjeje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID Fizike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Përshkrim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revisjon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>Driver Modë Kernel</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Adresë Kujtese</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID Fizike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Maksimum Fuqie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Version Përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Të dhëna Busi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Emër Logjik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Adresë Mac</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Të dhëna Busi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Maksimum Fuqie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID Fizike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID CPU-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID e Këndit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Tredha</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Arkitekturë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Familje CPU-sh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Kënd(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Virtualizim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Flamurka</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Zgjerime</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Fshehtinë l3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Fshehtinë L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Fshehtinë L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Fshehtinë L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Step</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Shpejtësi Maks.</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Kujtesë Grafike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID Fizike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Adresë Kujtese</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Portë IO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Të dhëna Busi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Qartësi Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Qartësi Minimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Qartësi e Tanishme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Përshkrim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Output Digital</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Dalje Ekrani</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Të dhëna Busi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID Fizike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Maksimum Fuqie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Numër Serial</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Ndërfaqe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Të dhëna Busi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Alias Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID Fizike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Rrymë Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Përmbledhje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Sasi CPU-sh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Skeda mëmë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Kujtesë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Përshtatës Ekrani</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Përshtatës Zëri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Depozitim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Pajisje të tjera PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Bateri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Përshtatës Rrjeti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Mi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Tastierë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Shtypës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Kamerë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Pajisje të Tjera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Pajisje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Lloj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Gjerësi Gjithsej</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Indikator</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Numër Serial</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Voltazh i Formësuar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Voltazh Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Voltazh Minimum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Shpejtësi e Formësuar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Gjerësi të Dhënash</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Lloj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Hyrje Ekrani</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Lloj Ndërfaqeje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Qartësi e Mbuluar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Qartësi e Tanishme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Përpjesëtim Ekrani</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Monitor Parësor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Numër Serial</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Prodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Lloj Media</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Aftësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Alias Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID Fizike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Version Firmware-i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Shpejtësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Përshkrim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Numër Serial</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Ndërfaqe</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Shpejtësi Rrotullimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Përzgjidhni një përudhës për përditësim</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>S’u gjetën përudhësa në këtë dosje</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Po ngarkohen të Dhëna Pajisjeje Audio…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Po ngarkohet të Dhëna BIOS-i…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Po ngarkohen të Dhëna CD-ROM-i…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Po ngarkohen të Dhëna Sistemi Operativ…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Po ngarkohet të Dhëna CPU-je…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Po ngarkohen të Dhëna Pajisjesh të Tjera…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Po ngarkohen të Dhëna Energjie…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Po ngarkohen të Dhëna Shtypësi…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Po ngarkohen të Dhëna Miu…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Po ngarkohen të Dhëna Përshtatësi Rrjeti…</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Të dhëna Pajisjeje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Mbylle</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Ndihmë</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Rifreskoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Përgjegjës Pajisjesh</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Përmbledhje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Përshtatës Ekrani</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Përshtatës Rrjeti</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Bateri</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Më tepër</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Version i Tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Version Platforme Përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Gjendje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Veprim</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Disqe të Kopjeruajtshëm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Disqe të Kopjeruajtur</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Po përditësohet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Pasuesi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Kujdes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Pas çinstalimit të përudhësit, pajisja s’do të jetë e përdorshme</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Çinstaloje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Po çinstalohet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Përditësim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Çinstalim i suksesshëm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Përditësimi dështoi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Çinstalimi dështoi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Pasuesi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Dosja e përzgjedhur s’ekziston, ju lutemi, ripërzgjidhni</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Përditësoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>E mëparshmja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Paketë e dëmtuar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Mospërputhje arkitekture pakete</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Kartela e përzgjedhur s’ekziston, ju lutemi, ripërzgjidhni</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>S’është përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>S’arrihet të instalohet - s’ka nënshkrim dixhital</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Gabim i panjohur</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>S’u gjet modul përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Format i pavlefshëm modulesh</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Moduli i përudhësit ka varësi</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Emër Pajisjeje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Version i Gatshëm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Madhësi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Gjendje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Veprim</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Version i Ri</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Version i Tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Mungojnë përudhës (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Përudhës të vjetruar (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Përudhës të përditësuar (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Instalim Përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Kopjeruajtje Disku</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Rikthim Disku</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Feedbajt</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>S’keni ndonjë disk për rikthim, ju lutemi, së pari bëni kopjeruajtje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Kalo te “Kopjeruaj Disk”</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Emër</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Version i Tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Version Kopjeruajtjeje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Veprim</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Disqe të Rikthyeshëm</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Rifreskoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Përmbledhje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Instalim Përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Kopjeruajtje Disku</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Rikthim Disku</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>S’u arrit të aktivizohej pajisja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>S’u arrit të çaktivizohej pajisja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>S’u arrit të çaktivizohet: s’arrihet të merret numër serial i pajisjes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Përditësoni Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Çinstaloni Përudhës</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Rifreskoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Përmbledhje</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Aktivizoje</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Lejoje të zgjojë kompjuterin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>S’u arrit të çaktivizohet: s’arrihet të merret numër serial i pajisjes</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>S’u arrit të çaktivizohej pajisja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>S’u arrit të aktivizohej pajisja</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Përditësoni Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Çinstaloni Përudhës</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Nënprodhues</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Nënpajisje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Përudhës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Gjendje Përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Urdhër Aktivizimi Përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Gjendje Formësimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>vonesë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Fizik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Shërbimë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KYÇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Hollësi BIOS-i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Hollësi Skede Bazë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Hollësi Mbi Sistemin</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Hollësi Shasie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Masjina Fizike të Memorisë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Datë Hedhjeje Në Qarkullim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adresë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Mëdha e Ejektores</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Madhësi ROM-i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Karakteristika</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Rishikim BIOS-i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Rishikim Firmware-i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Emër Produkti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Numër Serial</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Etiketë Burimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Veçori</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Vend Në Shasi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Kontrolli Këndi i Kapsules</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Lloj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Kontrolli Objekte të Mbuluar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Lloj Zgjimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Numër SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Familje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Blokuje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Gjendje Nisjeje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Gjendje Burimi Energjie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Gjendje Termike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Gjendje Sigurie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Hollësi OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Lartësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Numër Kabllosh Energjie</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Elementë të Përmbajtur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Vendndodhje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Lloj Ndreqjeje Gabimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Kapacitet Maksikum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Kontrolli Informacioneve të Shikimites të Gabitës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Numër Pajisjesh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>MADHËSI ROM BIOS-I</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Datë hedhjeje në qarkullim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Emër skede</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Version SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Format Përshkrimi Gjuhësh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Gjuhë të Instalueshme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Gjuhë Aktualisht e Instaluar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Adresë BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Lloj paketi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Rregull lidhjesh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Mënyrë lidhjesh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Klasë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Klasa Shërbimesh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Klasë Pajisjesh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Version HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Version LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Nënversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Pajisje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>ID Seriale</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>produkt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>përshkrim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Po Përgjigjet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Shërbimi i Discoverable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Shërbimi i Pairable</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Po Discovering</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Module Përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Kartelë Pajisje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Kartela Pajisjesh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Numër Pajisjeje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Aplikacion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>gjendje</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>emër logjik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Sendërtues CPU-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Arkitekturë CPU-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Variant CPU-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Bërë nga CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Revisioni i CPU-së</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Një</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Nëna</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Dhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Dymbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Katërmbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Gjashtëmbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Tetëmbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Njëzet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Njëzet e dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Njëzet e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Njëzet e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Njëzet e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Tridhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Tridhjetë e dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Tridhjetë e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Tridhjetë e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Tridhjetë e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Dyzet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Dyzet e dy  </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Dyzet e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Dyzet e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Dyzet e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Pesëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Pesëdhjetë e dy </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Pesëdhjetë e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Pesëdhjetë e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Pesëdhjetë e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Gjashtëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Gjashtëdhjetë e dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Gjashtëdhjetë e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Gjashtëdhjetë e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Gjashtëdhjetë e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Shtatëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Shtatëdhjetë e dy </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Shtatëdhjetë e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Shtatëdhjetë e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Shtatëdhjetë e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Tetëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Tetëdhjetë e dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Tetëdhjetë e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Tetëdhjetë e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Tetëdhjetë e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Nëntëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Nëntëdhjetë e dy </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Nëntëdhjetë e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Nëntëdhjetë e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Nëntëdhjetë e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Njëqind</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Njëqind e dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Njëqind e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Njëqind e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Njëqind e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Njëqind e dhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Njëqind e dymbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Njëqind e katërmbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Njëqind e gjashtëmbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Njëqind e tetëmbëdhjetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Njëqind e njëzet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Njëqind e njëzet e dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Njëqind e njëzet e katër</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Njëqind e njëzet e gjashtë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Njëqind e njëzet e tetë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Njëqind e nëntëdhjetë e dy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Dyqind e pesëdhjete e gjashtë </translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Kapacitet GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Tregtues GPU-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Lloj GPU-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Version EGL-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>API klientësh EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Version GL-je</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Version GLSL-je</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>E panjohur</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Klasë Hardware-i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>S’u gjet CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Skeda mëmë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>S’u gjet skedë mëmë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Kujtesë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>S’u gjet kujtesë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Depozitim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>S’u gjet disk</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Rikthimi i diskut dështoi!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Ju lutemi, riprovoni, ose na rrëfeni</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Kopjeruajtja e diskut dështoi!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Përshtatës Ekrani</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>S’u gjet GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>S’u gjet monitor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Përshtatës Rrjeti</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>S’u gjet përshtatës rrjeti</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Përshtatës Zëri</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>S’u gjet pajisje audio</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>S’u gjet pajisje Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Pajisje të tjera PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>S’u gjetën pajisje të tjera PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Energji</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>S&apos;u gjet bateri</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Përshtatës Zëri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>S’u gjet pajisje audio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>S’u gjet pajisje Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Pajisje të tjera PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>S’u gjetën pajisje të tjera PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Energji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>S&apos;u gjet bateri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Tastierë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>S’u gjet tastierë</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Mi</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>S’u gjet mi</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Shtypës</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>S’u gjet shtypës</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Kamerë</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>S’u gjet kamera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>S’u gjet CD-ROM</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Mi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>S’u gjet mi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Shtypës</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>S’u gjet shtypës</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Kamerë</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>S’u gjet kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>S’u gjet CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Pajisje të Tjera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>S’u gjetën pajisje të tjera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Kontrolli Array-ut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Formë e Formatit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Poza</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Banki i Lokatorit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Hollësi Lloji</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Numër Pjese</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Rank</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Teknologji Kujtese</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Aftësi Mënyrash Funksionimi Kujtese</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Version Firmware-i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ID Prodhuesi Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ID Produkti Moduli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ID Prodhuesi Kontrollori Nënsistemi Kujtese</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ID Produkti Kontrollori Nënsistemi Kujtese</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Mëdha e sështës së Sëshës së Sëshës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Mëdha e Sëshës së Sëshës</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Madhësi Fshehtine</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Madhësi Logjike</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>inç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Datë</translation>
     </message>
@@ -3634,12 +3636,12 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
         <source>number-up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
         <source>orientation-requested</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
@@ -3674,7 +3676,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
         <source>printer-state-reasons</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
@@ -3684,7 +3686,7 @@
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
         <source>printer-uri-supported</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
@@ -3692,313 +3694,313 @@
         <translation>anë</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>të dhëna busi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Gjeometri (Logjike)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Përgjegjës Pajisjesh</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Përgjegjësi i Pajisjeve është një mjet i dobishëm për të parë hollësi hardware-i dhe për administrim pajisjesh.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Ka përudhës të rinj! Instalojini, ose përditësojini tani.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Shiheni</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Përfshi nëndosje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Kërko për përudhës në këtë shteg</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 përditësime përudhësish të gatshme</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Kohë kontrolli: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Po shkarkohen përudhësa për %1…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Shpejtësi shkarkimi: %1 Të shkarkuar %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Po instalohen përudhës për %1…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>U instaluan %1 përudhës, dështoi instalimi për %2 përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>U instaluan %1 përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>S’u arrit të instalohet përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Gabim rrjeti. Po rilidhet…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Shpejtësi shkarkimi: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Përudhësit tuaj janë të përditësuar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Janë kopjeruajtur krejt disqet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>%1 disqe gjithsej, nga të cilët %2 janë kopjeruajtur</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Keni %1 disqe që mund të kopjeruhen, rekomandohet të bëni kështu menjëherë</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Keni %1 disqe që mund të kopjeruhen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Po kopjeruhet disku %1 driver, prej %2 disqesh gjithsej</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Po kopjeruhet: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 disqe të kopjeruajtur, dështoi për %2 disqe</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>S’u arrit të kopjeruhen disqe</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>U kopjeruajtën %1 disqe</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Keni %1 disqe që mund të rikthehen</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Ju lutemi, përzgjidhni një disk për rikthim</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Disku po rikthehet…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Rikthim: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>riniseni</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Ju lutemi, %1 që të hyjnë në fuqi përudhësit e instaluar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Shihni shteg kopjeruajtjeje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Kopjeruaji Krejt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>jepni përshtypjet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Ju lutemi, riprovoni, ose na %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Instaloji Krejt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Rikontrollo</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Po kontrollohet për përudhës pajisjesh hardware, ju lutemi, pritni…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Po kontrollohet %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Kontrolli dështoi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>S’ka lidhje në rrjet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Ju lutemi, kontrolloni lidhjen tuaj në rrjet</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Ju lutemi, rikontrolloni, ose na %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Po instaloni një përudhës, çka do të ndalet, nëse dilni.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Jeni i sigurt se doni të dilet?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Dil</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Po kopjeruani disqe, çka do të ndërpritet, nëse dilni.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Po bëhet rikthim disqesh, çka do të ndërpritet, nëse dilni.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>S’u arrit të merren kartela përudhësi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Përditësoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Kopjeruajtje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Riktheje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Instaloje</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Rifreskoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Përditësoni përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Çinstaloni përudhës</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Lejoje të zgjojë kompjuterin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Aktivizoje</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Rifreskoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Eksporto</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Çaktivizoje</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Jo i passhëm</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Ju lutemi, përzgjidhni një dosje</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Po ngarkohet…</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sr.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
-        <source>OK</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
+        <source>OK</source>
+        <translation>Ок</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Обратная связь</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Да</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Више</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Скупи</translation>
     </message>
 </context>
 <context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Више</translation>
     </message>
@@ -31,44 +46,28 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="85"/>
         <source>EC_NOTIFY_NETWORK</source>
-        <translation type="unfinished"/>
+        <translation>Уведоми о мрежи</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="86"/>
         <source>EC_REINSTALL</source>
-        <translation type="unfinished"/>
+        <translation>Понови инсталацију</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="87"/>
         <source>EC_6</source>
-        <translation type="unfinished"/>
+        <translation>EC_6</translation>
     </message>
 </context>
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Више</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Скупи</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Више</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Скупи</translation>
     </message>
@@ -77,92 +76,89 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
 </context>
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Назив уређаја</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Чип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Псеудоним модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Физички ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
-        <translation type="unfinished"/>
+        <translation>SysFS_Пут</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Ревизија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
-        <translation type="unfinished"/>
+        <translation>Дривер у режиму ядра</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Меморијска адреса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Чипсет</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Псеудоним</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Псеудоним модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Физички ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Максимална снага</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Верзија управљача</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Управљач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Подаци магистрале</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Логички назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>МАК адреса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Подаци магистрале</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Управљач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Максимална снага</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Псеудоним модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Физички ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ЦПЈ ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ИД језгра</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Нити</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>БогоМИПС</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Архитектура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>ЦПЈ породица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>Процесор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Језгра</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Виртуелизација</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Показатељи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Проширења</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 кеш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Кеш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Кеш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Кеш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Кеш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Степинг</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Брзина</translation>
     </message>
@@ -488,200 +479,200 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Графичка меморија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Псеудоним модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Физички ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Меморијска адреса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO прикључак</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Подаци магистрале</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Максимална резолуција</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Минимална резолуција</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Тренутна резолуција</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Управљач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
-        <translation type="unfinished"/>
+        <translation>Цифарно излаз</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Излази екрана</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
 </context>
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Подаци магистрале</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Псеудоним модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Физички ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Максимална снага</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Управљач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Серијски број</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Модел</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Сучеље</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Подаци магистрале</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Псеудоним модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Физички ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
-        <translation type="unfinished"/>
+        <translation>Максимални ток</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Управљач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Уопштено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>ЦПЈ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Количина процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Матична плоча</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Меморија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Графичка картица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Звучнa картица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Складиште</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Остали PCI уређаји</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Батерија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Блутут</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Мрежна картица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>Миш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Тастатура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>ЦД-РОМ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>Штампач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Остали уређаји</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Уређај</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>ОС</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Величина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Врста</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Укупна ширина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Локатор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Серијски број</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Подешени напон</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Максимални напон</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Минимални напон</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Подешена брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Ширина података</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Врста</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Улази екрана</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Врста сучеља</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Подржане резолуције</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Тренутна резолуција</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Размера екрана</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Главни монитор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Величина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Серијски број</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Врста</translation>
     </message>
@@ -1090,12 +1040,12 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
         <source>Maximum Rate</source>
-        <translation type="unfinished"/>
+        <translation>Максимална брзина</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
         <source>Negotiation Rate</source>
-        <translation type="unfinished"/>
+        <translation>Брзина преговора</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
@@ -1165,7 +1115,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
@@ -1286,7 +1236,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
@@ -1428,148 +1378,143 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Врста медија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Величина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Псеудоним модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Физички ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Верзија фирмвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Брзина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Серијски број</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Сучеље</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Брзина окретања</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Изаберите дривер за ажурирање</translation>
     </message>
 </context>
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
-        <translation type="unfinished"/>
+        <translation>Нема дривера у овој фолдеру</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
 </context>
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Учитавање података аудио уређаја...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Учитавање БИОС података...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Учитавање ЦД-РОМ података...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Учитавање података о оперативном систему...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Учитавање ЦПЈ података...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Учитавање података осталих уређаја...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Учитавање података о напајању...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Учитавање података штампача...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Учитавање података о мишу</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Учитавање података мрежне картице...</translation>
     </message>
@@ -1577,116 +1522,114 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступно</translation>
     </message>
 </context>
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Хардвер</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Подаци уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Прикажи пречице</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Затвори</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Помоћ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Систем</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Упрваник Уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
-        <translation type="unfinished"/>
+        <translation>Дривери</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Текућа верзија</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Уопштено</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Графичка картица</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>ЦПЈ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Мрежна картица</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Батерија</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Више</translation>
     </message>
@@ -1702,392 +1645,374 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>Текућа верзија</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>Верзија платформе дривера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Стање</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>Акција</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Дривери који могу да се накладе</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Накладени дривери</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирање</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>Warning</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>The device will be unavailable after the driver uninstallation</source>
-        <translation type="unfinished"/>
+        <translation>Следећи</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
-        <source>Uninstall</source>
-        <comment>button</comment>
-        <translation type="unfinished"/>
+        <source>Warning</source>
+        <translation>Упозорење</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Уређај ће бити недоступан после деактивације дривера</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Деактивирај</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
-        <translation type="unfinished"/>
+        <translation>Деактивирање</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирање је успешно</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
-        <translation type="unfinished"/>
+        <translation>Деактивација је успешно</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирање је неуспешно</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
-        <translation type="unfinished"/>
+        <translation>Деактивација је неуспешна</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Ок</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
-        <source>The selected folder does not exist, please select again</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
-        <source>Update</source>
-        <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Следећи</translation>
     </message>
     <message>
         <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Изабрана фолдер не постоји, молимо вас да изаберете поново</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Ажурирај</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Претходни</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
-        <translation type="unfinished"/>
+        <translation>Оштећен пакет</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
-        <translation type="unfinished"/>
+        <translation>Архитектура пакета не подудара се</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
-        <translation type="unfinished"/>
+        <translation>Изабрана датотека не постоји, молимо вас да изаберете поново</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
-        <translation type="unfinished"/>
+        <translation>Ово није дривер</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
-        <translation type="unfinished"/>
+        <translation>Не могу да инсталирам - нема цифралног потписа</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
-        <translation type="unfinished"/>
+        <translation>Непознати грешка</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
-        <translation type="unfinished"/>
+        <translation>Модул дривера није пронађен</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
-        <translation type="unfinished"/>
+        <translation>Неважећи формат модула</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
-        <translation type="unfinished"/>
+        <translation>Модул дривера има зависности</translation>
     </message>
 </context>
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Назив уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
-        <translation type="unfinished"/>
+        <translation>Доступна верзија</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Величина</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Стање</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>Акција</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
-        <translation type="unfinished"/>
+        <translation>Нова верзија</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>Текућа верзија</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>Мислије дривери (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>Старе дривери (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
-        <translation type="unfinished"/>
+        <translation>Ажуриране дривери (%1)</translation>
     </message>
 </context>
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Инсталисање дривера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Резервна копија дривера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Врати дривер</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>Обратна се увид</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>Немате ниједан дривер за врати, молимо вас прво направите резервну копију</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>Одаберите резервну копију дривера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
-        <translation type="unfinished"/>
+        <translation>Текућа верзија</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>Резервна верзија</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
-        <translation type="unfinished"/>
+        <translation>Акција</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Вративи дривери</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Уопштено</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>Инсталисање дривера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>Резервна копија дривера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>Врати дривер</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Неуспешно омогућавање уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Неуспешно онемогућавање уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>Неуспешно искључење: не могу да добијем серијски број уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирај дривере</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Деинсталисај дривере</translation>
     </message>
 </context>
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Уопштено</translation>
     </message>
@@ -2111,1368 +2036,1204 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>Омогући</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирај дривере</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>Деинсталисај дривере</translation>
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>Дозволи да пробужи компјутер</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
-        <translation type="unfinished"/>
+        <translation>Неуспешно искључење: не могу да добијем серијски број уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Неуспешно онемогућавање уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Неуспешно омогућавање уређаја</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирај дривере</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
-        <translation type="unfinished"/>
+        <translation>Деинсталисај дривере</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>Под-произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>Под-урећај</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Управљач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Стање управљача</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Комада за активирање управљача</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>Стање подешавања</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>кашњење</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Обрађивачи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>ПРОП</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>ЕВ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Магистрала</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Подаци БИОС-а</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Подаци основне плоче</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Подаци система</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Подаци о шасији</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Физички меморијски низ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Датум објаве</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Величина извршавања</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Величина РОМ-а</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Особине</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>БИОС ревизија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Рвизија фирмвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Назив производа</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Серијски број</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Ознака средства</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Могућности</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Положај у шасији</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Идентификатор шасије</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Врста</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Садржани идентификатори објекта</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>УУИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Врста буђења</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>СКУ број</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>Породица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Брава</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Стање покретања</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Стање напајања</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Термичко стање</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Безбедносни статус</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>ОЕМ подаци</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Висина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Број напојних каблова</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Садржани елементи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Локација</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Начин исправљања грешака</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Максимални капацитет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>Идентификатор података грешака</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Број уређаја</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROMSIZE</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Датум објаве</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Назив плоче</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>СМБИОС верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Формат описа језика</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Уградиви језици</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Тренутно инсталирани језик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD адреса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Тип пакета</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Политика везе</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Режим везе</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Класа</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Сервисне класе</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Класа уређаја</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>ХЦИ верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>ЛМП верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Подверзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Уређај</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>Серијски ИД</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>производ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Напојено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Може се открити</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Упариво</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Откривање</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Модули управљача</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>Датотека уређаја</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Датотеке уређаја</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Број уређаја</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Примена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>статус</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>логичко име</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ANSI верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>ЦПЈ реализатор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>ЦПЈ архитектура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>ЦПЈ варијанта</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>ЦПЈ део</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>ЦПЈ ревизија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Једно</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>Девет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Десет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Дванест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Четрнест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Шеснест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Осамнест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Двадесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Двадесет два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Двадесет четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Двадесет шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Двадесет осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Тридесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Тридесет два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Тридесет четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Тридесет шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Тридесет осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Четрдесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Четрдесет два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Четрдесет четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Четрдесет шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Четрдесет осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Педесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Педесет два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Педесет четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Педесет шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Педесет осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Шездесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Шездесет два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Шездесет четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Шездесет-шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Педесет-осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Седамдесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Седамдесет-два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Седамдесет-четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Седамдесет-шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Седамдесет-осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Осамдесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Осамдесет-два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Осамдесет-четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Осамдесет-шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Осамдесет-осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Деведесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Деведесет-два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Деведесет-четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Деведесет-шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Деведесет-осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Сто</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Сто-два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Сто-четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Сто-шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Сто-осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Сто-десет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Сто-дванаест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Сто-четрнаест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Сто-шеснаест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Сто-осамнаест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Сто-двадесет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Сто-двадесет-два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Сто-двадесет-четири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Сто-двадесет-шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Сто двадесет осам</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
-        <translation type="unfinished"/>
+        <translation>Један стотини и деветдесет и два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Двеста педесет шест</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR капацитет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU произвођач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU врста</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL клијент API-ји</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL верзија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL верзија</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Непознато</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Класа уређаја</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>ЦПЈ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Није пронађен ЦПЈ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Матична плоча</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Матична плоча није пронађена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Меморија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Меморија није пронађена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Складиште</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Није пронађен диск</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>Вратио везу водача није успело!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>Молимо вас покушајте поново или нам пошаљите фидбек</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>Веза водача за бакап није успела!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Графичка картица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Није пронађен GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Монитор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Монитор није пронађен</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Мрежна картица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Мрежна картица није пронађена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Звучнa картица</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Није пронађен аудио уређај</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Блутут</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Није пронађен блутут уређај</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Остали PCI уређаји</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Нису пронађени други PCI уређаји</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Напајање</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Није пронађена батерија</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Тастатура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Тастатура није проађена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>Миш</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Миш није пронађен</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>Штампач</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Штампач није пронађен</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Камера није пронађена</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>ЦД-РОМ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Није пронађен ЦД-РОМ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Остали уређаји</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Нису пронађени други уређаји</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Идентификатор низа</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Формат</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Комплет</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Локатор банке</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Детаљи врсте</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Произвођачки број</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Ранг</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Технологија меморије</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Капацитет меморије у радном режиму</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Верзија фирмвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>ИД произвођача модула</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>ИД производа</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ИД произвођача контолера меморијског подсистема</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Ид производа контолера меморијског подсистема</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Постојана величина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Непостојана величина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Величина кеша</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Логичка величина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>инча</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Датум</translation>
     </message>
@@ -3692,446 +3453,428 @@
         <translation>стране</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>подаци магистрале</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>величина логичких сектора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>величина сектора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Геометрија (Логичка)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Упрваник Уређаја</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Управник Уређаја је користан алат за приказ података о рачунару, апаратури и за управљање уређајима.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
-        <translation type="unfinished"/>
+        <translation>Нови водачи доступни! Инсталирајте их или ажурирајте их сада.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
-        <translation type="unfinished"/>
+        <translation>Поглед</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
-        <translation type="unfinished"/>
+        <translation>Укључи подфолдере</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
-        <translation type="unfinished"/>
+        <translation>Претражите водаче у овом путањи</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
-        <translation type="unfinished"/>
+        <translation>'%1 ажурирања водача доступна'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
-        <translation type="unfinished"/>
+        <translation>'Време проверено: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>Преузимање водача за %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation type="unfinished"/>
+        <translation>' Брзина преузимања: %1 преузето %2/%3'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
-        <translation type="unfinished"/>
+        <translation>Инсталирање водача за %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 водача инсталирано, %2 водача неуспех'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 водача инсталирано'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
-        <translation type="unfinished"/>
+        <translation>Инсталирање водача није успело</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
-        <translation type="unfinished"/>
+        <translation>Мрежна грешка. Поново се повезива...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
-        <translation type="unfinished"/>
+        <translation>'Брзина преузимања: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
-        <translation type="unfinished"/>
+        <translation>Ваша ажурирања водача су актуелна</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>Сви водачи су бакаповани</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>'Укупно %1 водача, од којих %2 су бакаповани'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>>
+Имаш %1 водача који могу бити бакаповани, препоручује се да то уčините
+одмах</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>Имаш %1 водача који могу бити бакаповани</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>Бакапирање водача %1, укупно %2 водача</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>'Бакапирање: %1'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>'%1 водача бакапованих, %2 водача неуспех'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>Бакапирање водача није успело</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>'%1 водача бакапованих'</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>Имаш %1 водача који могу бити вратијени</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>Молимо вас одаберите водача да би се вратио</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>Водач се вратије...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>Поврати: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
-        <translation type="unfinished"/>
+        <translation>поврати</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
-        <translation type="unfinished"/>
+        <translation>Молимо %1 да би се примениле инсталиране дривери</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>Погледајте путању за резервну копију</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
-        <source>submit feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
-        <source>Please try again or %1 to us</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
-        <source>Install All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
-        <source>Scan Again</source>
-        <translation type="unfinished"/>
+        <translation>Резервна копија свих</translation>
     </message>
     <message>
         <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>пошаљите фидбек</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Молимо покушајте поново или %1 нам</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Инсталирај све</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Сканирај поново</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Сканирање дривера за хардвер уређа, молимо подржите...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
-        <translation type="unfinished"/>
+        <translation>Сканирање %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
-        <translation type="unfinished"/>
+        <translation>Сканирање неуспешно</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Мрежа недоступна</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
-        <translation type="unfinished"/>
+        <translation>Молимо проверите вашу мрежну везу</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
-        <translation type="unfinished"/>
+        <translation>Молимо сканирајте поново или %1 нам</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Инсталирајте дривер, који ће бити прекинут ако напустите.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
-        <translation type="unfinished"/>
+        <translation>Сигурни сте да желите да напустите?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
-        <translation type="unfinished"/>
+        <translation>Излаз</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Резервна копија дривера, која ће бити прекинута ако напустите.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>Повраћање дривера, које ће бити прекинуто ако напустите.</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
         <source>Bluetooth adapter</source>
-        <translation type="unfinished"/>
+        <translation>Bluetooth адаптер</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
-        <translation type="unfinished"/>
+        <translation>Уређа за сликање</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="38"/>
         <source>Display adapter</source>
-        <translation type="unfinished"/>
+        <translation>Адаптер за приказ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="40"/>
         <source>Sound card</source>
-        <translation type="unfinished"/>
+        <translation>Звучна картица</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="42"/>
         <source>Network adapter</source>
-        <translation type="unfinished"/>
+        <translation>Мрежни адаптер</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="46"/>
         <source>Wireless network adapter</source>
-        <translation type="unfinished"/>
+        <translation>Беспроводни мрежни адаптер</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="66"/>
         <source>Installation successful</source>
-        <translation type="unfinished"/>
+        <translation>Инсталација успешна</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="67"/>
         <source>Installation failed</source>
-        <translation type="unfinished"/>
+        <translation>Инсталација неуспешна</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="68"/>
         <source>Downloading</source>
-        <translation type="unfinished"/>
+        <translation>Преузимање</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="69"/>
         <source>Installing</source>
-        <translation type="unfinished"/>
+        <translation>Инсталација</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="70"/>
         <source>Not installed</source>
-        <translation type="unfinished"/>
+        <translation>Не инсталиран</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="71"/>
         <source>Out-of-date</source>
-        <translation type="unfinished"/>
+        <translation>Стар</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="72"/>
         <source>Waiting</source>
-        <translation type="unfinished"/>
+        <translation>Чекање</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>Не је захвачен</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>Захваћање</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>Захваћање неуспешно</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>Захваћање успешно</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>Врати</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
         <source>Unknown error</source>
-        <translation type="unfinished"/>
+        <translation>Неизвестна грешка</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="82"/>
         <source>Network error</source>
-        <translation type="unfinished"/>
+        <translation>Грешка у мрежи</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="83"/>
         <source>Canceled</source>
-        <translation type="unfinished"/>
+        <translation>Одказано</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="84"/>
         <source>Failed to get driver files</source>
-        <translation type="unfinished"/>
+        <translation>Неуспешно добијање датотека драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирање</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>Захваћање</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Врати</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation>Инсталирање</translation>
     </message>
     <message>
         <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
@@ -4142,39 +3885,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
-        <translation type="unfinished"/>
+        <translation>Ажурирај драйвере</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
-        <translation type="unfinished"/>
+        <translation>Деинсталирај драйвере</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
-        <translation type="unfinished"/>
+        <translation>Дозволи да буди укључен</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Омогући</translation>
     </message>
@@ -4182,43 +3923,43 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Извези</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Онемогући</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
-        <translation type="unfinished"/>
+        <translation>Недоступан</translation>
     </message>
 </context>
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
-        <translation type="unfinished"/>
+        <translation>Молимо вас, изаберите локалну фолдер</translation>
     </message>
 </context>
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Учитавање...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sv.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sv.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Mer</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>EC_NOTIFY_NETWORK</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>EC_REINSTALL</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Mer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Kollaps</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Enhetsnamn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Revisionsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>KernelModeDriver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Minnesadress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Lägg till</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Maximal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Driver version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Förmågor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Bussinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Logiskt namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC-adress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Lägg till</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Bussinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Förmågor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Maximal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>Lägg till</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>CPU ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Kärnkod</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Trådar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Arkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>CPU-familj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Processor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Kärna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualisering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Flaggor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Utökningar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d-cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Steg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Max hastighet</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Grafisk minneshukommelse</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>Fysiskt ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Minnesadress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>IO-port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Bussinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Maximal upplösning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Minimial upplösning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Aktuell upplösning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Beskrivning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Digital Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Skäravspump</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Ommöjlig</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Bussinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Maximal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Ommöjlig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Gränssnitt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Bussinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Maximal ström</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Förmågor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Översikt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>Processort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Antal processort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Minne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Skärmlampadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Ljudadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Lagring</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Andra PCI-enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Nätverksadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Mus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Tangentbord</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Monitorskärm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Skrivare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Andra enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Enhet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>Operativsystem</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Total Width</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Locator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Seriennummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Konfigurerad spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Maximal spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Minimell spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Konfigurerad hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Data Width</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Visningsinmatning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Gränssnitts typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Stöd för upplösning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Aktuell upplösning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Visningsförhållande</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Huvudskärm</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Seriennummer</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Bussinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Driver version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Maximal hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Negotiation Rate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Länk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Dubbel</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto-negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Minnesadress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC-adress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logiskt namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>In/Ut</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Minne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Färdigheter</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Bus-info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Färdigheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Drivrutin</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Maximal effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kapacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Skaft</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Designkapacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Designspänning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS-serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS-fabrikationsdatum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS-kemi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Temperatur</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Delad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Typ av gränssnitt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Leverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Mediums typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Firmwareversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Beskrivning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Gränssnitt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Orets rotationshastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Välj en drivare för uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Inga drivare hittades i denna mapp</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Laddar ljudenhetsinformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Laddar BIOS-information...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Laddar CD-ROM-information...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Laddar operativsysteminformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Laddar CPU-information...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Laddar information om andra enheter...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Laddar ströminformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Laddar skrivareinformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Laddar musinformation...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Laddar nätverkskortinformation...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Otilgänglig</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Information om enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Visa snickar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Stäng</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Hjälp</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopiera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Exportera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Förnya</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Enhetshanterare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Hårdvara</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Drivrut</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Översikt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Skärmlösare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Nätverkskort</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Batteri</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Mer</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Drivrutens plattformsversion</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Backupbar drivrut</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Backupade drivrut</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Uppdaterar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Nästa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Varning</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Enheten kommer inte att vara tillgänglig efter att drivrutet har avinstalleras</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Avinstallera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Avinstallerar</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Uppdatering lyckad</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Avinstallation lyckad</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Uppdatering misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Avinstallering misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Nästa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Den valda mappen finns inte, vänligen välj om</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Uppdatera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Föregående</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Skadad paket</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Omatchat paketarkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Den valda filen finns inte, vänligen välj om</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Det är inte en drivare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Kan inte installera - inget digitalt certifikat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Okänd fel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Den drivarmodulen hittades inte</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Ogiltigt modulformat</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Den drivarmodulen har beroenden</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Installera drivare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Spara drivare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Återställ drivare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Feedback</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Du har inga drivare att återställa, vänligen spara först</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Gå till Drivarespald</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Sparad version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Återställbara drivare</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Uppdatera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Exportera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Översikt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Installera drivare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Spara drivare</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Återställ drivare</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Kunde inte aktivera enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Kunde inte deaktivera enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Kunde inte deaktivera det: kan inte hämta enhetens serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Uppdatera drivrutiner</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Avinstallera drivrutiner</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Uppdatera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Exportera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Översikt</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Uppdatera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Exportera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopiera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Aktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Uppdatera drivrutiner</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Avinstallera drivrutiner</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Tillåt att det väcker datorn</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Deaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Kunde inte deaktivera det: kan inte hämta enhetens serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Kunde inte deaktivera enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Kunde inte aktivera enheten</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Uppdatera drivrutiner</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Avinstallera drivrutiner</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Underleverantör</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Underenheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Driver-status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Driver-aktiveringskommando</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Konfigurationsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>Latens</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Fysisk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Hanterare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Buss</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>BIOS-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Grundplattformsinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Systeminformation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Chassis-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Fysiskt minnesarrangemang</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Utgivningsdatum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Adress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Körningsstorlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ROM-storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Egenskaper</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>BIOS-revision</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Firmware-revision</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Produktnamn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Varugruppsetikett</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Plats i chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Chassis-hanterare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Innehållande objektshanterare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Väckningsotyp</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU-nummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Familj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Lås</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Startstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Strömsläppstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Termisk status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Säkerhetsstatus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>OEM-information</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Höjd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Antal strömcordar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Innehållande element</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Lokalisering</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Felkorrektions typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Maximal kapacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Felinformationshanterare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Antal enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMstorlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Utgivningsdatum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Bordnamn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Språkbeskrivningsformat</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Installationsbara språk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Aktuellt installerat språk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD-adress</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Pakettyp</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Länkpolitik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Länkmodus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Klass</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Tjänsteklasser</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Enhetsklass</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Underversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Enhetsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>Serienummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>Produkt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>Beskrivning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Tänd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Upptäckbar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Parable</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Upptäcker</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Drivermoduler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Enhetsfil</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Enhetsfiler</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Enhetsnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>logiskt namn</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU-implementerare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU-arkitektur</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU-variant</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU-del</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU-revision</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Ett</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Två</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Fyra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Sex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Åtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Nio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Tio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Tolv</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Fjorton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Sexton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Attton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Tjugot</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Tjugotvå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Tjugofour</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Tjugosex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Tjugotåtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Trettio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Trettiotvå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Trettiofour</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Trettiosex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Trettiotåtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Fortsio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Fortsiotvå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Fortsiofour</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Fortsiosex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Fortsiotåtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Femtio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Femtiotvå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Femtiofour</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Femtiosex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Femtiotåtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Sextio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Sextiotvå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Sextiofour</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Sexton sjutton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Sexton åtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Sjutton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Sjutton och två</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Sjutton och fyra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Sjutton och sex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Sjutton och åtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Åttio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Åttio och två</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Åttio och fyra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Åttio och sex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Åttio och åtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Nitton</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Nitton och två</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Nitton och fyra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Nitton och sex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Nitton och åtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Ett hundra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Ett hundra och två</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Ett hundra och fyra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Ett hundra och sex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Ett hundra och åtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Ett hundra och tio</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Ett hundra och tjugotvå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Ett hundra och tjugofyra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Ett hundra och tjugosex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Ett hundra och tjugoocto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Ett hundra och tjugoci</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Ett hundra och tjugotvå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Ett hundra och tjugofyra</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Ett hundra och tjugosex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Ett hundra och tjugåtta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Ett hundra och nittio-två</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Två hundra och femtio-sexa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR-kapacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU-företag</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU-typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL-klient-API:er</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Okänd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Unik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Hårdvaruklass</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Ingen CPU hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Motherboard</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Inget motherboard hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Minne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Inget minne hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Lagring</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Ingen disk hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Återställning av drivrutrustning misslyckades!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Vänligen försök igen eller ge oss feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Säkerhetskopia av drivrutrustning misslyckades!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Skäravadare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Ingen GPU hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Ingen monitor hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Nätverkskort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Inget nätverkskort hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Ljudkort</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Inget ljudenhetsenheter hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Inget Bluetooth-enheter hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Andra PCI-enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Inga andra PCI-enheter hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Kraft</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Ingen batteri hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Tangentbord</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Inget tangentbord hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Ingen mus hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Skrivare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Ingen skrivare hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Ingen kamera hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Ingen CD-ROM hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Andra enheter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Inga andra enheter hittades</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Array Handle</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Formfaktor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Set</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Bank Locator</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Typdetalj</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Delnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Minnesteknik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Funktion för minnesoperativt läge</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Firmware-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Modul tillverkarens ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Modul produkt-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Minnesystemstyrkans tillverkarens ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Minnesystemstyrkans produkt-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Oändlig storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Växelbar storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Cache-storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Logisk storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>tum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Datum</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>IO-port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>nätverk</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>nativ väg</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>strömkälla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>uppdaterad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>har historik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>har statistik</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>laddbar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>varning nivå</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energi tom</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energi full</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>energi full design</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>energi takt</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>spänning</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>procent</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknologi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ikone</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>på batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>lidskärv är stängd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>lidskärv finns tillgänglig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>kritisk åtgärd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>kopia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>jobb avbryt efter</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>jobb hålls fram till</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>jobb prioritet</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>marker förändring tid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>antal upp</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientering begärd</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>tryck färgläge</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>skrivare accepterar jobb</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>skrivare är delad</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>skrivare är tillfällig</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>skrivare tillverkare och modell</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>skrivare tillstånd förändring tid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>skrivare tillstånd orsaker</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>skrivare typ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>skrivare uri stöds</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>sider</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logicalsectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>GUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>Geometri (Logisk)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>Enhetshanteraren</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>Enhetshanteraren är ett användbart verktyg för att visa hårdvaruinformation och hantera enheterna.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>Nya drivrutiner är tillgängliga! Installera eller uppdatera dem nu.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>Visa</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>Inkludera undermappar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>Sök efter drivrutiner i den här sökvägen</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 drivrutiner uppdateringar tillgängliga'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'Tid kontrollerad: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>Laddar drivrutiner för %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'Nerladdningshastighet: %1 Laddat %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>Installerar drivrutiner för %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 drivrutiner installerade, %2 drivrutiner misslyckades'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 drivrutiner installerade'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>Misslyckades med installation av drivrutiner</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>Nätverksfel. Återansluter...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'Nerladdningshastighet: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>Dina drivrutiner är uppdaterade</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>Alla drivrutiner har backats upp</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>Totalt %1 drivrutiner, varav %2 har backats upp</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>Du har %1 drivrutiner som kan backas upp, det rekommenderas att göra det omedelbart</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>Du har %1 drivrutiner som kan backas upp</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>Backar upp drivrutinen %1, totalt %2 drivrutiner</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'Backar upp: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 drivrutiner backade upp, %2 drivrutiner misslyckades'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>Misslyckades med att backa upp drivrutiner</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 drivrutiner backade upp'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>Du har %1 drivrutiner som kan återställas</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>Vänligen välj en drivrutin att återställa</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver är i återställning...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Återställer: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>starta om</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Vänligen %1 för att installationen ska börja gälla</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Visa säkerhetskopieringsväg</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Säkerhetskopiera allt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>skicka feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Vänligen försök igen eller %1 till oss</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Installera allt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Skanna igen</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Söker efter drivrutrustning, vänligen vänta...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Skannar %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Skanning misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Nätverk är inte tillgängligt</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Vänligen kontrollera din nätverksanslutning</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Vänligen skanna igen eller %1 till oss</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Du installerar ett driver, vilket kommer att avbrytas om du lämnar.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Är du säker på att du vill avsluta?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Avsluta</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Du säkerhetskopierar drivrutrustning, vilket kommer att avbrytas om du lämnar.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Du återställer drivrutrustning, vilket kommer att avbrytas om du lämnar.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth-adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Bildskärm</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Skärmadapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Ljudkort</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Nätverkskort</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Trådlösa nätverkskort</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Installation lyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Installation misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Laddar ner</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Installerar</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Inte installerat</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Utdaterad</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Väntar</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Inte säkerkopierat</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Säkerkopierar</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Säkerkopiering misslyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Säkerkopiering lyckades</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Återställer</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Okänd fel</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Nätverksfel</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Avbrytt</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Misslyckades att hämta drivrutredningsfilerna</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Uppdatera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Säkerkopiera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Återställ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Installera</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Förnya</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Exportera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Uppdatera drivrutredningar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Avinstallera drivrutredningar</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Tillåt att det väcker datorn</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Aktivera</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Förnya</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Exportera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kopiera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Inaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Otomatisk</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Välj en lokal mapp vänligen</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Laddar...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_sw.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_sw.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sw">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>Mato ya kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>Zaidi</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>Unganisha kwenye tawi</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>Unganisha tena</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>Zaidi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>Kupungua</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>Kupungua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>Hapana</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>Jina la mazingira</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>Mwamkono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>Chip</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>Kazi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>SysFS_Path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>Makala</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Driver ya KernelMode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>Makala ya memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>Hapana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>Kupungua</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>Mwamkono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>Modeli</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Mwamkono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Siku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>Chipset</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>Mzigo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>Mwana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>Namba ya siku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>Mwendo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>Kupatikana kwa jumla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>Namba ya Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>Kazi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>Idadi ya Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>Jina ya Logi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>Jina ya MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>Hakuna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>Ongeza</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>Mwana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>Namba ya siku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>Idadi ya Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>Kazi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>Kupatikana kwa jumla</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>Mwendo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>Hakuna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>Ongeza</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>Mwana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>ID ya CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>ID ya Core</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>Mwendo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>Mato ya kipimo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>BogoMIPS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>Architecture</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>Keluarga CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>Model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>Processor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>Core (s)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>Virtualization</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>Flags</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>Extensions</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>Cache L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>Cache L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>Cache L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>Cache L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>Stepping</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>Speed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>Max Speed</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>Modeli</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>Memory ya Graphics</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ID ya Physical</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>Address ya Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>Port ya IO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>Matokeo ya Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>Resolution ya Kimo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>Resolution ya Kimo cha Kwanza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>Resolution ya Sasa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>Maelezo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>Moto ya Uzalishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>Moto ya Uzalishaji ya Kificha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>Kificha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>Hapene</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>Mtu wa Mipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>Namba ya Siku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>Modeli</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>Maelezo ya Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>Moyoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>Kificha ya Kipato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kificha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>Namba ya Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>Hapene</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>Onyeshi</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>Mtu wa Mipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>Modeli</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>Mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>Maelezo ya Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>Moyoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>Kipato ya Kipato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>Kutambulizi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>Namba ya Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>Hapana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>Kufunga</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>Miongoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>Idadi ya CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>Maktaba ya Baba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>Mshiriki wa Kupangwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>Mshiriki wa Kupangwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>Kutazama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>Wenzake wa PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>Bateri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>Mshiriki wa Tawi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>Maktaba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>Kabisa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>Maktaba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>Machapishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>Wenzake</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>Maktaba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>MS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>Idadi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>Mato</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>Mikono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>Uwezo wa kubadilika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>Wakilishi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Namba ya serikali</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>Voltage iliyobadilika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>Voltage mazigo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>Voltage kimo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>Uwezo wa kubadilika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>Uwezo wa data</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>Madarasa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>Mara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>Input ya kubadilika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>Mara ya interface</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>Resolution inayotumika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>Resolution ya sasa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>Rasio ya kubadilika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>Monitor ya kwanza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>Uwezo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>Namba ya serikali</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>Madarasa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>Mara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>Namba ya siku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>Maelezo ya bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>Kazi za kubadilika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>Namba ya siku ya driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>Mazigo ya kibariki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>Mazigo ya kibariki ya kubadilika</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>Multicast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>Umkoraa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>Duplex</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>Broadcast</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>Auto Negotiation</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>Memory Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>MAC Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>Logical Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>Hakikishi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>Kufuta</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>Modeli</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>Maelezo ya Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>Sera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>Input/Output</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>Memory</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>Umkoraa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>Umkoraa</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>Modeli</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>Sera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>Maelezo ya Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>Kazi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>Mshabisi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>Kiasi cha Uzalishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>Moyoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>Namba ya Seria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>Hakuna</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Onyeshana</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>Moto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>Mwambo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>Namba ya Seria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>Mara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>Hali</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>Kiasi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>Mvuto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>Mkono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>Kiasi ya Kujitokeza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>Mvuto ya Kujitokeza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>Namba ya Sauti</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>Namba ya Seria ya SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>Tarehe ya Uzalishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>Matokeo ya SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>Moyoni</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>Jina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>Moto</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>Mwambo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>Namba ya Seria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>Imeongezwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>Hali</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>Mipaka ya Mwakilishi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>Onyeshi</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>Mwakilishi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>Mipaka ya Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>Uwezo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>Namba ya Siku</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>Kazi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>Namba ya Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>Moyoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>Maelezo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>Namba ya Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>Mipaka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>Moyoni ya Kifua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>Hakuna</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>Chagua driver ya kujaribu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>Hakuna drivers kwenye mpira hii</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>Kutambua maelezo ya pereti...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>Kutambua maelezo ya BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>Kutambua maelezo ya CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>Kutambua maelezo ya Mshinisi wa Moyo...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>Kutambua maelezo ya CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>Kutambua maelezo ya Mipaka Mengine...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>Kutambua maelezo ya Moyo...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Kutambua maelezo ya Mipaka...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Kutambua maelezo ya Mipaka...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>Kutambua maelezo ya Mipaka ya Uingilizaji...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>Onyeshi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>Hakuna</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>Onyeshi</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>Hakuna</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>Mato ya Miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>Kupambana na Mato</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>Futa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>Mchezo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>Kopya</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>Mazingira</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>Eksporta</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>Tafuta</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>Mang'isha ya Miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>Mazingira ya Miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>Mang'isha ya Miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>Maktaba</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>Mato ya Miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>Mang'isha ya Mato</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>Mang'isha ya Mato</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>Mang'isha ya Mato</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>Zaidi</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>Vipengele ya Miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>Mang'isha ya Miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>Mang'isha ya Miti</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>Unganisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Futa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>Sasafisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>Uwanja</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>Miti hauwezana baada ya kusafisha mang'isha ya miti</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>Kusafisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>Kusafisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>Unganisha kwa njia ya mato</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>Kusafisha kwa njia ya mato</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>Uingi katiwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>Uingi katiwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>Tumaini</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>Pili ya kichwa</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>Mifano wa kichwa katiwe, tumeleka kichwa bila kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>Uingi</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>Pili ya kichwa ya kati</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>Paketi ya katiwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>Mifano wa paketi ya katiwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>Faili katiwe, tumeleka faili bila kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>Haiyo driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>Haiyo kujitambua - haidhiki kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>Ghali ghafla</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>Moduli ya driver katiwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>Formati ya moduli katiwe</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>Moduli ya driver inayotumia mifano</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>Kujitambua Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>Kujitambua Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>Kujitambua Restore</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>Kujitambua Ujumbe</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>Haiyo kujitambua driver kwa kusafisha, tumeleka kujitambua backup kwa kwanza</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>Kunjika Backup Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>Mwaka wa Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>Driver za kusafisha</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>Tazama</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>Kusafisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>Mwongozo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>Kujitambua Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>Kujitambua Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>Kujitambua Restore</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>Hakikishi kubaliwa kwa mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>Hakikishi kubadiliwa kwa mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Hakikishi kubadiliwa: hakuna kufundisha namba ya mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>Tafuta Mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>Kukutsa Mfumo</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Tafuta Yeye</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Kuzalisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopya</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Kwa njia</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>Tafuta Yeye</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>Kuzalisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>Kopya</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>Kubali</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>Tafuta mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>Kukutsa mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Pata kubadilisha kwa kompyuta</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>Kubadili</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>Hakikishi kubadiliwa: hakuna kufundisha namba ya mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>Hakikishi kubadiliwa kwa mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>Hakikishi kubaliwa kwa mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>Tafuta Mfumo</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>Kukutsa Mfumo</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>Mwanaume</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Wanishia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>Versi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>Mato ya BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>Mato ya Picha ya Picha</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>Mato ya Mazingira ya Mwakilishi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>Mato ya Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>Mato ya Array ya Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>Tarehe ya Kusalama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>Makusanyoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>Ukubwa wa Mwakilishi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>Ukubwa wa ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>Mipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>Mipango ya BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>Mipango ya Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>Jina la Mahsula</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>Namba ya Seri</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>Tag ya Asset</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>Mipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>Mkono wa Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>Handle ya Chassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>Mara</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>Handles ya Obje za Kati</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>Mara ya Kusikiliza</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>Namba ya SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>Mifumo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>Kilimo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>Makini ya Ufundi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>Makini ya Uzalishaji wa Jua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>Makini ya Uzalishaji wa Uwanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>Makini ya Uzalishaji wa Uzalishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>Makini ya OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Uwanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>Idadi ya Jua</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>Elementi Zilizokamilishwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Makini ya Uwanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Makini ya Mlango wa Kufanya</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Idadi ya Uwanja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Makini ya Uzalishaji ya Mlango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Idadi ya Mlango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ROMSIZE ya BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Tarehe ya Kukabiliana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Jina la Board</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS Version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>Format ya Ujumbe wa Mlango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>Mlango ya Kukabiliana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>Mlango ya Kukabiliana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD Address</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>Mlango ya Paketi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>Mlango ya Uzalishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>Mlango ya Uzalishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>Mlango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>Mlango ya Uzalishaji</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>Makala ya Mazingira</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>Vesion ya HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>Vesion ya LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>Subversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>Makina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID ya Seria</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>mbunifu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>mavuno</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Imepakia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>Inapakia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>Inapakia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>Inapakia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>Moduli ya Driver</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>Faili ya Makina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>Faili za Makina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>Idadi ya Makina</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>Programu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>Makala ya Uhusiano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>Jina la Logiki</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>Mtu wa Implementer wa CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>Makala ya Architecture ya CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>Varianti ya CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>Moto ya CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>Makala ya Revision ya CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>Mwaka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>Mwaka Mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>Mwaka Nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>Mwaka Saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>Simba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>Ninem</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>Mlioni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>Mlioni mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>Mlioni tatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>Mlioni nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>Mlioni tano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>Mlioni saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>Mlioni saba moja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>Mlioni saba mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>Mlioni saba tatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>Mlioni saba nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>Mlioni tano moja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>Mlioni tano moja moja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>Mlioni tano moja mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>Mlioni tano moja tatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>Mlioni tano moja nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>Mlioni tano moja tano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>Mlioni tano moja tano moja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>Mlioni tano moja tano mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>Mlioni tano moja tano tatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>Mlioni tano moja tano nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>Mlioni tano moja tano tano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>Mlioni tano moja tano tano moja</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>Mlioni tano moja tano tano mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>Mlioni tano moja tano tano tatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>Mlioni tano moja tano tano nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>Mlioni tano moja tano tano tano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>Mwaka wa tano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>Mwaka wa tano kati</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>Sita saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>Sita nane</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>Saba tatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>Saba tatu na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>Saba tatu na nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>Saba tatu na sita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>Saba tatu na saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>Tatu tatu</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>Tatu tatu na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>Tatu tatu na nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>Tatu tatu na sita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>Tatu tatu na saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>Saba tatu na nane</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>Saba tatu na nane na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>Saba tatu na nane na nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>Saba tatu na nane na sita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>Saba tatu na nane na saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>Mojini</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>Mojini na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>Mojini na nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>Mojini na sita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>Mojini na saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>Mojini na kumi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>Mojini na kumi na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>Mojini na kumi na nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>Mojini na kumi na sita</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>Mojini na kumi na saba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>Mojini na kumi na nane</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>Mojini na kumi na nane na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>Mojini na kumi na nane na nne</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>Saha moja na mbili na sero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>Saha moja na mbili na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>Saha moja na tatu na mbili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>Saha mbili na tatu na sero</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>Kapasiti ya GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>Mwakilishi wa GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>Mipango ya GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>Vesion ya EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API za EGL ya mtandaoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>Vesion ya GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>Vesion ya GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>Mwaka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>Mlango wa Hardware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>Hakuna CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>Maktaba ya Mama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>Hakuna maktaba ya mama</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>Hakuna moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>Maktaba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>Hakuna disk</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>Uzalishaji wa driver uliokolekea!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>Tafadhali jaribu tena au kusawanya kwa msaada</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>Uzalishaji wa driver uliokolekea!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>Maktaba ya Sajili</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>Hakuna GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>Monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>Hakuna monitor</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>Maktabi ya Ushari</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>Hakuna maktabi ya ushari</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>Maktabi ya Vichwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>Hakuna mifumo ya vichwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>Hakuna mifumo ya Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>Mifumo ya PCI Nyingine</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>Hakuna mifumo ya PCI nyingine</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>Mipaka</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>Hakuna batari</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>Kibochi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>Hakuna kibochi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>Mikono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>Hakuna mikono</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>Maktabi ya Mafumbo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>Hakuna maktabi ya mafumbo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>Maktabi ya Mafumbo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>Hakuna maktabi ya mafumbo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>Hakuna CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>Mifumo ya Nyingine</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>Hakuna mifumo ya nyingine</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>Maktabi ya Array</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>Moyoni ya Mifumo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>Set</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>Maktabi ya Bank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>Moyoni ya Mifumo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>Namba ya Mifumo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>Rank</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>Uchumi wa Mifumo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Kujifajia ya Udogo wa Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Sensha ya Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>ID ya Mipango wa Mipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>ID ya Mipango wa Mipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>ID ya Mipango wa Mipango wa Udogo wa Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>ID ya Mipango wa Mipango wa Udogo wa Moyo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Udogo wa Moyo wa Kipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Udogo wa Moyo wa Kipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Udogo wa Moyo wa Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Udogo wa Moyo wa Kifajia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>Inchi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Tarehe</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>Ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>Tawi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>Maktaba</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>Jiji ya Kifajia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>Maktaba ya Udogo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>Imeongezwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>Imeongezwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>Imeongezwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>Imeongezwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>Maelezo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>Maelezo ya Udogo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>Udogo</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>Udogo wa Kipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>Udogo wa Kipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>Udogo wa Kipango wa Kifajia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>Udogo wa Kipango</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>Voltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>Mwana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>teknolojia</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>jina ya ikoni</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>versi ya daemon</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>pamoja na baterai</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>mifano wa lid inaonekana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>mifano wa lid inaonekana</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>neno ya kifaa kikubwa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>namba ya nukta</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>kupata kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>kupata kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>wakati wa kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>namba ya kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>wakati wa kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>sababishi ya kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>kifaa kwenye muda</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>mifano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>maraa ya mifano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>maraa ya mifano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>maraa ya mifano</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>هندسة (منطقية)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير الأجهزة هو أداة مفيدة لعرض معلومات الأجهزة وتحييدها.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>موجودات سائق جديدة! قم بتنصيبها أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>شامل المجلدات الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ابحث عن سائق في هذا المسار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 تحديثات سائق متاحة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'وقت التحقق: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل سائق لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تنصيب سائق لـ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 سائق تم تنصيبها، %2 سائق فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 سائق تم تنصيبها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تنصيب السائق</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعة التنزيل: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>سائقك محدث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع السائق</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>إجمالي %1 سائق، منها %2 تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 سائق يمكن نسخها، يُنصح بأن تقوم بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 سائق يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ السائق %1، إجمالي %2 سائق</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'نسخ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 سائق تم نسخها، %2 سائق فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ السائق</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 سائق تم نسخها'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 سائق يمكن استعادتها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار سائق لاستعادته</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver inya inyika...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Inyika: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>kupiga kipande</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Tafadhali %1 kwa kuzalisha driver zilizochaguliwa</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Ona jambini ya kushughalia</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Kushughalia Wote</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>Ona makala ya kuzalisha</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Tafadhali tafadhali kushuka au %1 kwa sababu</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Kuzalisha Wote</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Kushuka kushuga</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Bika</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Kushuga driver zilizochaguliwa za pereti, tafadhali kushuka...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Kushuga %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Kushuga kipande</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Tarehe ya kipande</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Tafadhali tafadhali kushuka kipande</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Tafadhali tafadhali kushuka kushuga au %1 kwa sababu</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>Unayozalisha driver, kipande ina kushuka kipande kama unapakua kipande.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Ukamotambua kipande kipande?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Kipande</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Bika</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>Unayoshausha driver, kipande ina kushuka kipande kama unapakua kipande.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>Unayoinyika driver, kipande ina kushuka kipande kama unapakua kipande.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Adapter ya Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Pereti ya imaji</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Adapter ya kushughalia</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Kipande cha soni</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Adapter ya tarehe</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Adapter ya tarehe ya kipande</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Kuzalisha kipande</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>Ushindani wa kufaniki</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>Kutangaza</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>Kufaniki</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>Hapana kufaniki</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>Pelepele</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>Kutangaza</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>Hapana kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>Kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>Ushindani wa kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>Ushindani wa kujitambua kwa muda</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>Kutambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>Safu ya kosa</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>Kosa ya tawi</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>Ukambo</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>Hapana kujitambua faili ya driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>Kutambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>Kujitambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>Kutambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>Kufaniki</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>Kufuta</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>Kutambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>Kutangaza</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>Kutambua driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>Kufuta driver</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>Oneshia kujitambua kompyuta</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>Kifuta</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>Kutambua</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>Kutangaza</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>Kukopia</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>Kufuta</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>Haplo</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>Tumia kifalini cha michezo</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>Inyango...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ta.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ta.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ta">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>மேலும் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>சரி</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>மேலும்</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>முடிவில் நெட்வொர்க்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>மீண்டும் பொருத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>மேலும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>குறைக்க</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>தடை</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>முறிவுறுத்தலாம்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>அமைப்பு பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>வணிக நிறுவனம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>சிப்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>முடிவுறுத்தலாம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>சிஸ்எஃப்ஸ் பாத்தை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>முறைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>கர்னல் மோட் டிரைவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>குறிப்பிட்ட நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>ஐ.ஆர்.கே</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>முறிவுறுத்தலாம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>தடை</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>வணிக நிறுவனம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>வணிக நிறுவனம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>சிப்செட்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>உறுதிப்படுத்தல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>தயாரிப்பாளர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>மிகை சக்தி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>தயாரிப்பாளர் பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>தயாரிப்பாளர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>முடிவுகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>விதி பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>மெக் அட்டைக்குறியீடு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>தரவு கிடைக்காது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>தடுக்க</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>தயாரிப்பாளர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>முடிவுகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>தயாரிப்பாளர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>மிகை சக்தி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>தரவு கிடைக்காது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>தடுக்க</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>தயாரிப்பாளர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>சிபியூ ஐ.டி.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>கோர் ஐ.டி.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>தேடல்கள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>போகோமிப்ஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>அமைப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>சிபியு குடும்பம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>செயலியை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>கோர்(கள்)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>விண்ட்யூவலிசேஷன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>பிளாக்ஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>எக்ஸ்டன்ஷன்ஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>L3 கேச்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>L2 கேச்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>L1i கேச்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>L1d கேச்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>ஸ்டிப்பிங்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>மூலம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>மெக்சிமம் ஸ்பீட்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>வெண்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>வேர்சன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>கிராஃபிக்ஸ் மெமரி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ஃபிசிகல் ஐடி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>மெமரி ஆட்டோ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>ஐ.ஓ. போர்ட்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>மெக்சிமம் ரீசல்யூஷன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>மினிமம் ரீசல்யூஷன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>தற்போதைய ரீசல்யூஷன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>டிரைவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>விவரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>டிபி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>டிபி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>एचडीएम</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>वीजीए</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>டிவி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>திரைக்காட்சி வெளியீடு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>திரைக்காட்சி வெளியீடு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>முடிவுகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>ஐ.ஆர.க்கே</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>கிடைக்காத</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>வாட்மன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>மிகை ஆற்றல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>டிரைவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>முடிவுகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>தொடர் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>கிடைக்காத</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>தடு</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>வாட்மன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>தொடர்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>மிகை தொடர்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>டிரைவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>முடிவகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>முறிவடைந்துள்ளது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>தடு</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>மொத்த காட்சி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>சிப்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>சிப் அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>மாதர்போர்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>கிளாசிக்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>காட்சி ஏற்றுமதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>சூடு ஏற்றுமதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>மேலோடு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>மற்ற பிசிபி பொருட்கள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>மின்னாற்றல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>பிளூடூத்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>நெட்வொர்க் ஏற்றுமதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>மௌச்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>கீப்போர்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>மானிட்டரு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>சி.டி.ஆர்.ஒ.ம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>பிரிண்டரு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>கேமரா</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>மற்ற பொருட்கள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>பொருட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ஓ.எஸ்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>வணிகர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>மொத்த அகலம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>நிலைநிர்ணயம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>சீரியல் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>அமைக்கப்பட்ட மின்னழுத்தம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>அதிகபட்ச மின்னழுத்தம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>குறைந்தபட்ச மின்னழுத்தம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>அமைக்கப்பட்ட வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>தரவு அகலம்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>வணிகர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>காட்டு கொடுக்கும் வழிமுறை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>அணுகுமுறை வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>அதிகபட்ச பகுதி தீர்மானம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>தற்போதைய பகுதி தீர்மானம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>காட்டு விகிதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>முதன்மை காட்டும் சாதனம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>சீரியல் எண்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>வணிகர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>முடிவுறு திறன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>தூண்டும் நிரல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>தூண்டும் நிரல் பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>அதிகபட்ச வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>விருப்பம் வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>போர்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>மல்டிகாஸ்ட்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>காணொளி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>கால தாமதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>ஐபிபி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>பிரோகிராம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>டப்ளெக்ஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>பிராட்காஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>ஏ.என். ஆட்டோ போட்டி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>கிடைமை முகவரி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ஐ.ஆர்.கே</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>மே.சி. முகவரி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>விரிவாக்கப்பட்ட பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>கிடைக்காத</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>தடுக்க</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>வாட்மேன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>உள்ளீடு/வெளியீடு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>கிடைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ஐ.ஆர்.கே</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>கால தாமதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>டிரைவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>முடிவுறு திறன்கள்</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>வாட்மேன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>பஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>முabilitிகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>டிரைவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>மீப்பெரும் பவர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>சீரியல் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>மாறாமல் இருக்கிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>தடை</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>வெண்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>சீரியல் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>கேபாசிடி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>வோல்டேஜ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>சால்ட்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>டிசைன் கேபாசிடி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>டிசைன் வோல்டேஜ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>எஸ்.பிடிஎஸ் வேர்சன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>எஸ்.பிடிஎஸ் சீரியல் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>எஸ்.பிடிஎஸ் மேனுஃபேக்ச்சர் தேதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>எஸ்.பிடிஎஸ் கீமியாலஜி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>தாபத்தை</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>மாடல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>வெண்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>சீரியல் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>ஈ-பை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>ஈ-ஆர்ஆய்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>முகப்பு வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>தடு</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>விண்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>மீடியா வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>தலைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>முடிவுகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>ஃபியர்ம்வேர் தலைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>வேகம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>விவரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>அடையாள எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>முகப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>துருவல் வீதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>கிடைக்காத</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>புதுப்பிக்க ஒரு டிரைவரை தேர்ந்தெடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>இந்த குழாரில் டிரைவர் கிடைக்கவில்லை</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>ஒலி உபகரணம் தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>BIOS தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>டிசி-ரோம் தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>தேய்மான் அமைப்பு தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>சிபியூ தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>மற்ற உபகரணங்கள் தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>மின்னழைத்தல் தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>பிரிண்டர் தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>மூச்சு உபகரணம் தகவல் பதிவேற்றம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>நெட்வேர்க் ஏடாப்டர் தகவல் பதிவேற்றம்...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>தடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>கிடைக்காத</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>தடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>கிடைக்காத</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>அங்கீகரிக்கப்பட்ட பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>குறியீடுகளை காட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>மூடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>துணை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>காப்பி</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>முக்கியது</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>முன்னேற்று</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>திருத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>அங்கீகரிக்கப்பட்ட மேலாண்மை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>மெக்கானிக்கல்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>போர்ட்ஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>நிர்க்கண்ணி</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>மெய்ப்பார்வை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>காட்டு பொருளாக்கம்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>சிபியூ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>நெட்வொர்க் பொருளாக்கம்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>உற்ப்பாக்கம்</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>மேலும்</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>போர்ட் platform பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>பேக்கப் செய்யக்கூடிய போர்ட்ஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>பேக்கப் செய்யப்பட்ட போர்ட்ஸ்</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>தொடர்ந்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>அடுத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>எச்சரிக்கை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>போர்ட் நீக்கம் பின்னர் இந்த பொருள் பயன்பாட்டிற்கு கிடைக்காது</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>நீக்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>நீக்குகிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>பதிப்பு வெற்றிகண்டது</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>நீக்கம் வெற்றிகண்டது</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>பேருறுப்பு வெற்றியின்றி</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>களவுறுப்பு வெற்றியின்றி</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>சரி</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>அடுத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>தேர்ந்தெடுத்த குறிப்பிட்ட மென்பொருள் இல்லை, மீண்டும் தேர்ந்தெடுக்கவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>பேருறுப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>முந்தையும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>தீநீர்ப்பொருள்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>தொடர்புடைய பொருள் மேலோட்டம் பொருந்தவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>தேர்ந்தெடுத்த பெயர் கொண்ட குறிப்பிட்ட மென்பொருள் இல்லை, மீண்டும் தேர்ந்தெடுக்கவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>இது ஒரு தூண்டியல்ல</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>மென்பொருளை பேருறுப்பு செய்ய முடியவில்லை - ஆட்டோமேட்டிக் கோடிட்டியில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>தெரியாத பிழை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>தூண்டி மாட்யூல் கண்டுபிடிக்க முடியவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>தவறான மாட்யூல் வடிவமைப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>தூண்டி மாட்யூல் தொடர்புடைய பொருள்களை கொண்டுள்ளது</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>தூண்டி பேருறுப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>தூண்டி பின்புலம்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>தூண்டி மீட்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>வினைகள்</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>நீங்கள் மீட்பதற்கு தூண்டிகளை கொண்டிருக்க முடியவில்லை, முதலில் பின்புலம் செய்யவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>பின்புலம் தூண்டிக்கு செல்லவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>பின்புலம் பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>மீட்பதற்கு தூண்டிகள்</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>புதுப்பிக்கவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>தொகுப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>மென்பொருள் முக்கியமான தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>தூண்டி பேருறுப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>தூண்டி பின்புலம்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>தூண்டி மீட்பு</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>அந்த உபகரணத்தை செயல்படுத்த முடியவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>அந்த உபகரணத்தை நிருப்ப முடியவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>அந்த உபகரணத்தை நிருப்ப முடியவில்லை: உபகரணத்தின் SN பெற முடியவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>செயலியின் கருவிகளை மேம்படுத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>செயலியின் கருவிகளை நிறுவ வேண்டாம்</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>மறுபரிசீலனை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ஏக்கரணத்திற்கு போக</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>கொடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>மொத்தம்</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>மறுபரிசீலனை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ஏக்கரணத்திற்கு போக</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>கொடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>தொடங்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>கருவிகளை மேம்படுத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>கருவிகளை நிறுவ வேண்டாம்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>அதனை கணினி மூடப்பட்ட நிலையில் வெளியே கொண்டு வர அனுமதிக்க</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>தடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>அந்த உபகரணத்தை தடுக்க முடியவில்லை: உபகரணத்தின் SN பெற முடியவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>அந்த உபகரணத்தை நிருப்ப முடியவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>அந்த உபகரணத்தை செயல்படுத்த முடியவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>கருவிகளை மேம்படுத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>கருவிகளை நிறுவ வேண்டாம்</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>முதன்மை தயாரிப்பாளர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>முதன்மை உபகரணம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>கருவி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>கருவி நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>கருவி செயல்படுத்தும் கட்டளை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>மாற்றங்கள் நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>தாமதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>இயற்கை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>சிஸ்பிஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>ஹெண்ட்லர்ஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>ப்ராப்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ஈவ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>கேய்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>பதிவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>பஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>பியோஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>பேஸ் போர்ட் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>சிஸ்டம் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>சேஸ்சிஸ் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>பொறுத்த மெமரி அரியா</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>வெளியீடு தேதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>அதிர்வு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>ரன்டைம் அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ஆர்ஓஎம் அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>விளக்கம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>பியோஸ் பதிவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>ஃபியர்ம்வே어் பதிவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>பொருள் பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>சீரியல் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ஆசெட் டேக்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>முக்கியத்துவம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>சேஸ்சிஸ் மேல் இடம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>சேஸ்சிஸ் கைதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>கைதி உள்ள பொருள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>வேக்-அப் வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>ச்கூ எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>தொடர்ச்சி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>காவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>தொடர்பு நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>மின்சார நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>தாபன நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>மீன்மை நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>வாடிக்கையாளர் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>மெருகு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>மின்சார கம்பிகளின் எண்ணிகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>கொண்டுள்ள உறுப்புகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>இடம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>தவறு சீரமைப்பு வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>மிகப்பெரிய திறன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>தவறு தகவல் கையே hold</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>அமைப்புகளின் எண்ணிகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>வெளியீடு தேதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>பீட் பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS வெர்சன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>மொழி விவரம் வடிவமைப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>மின்னஞ்சல் மொழிகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>தற்போது பொருத்தப்பட்ட மொழி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD முகவை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>பேக்கெட் வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>காணிக்கை விதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>காணிக்கை திசை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>குறிப்பிட்ட சிறப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>மேல்நிலை சிறப்புகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>அந்த கருவி பகுப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>HCI பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>LMP பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>சப்பர்வர்ஷன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>கருவி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>சீரியல் ஐ.டி.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>பொருள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>விவரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>மின்சாரம் பெற்ற</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>கண்டுபிடிக்க முடியும்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>உரிமையுடைய</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>மோடலியஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>கண்டுபிடித்து வருகிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>செயலியக்க பகுப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>கருவி காணொ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>கருவி காணொகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>கருவி எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>விண்டோஸ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>தர்க்க பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ANSI பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU அமலாக்கிய</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU அமைப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU திசை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU பகுதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU மாற்றம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>ஒன்று</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>நாற்று</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>நூறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>பத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>இருபத்து இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>பத்து நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>பத்து ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>பத்து எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>இருபது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>இருபது இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>இருபது நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>இருபது ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>இருபது எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>மூன்று பத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>மூன்று பத்து இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>மூன்று பத்து நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>மூன்று பத்து ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>மூன்று பத்து எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>நாற்பது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>நாற்பது இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>நாற்பது நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>நாற்பது ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>நாற்பது எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>ஐம்பது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>ஐம்பது இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>ஐம்பது நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ஐம்பது ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ஐம்பது எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>அறுபது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>அறுபது இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>அறுபது நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>நாற்பத்து ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>நாற்பத்து எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>ஏழுபது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>ஏழுபத்து இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>ஏழுபத்து நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>ஏழுபத்து ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>ஏழுபத்து எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>எண்பது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>எண்பத்து இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>எண்பத்து நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>எண்பத்து ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>எண்பத்து எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>தொண்ணூறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>தொண்ணூற்று இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>தொண்ணூற்று நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>தொண்ணூற்று ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>தொண்ணூற்று எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>ஒன்று பத்து</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>ஒன்று பத்து மற்றும் இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>ஒன்று பத்து மற்றும் நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>ஒன்று பத்து மற்றும் ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>ஒன்று பத்து மற்றும் எட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>ஒன்று பத்து மற்றும் பதினாறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>ஒன்று பத்து மற்றும் பன்னிரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>ஒன்று பத்து மற்றும் பன்னிரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>ஒன்று பத்து மற்றும் பன்னிருபது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>ஒன்று பத்து மற்றும் பதினெட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>ஒன்று பத்து மற்றும் இருபது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>ஒன்று பத்து மற்றும் இருபத்து இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>ஒன்று பத்து மற்றும் இருபத்து நான்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>நூறு மற்றும் இருபத்து இரண்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>நூறு மற்றும் இருபத்து ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>நூறு மற்றும் தொ192</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>இருநூறு மற்றும் ஐம்பத்து ஆறு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>GDDR கூடுதல் திறன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU தயாரிப்பாளர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL குடியேற்ற பயனர் பொருட்கள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>அறியப்படாதது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>ஒருமுறை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>கணினி வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>சிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>சிப்பு காணவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>மோதர்போர்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>மோதர்போர்டு காணவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>கிளைட்டு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>கிளைட்டு காணவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>மேம்பாடு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>டிஸ்க் காணவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>வேரியூன் மீட்டரிச்சு தோல்வியடைந்தது!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>மீண்டும் முயற்சிக்கவும் அல்லது நமக்கு கருத்து கூறவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>வேரியூன் பேக்கப் தோல்வியடைந்தது!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>காட்டு பொருட்செல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>கேயு காணவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>மானிடர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>மானிடர் காணவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>நெட்வொர்க் அடப்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>நெட்வொர்க் அடப்டர் காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>சவுண்ட் அடப்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>ஒலிப்பெட்டி காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>பிளூடூத்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>பிளூடூத் பெட்டி காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>மற்ற PCI பெட்டிகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>மற்ற PCI பெட்டிகள் காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>மின்சாரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>உறைவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>கீரோட்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>கீரோட் காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>மௌச்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>மௌச் காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>பிரிண்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>பிரிண்டர் காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>கேமரா</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>கேமரா காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>சிட் ரோம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>சிட் ரோம் காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>மற்ற பெட்டிகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>மற்ற பெட்டிகள் காணப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>அரே கைல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>படிமம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>செட்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>பான்க் லொகேட்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>தொழில்நுட்ப விவரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>பார்ட் எண்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>ரேங்க்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>மெமரி தொழில்நுட்பம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>மெமரி ஓப்பரேட்டிங் மோட் கேபாசிட்டி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>ஃபியர்ம்வேர் வெர்சன்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>மாடுல் மேனுஃபேக்டர் ஐ.டி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>மாடுல் பிரோடக்ட் ஐ.டி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>மெமரி ஸப்ஸிஸ்டம் கன்ட்ரோலர் மேனுஃபேக்டர் ஐ.டி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>மெமரி ஸப்ஸிஸ்டம் கன்ட்ரோலர் பிரோடக்ட் ஐ.டி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>நான்-வோலட்டில் பரிமாணம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>வோலட்டில் பரிமாணம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>கேச் பரிமாணம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>லாஜிக்கல் பரிமாணம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>இன்ச்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>தேதி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ஐ.ஓ.போர்ட்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>நெட்வொர்க்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>பேட்டரி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>நேடிவ்-பாதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>பவர் சப்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>புதுப்பிக்கப்பட்ட</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>தொலைவின் வரலாறு இருக்கிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>தகவல் தொகுப்பு இருக்கிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>திரும்பி சார்ஜ் செய்யக் கூடிய</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>நிலை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>வார்னிங்-லெவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>ஆற்றல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>ஆற்றல் காலியாக</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>ஆற்றல் நிரம்பியாக</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>ஆற்றல் நிரம்பிய வடிவமைப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>ஆற்றல் வீதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>வோல்டேஜ்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>சதவீதம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>தொழில்நுட்பம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>மென்மேலும் பெயர்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ஆன்லைனில்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>டேமன் பதிப்பு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>அடிப்படை பேட்டரி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>பைப்பில் மூடிக் கொண்டிருக்கிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>பைப்பில் உள்ளது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>முக்கிய செயல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>கோப்புகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>முறையான வேலை தவிர்க்க</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>வேலை தாங்கி இருக்க வேண்டும்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>வேலை முக்கியத்துவம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>மார்க்கர் மாற்று நேரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>நம்பர்-அப்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>வினைமுறை கோரப்பட்டது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>பிரிண்ட் நிற முறை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>பிரிண்டர் வேலைகளை ஏற்றுக்கொண்டிருக்கிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>பிரிண்டர் பகிரப்பட்டிருக்கிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>பிரிண்டர் தாவரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>பிரிண்டர் தயாரிப்பு மற்றும் மாதிரி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>பிரிண்டர் நிலை மாற்று நேரம்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>பிரிண்டர் நிலை காரணிகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>பிரிண்டர் வகை</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>பிரிண்டர் URI ஆதரிக்கப்பட்டது</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>பக்கங்கள்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>எச்சிடி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>எச்சிடி</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>பேச் தகவல்</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>வினைமுறை செக்டர் அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>செக்டர் அளவு</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>கு.ஐ.டி.</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>வடிவமைப்பு (வாழியான)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>அமைப்பு மேலாண்மை</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>அமைப்பு மேலாண்மை கணினி அமைப்பு தகவல்களை பார்க்கவும் அமைப்புகளை மேலாண்மை செய்யவும் உதவும் ஒரு பயனுள்ள கருவி</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>புதிய அமைப்பு தொடர்பான விரிவுரைகள் கிடைக்கின்றன! அவற்றை இப்போது பதிவிறக்கவும் அல்லது மேம்பட உதவவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>காண்க</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>அடுத்த கூட்டுப்பத்திரிகளை உள்ளடக்கு</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>இந்த பாதம் மூலம் அமைப்பு தொடர்பான விரிவுரைகளை தேடு</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 விரிவுரை அப்டேட்கள் கிடைக்கின்றன'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'சோதனை நேரம்: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 விரிவுரைகளை பதிவிறக்குகின்றன... </translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'பதிவிறக்க வேகம்: %1 பதிவிறக்கம் %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 விரிவுரைகளை பதிவிறக்குகின்றன... </translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 விரிவுரைகள் பதிவிறக்கம், %2 விரிவுரைகள் தோல்வியடைந்தன'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 விரிவுரைகள் பதிவிறக்கம்'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>விரிவுரைகளை பதிவிறக்க வேண்டும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>மென்பொருள் பிழை. மீண்டும் இணைக்கலாம்...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'பதிவிறக்க வேகம்: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>உங்கள் விரிவுரைகள் புதியதாக உள்ளன</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>அனைத்து விரிவுரைகளும் புதுப்படுத்தப்பட்டுள்ளன</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 விரிவுரைகள் மொத்தமாக உள்ளன, அவற்றில் %2 புதுப்படுத்தப்பட்டுள்ளன</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>%1 விரிவுரைகள் புதுப்படுத்த முடியும், இதை இப்போது செய்ய பரிந்துரைக்கப்படுகிறது</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>%1 விரிவுரைகள் புதுப்படுத்த முடியும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 விரிவுரையை புதுப்படுத்துகின்றன, மொத்தமாக %2 விரிவுரைகள்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'புதுப்படுத்துகின்றன: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 விரிவுரைகள் புதுப்படுத்தப்பட்டுள்ளன, %2 விரிவுரைகள் தோல்வியடைந்தன'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>விரிவுரைகளை புதுப்படுத்த வேண்டும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 விரிவுரைகள் புதுப்படுத்தப்பட்டுள்ளன'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>%1 விரிவுரைகள் மீட்பு முடியும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>மீட்பு மூலம் ஒரு விரிவுரையை தேர்வு செய்யவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>தேர்வு செய்யப்பட்ட டிரைவர் மீட்டரிக்கிறது...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>மீட்டரிப்பு: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>ரீபூட்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>முற்றிலும் டிரைவர் மீட்டரிப்பு மீண்டும் பயன்படுத்தப்பட வேண்டும் %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>பின்புற மாற்று மாற்று பாதையை பார்க்கவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>அனைத்தையும் பின்புறம் செய்யவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>மீட்டரிப்பு கருத்துகளை அனுப்பவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>முற்றிலும் மீண்டும் முயற்சி செய்யவும் அல்லது %1 என்று நாங்களுக்கு அனுப்பவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>அனைத்தையும் நிறுவவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>மீண்டும் சென்னில்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>தவறாக</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>கணினி செயலியின் டிரைவர்களை மீட்டரிப்பு செய்கிறது, போதுமான நேரம் காத்திருக்கவும்...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>மீட்டரிப்பு %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>மீட்டரிப்பு தோல்வியடைந்தது</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>நெட்வேர் கிடைக்கவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>நான் நெட்வேர் இணைப்பை சரிபார்க்கவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>முற்றிலும் மீண்டும் மீட்டரிப்பு செய்யவும் அல்லது %1 என்று நாங்களுக்கு அனுப்பவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>நீங்கள் ஒரு டிரைவரை நிறுவுகிறீர்கள், நீங்கள் விடுவிக்கிறது என்றால் அது தொங்கிப்போகும்.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>நீங்கள் விடுவிப்பதை உறுதிப்படுத்துகிறீர்களா?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>விடுவிக்கவும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>தவறாக</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>நீங்கள் டிரைவர்களை பின்புறம் செய்கிறீர்கள், நீங்கள் விடுவிப்பது என்றால் அது தொங்கிப்போகும்.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>நீங்கள் டிரைவர்களை மீட்டரிப்பு செய்கிறீர்கள், நீங்கள் விடுவிப்பது என்றால் அது தொங்கிப்போகும்.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>பிளூடூத் அடப்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>படமெட்டிரிக்கின் உபகரணம்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>காட்டு அடப்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>சவுண்ட் கார்ட்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>நெட்வேர் அடப்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>இணையமில்லா நெட்வேர் அடப்டர்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>நிறுவல் வெற்றியுடன் முடிந்தது</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>மிக்கை நிலைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>மின்னணி பெறுதல்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>மிக்கை நிலைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>மிக்கை நிலைமை இல்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>மிக்கை நிலைமை பழையது</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>உள்ளீடு பெறுதல்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>பிரதிப்பொருள் செய்யப்படவில்லை</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>பிரதிப்பொருள் செய்யும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>பிரதிப்பொருள் மிக்கை நிலைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>பிரதிப்பொருள் வெற்றிக்கண்ட</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>பிரதிப்பொருள் மீட்கும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>தெரியாத பிழை</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>நெட்வேர் பிழை</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>தொடர்பு நீக்கப்பட்டது</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>செயலாக்க கையேடு பெற மிக்கை நிலைமை</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>புதுப்பிக்க</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>பிரதிப்பொருள்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>மீட்க</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>மிக்கை</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>தடை</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>புதுப்பிக்க</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>முகவரியில் பெறுதல்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>செயலாக்க கையேடு புதுப்பிக்க</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>செயலாக்க கையேடு நீக்கும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>கணினி மூச்சு முடக்கும்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>மீண்டும் தொடங்க</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>புதுப்பிக்க</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>முகவரியில் பெறுதல்</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>கொட்டி</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>தடை</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>மாற்று வழியில்லை</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>மையக் கோப்பை தேர்வு செய்யவும்</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>கொண்டு வருகிறது...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_th.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_th.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="th">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>ข้อเสนอแนะ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ตกลง</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>เพิ่มเติม</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>แจ้งเตือนเครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>ติดตั้งใหม่</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>เพิ่มเติม</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>ยุบ</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ชื่ออุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>ชิป</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>เส้นทาง SysFS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>Driver แบบ KernelMode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>ที่อยู่หน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>ชิปเซ็ต</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>ชื่อเล่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>พลังงานสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>เวอร์ชันไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลเส้นทางการสื่อสาร</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>ชื่อทางตรรกะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>ที่อยู่ MAC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลเส้นทางการสื่อสาร</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>พลังงานสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>รหัส CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>รหัสแกน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>เส้นใย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>บอโกมิปส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>สถาปัตยกรรม</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>ครอบครัว CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>โมเดล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>โปรเซสเซอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>คอร์ (ตัว)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>การเสมือนจริง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>แฟลกส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>การขยาย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>แคช L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>แคช L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>แคช L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>แคช L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>สตีปปิ้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>ความเร็วสูงสุด</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>โมเดล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>หน่วยความจำกราฟิก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>ID กายภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>ที่อยู่หน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>พอร์ต I/O</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>ความละเอียดสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>ความละเอียดต่ำสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>ความละเอียดปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>คำอธิบาย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>พอร์ตแสดงผลดิจิทัล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>การแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลสายหลัก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>กำลังไฟฟ้าสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>ไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>หมายเลขลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>อินเทอร์เฟซ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลสายหลัก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>กระแสไฟฟ้าสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ไดรฟ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>ภาพรวม</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>ซีพียู</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>จำนวนซีพียู</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>เมนบอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>หน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>แอดAPTERการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>แอดAPTERเสียง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>การจัดเก็บข้อมูล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>อุปกรณ์ PCI อื่นๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>แบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>บลูทูธ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>แอดAPTERเครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>เมาส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>คีย์บอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>จอภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>ดีวีดี</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>เครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>กล้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>อุปกรณ์อื่นๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>อุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>ระบบปฏิบัติการ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>ขนาด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>ความกว้างทั้งหมด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>ตำแหน่ง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>แรงดันที่กำหนด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>แรงดันสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>แรงดันต่ำสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>ความเร็วที่กำหนด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ความกว้างข้อมูล</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>อินพุตการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>ประเภทอินเทอร์เฟส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>ความละเอียดที่รองรับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>ความละเอียดปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>อัตราส่วนการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>จอหลัก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>ขนาด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลสายส่ง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>เวอร์ชันไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>อัตราสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>อัตราการต่อรอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>พอร์ต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>มัลทิแคสต์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>ลิงค์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>เวลาตอบสนอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>ไอพี</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>เฟิร์มแวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>ดัปเลย์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>บราเดิร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>อัตโนมัติในการเจรจา</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>ที่อยู่หน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>ไออาร์คิว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>ที่อยู่แมค</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>ชื่อทางตรรกะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>การนำเข้า/ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>หน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>ไออาร์คิว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>เวลาตอบสนอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>ข้อมูลบัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>กำลังไฟฟ้าสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ซีเรียล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>ไม่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ซีเรียล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>สถานะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>กำลังการผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>แรงดัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>สล็อต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>กำลังการผลิตตามการออกแบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>แรงดันตามการออกแบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>เวอร์ชัน SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>เลขที่ซีเรียล SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>วันที่ผลิต SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>เคมีส่วนประกอบ SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>อุณหภูมิ</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>รุ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ซีเรียล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>แบ่งปัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>สถานะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>ประเภทอินเทอร์เฟซ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>ผู้ผลิต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>ประเภทสื่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>ขนาด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>ความสามารถ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>เวอร์ชันเฟิร์มแวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>ความเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>คำอธิบาย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>อินเทอร์เฟซ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>อัตราการหมุน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>เลือกไดรเวอร์สำหรับการอัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>ไม่พบไดรเวอร์ในโฟลเดอร์นี้</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>กำลังโหลดข้อมูลอุปกรณ์เสียง...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>กำลังโหลดข้อมูล BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>กำลังโหลดข้อมูล CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>กำลังโหลดข้อมูลระบบปฏิบัติการ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>กำลังโหลดข้อมูล CPU...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>กำลังโหลดข้อมูลอุปกรณ์อื่นๆ...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>กำลังโหลดข้อมูลพลังงาน...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>กำลังโหลดข้อมูลเครื่องพิมพ์...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>กำลังโหลดข้อมูลเมาส์...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>กำลังโหลดข้อมูลการ์ดเครือข่าย...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ข้อมูลอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>แสดงสั้น ๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>ปิด</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>ช่วยเหลือ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>ระบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>จัดการอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>ฮาร์ดแวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>จอภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>ภาพรวม</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>แอดAPTERจอภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>ซีพียู</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>แอดAPTERเครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>แบตเตอรี่</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>เพิ่มเติม</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>เวอร์ชันแพลตฟอร์มไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>ไดรเวอร์สำรองได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>ไดรเวอร์ที่ถูกสำรองแล้ว</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>กำลังอัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ยกเลิก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>ต่อไป</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>เตือน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>อุปกรณ์จะไม่สามารถใช้งานได้หลังจากถอนไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>ถอน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>กำลังถอน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>อัปเดตสำเร็จ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>การถอนสำเร็จ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>การอัปเดตล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>การติดตั้งล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ตกลง</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>ถัดไป</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>โฟลเดอร์ที่เลือกไม่มีอยู่ กรุณาเลือกอีกครั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>ก่อนหน้า</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>แพ็กเกจเสียหาย</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>สถาปัตยกรรมแพ็กเกจไม่ตรงกัน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>ไฟล์ที่เลือกไม่มีอยู่ กรุณาเลือกอีกครั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ไม่ใช่ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>ไม่สามารถติดตั้งได้ - ไม่มีลายเซ็นดิเจียล</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>ข้อผิดพลาดไม่ทราบ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>โมดูลไดรเวอร์ไม่พบ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>รูปแบบโมดูลไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>โมดูลไดรเวอร์มีขึ้นอยู่กับสิ่งอื่น</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ติดตั้งไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>สำรองไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>กู้คืนไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>ข้อเสนอแนะ</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>คุณไม่มีไดรเวอร์ใด ๆ ที่สามารถกู้คืนได้ กรุณาสำรองก่อน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>ไปยังการสำรองไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>เวอร์ชันสำรอง</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>ไดรเวอร์ที่สามารถกู้คืนได้</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>ภาพรวม</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ติดตั้งไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>สำรองไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>กู้คืนไดรเวอร์</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>ไม่สามารถเปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>ไม่สามารถปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ไม่สามารถปิดใช้งานได้: ไม่สามารถดึงข้อมูล SN ของอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>ภาพรวม</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>เปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>อนุญาตให้อุปกรณ์สามารถตื่นเครื่องได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>ไม่สามารถปิดใช้งานได้: ไม่สามารถดึงข้อมูล SN ของอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>ไม่สามารถปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>ไม่สามารถเปิดใช้งานอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>ผู้ผลิตย่อย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>อุปกรณ์ย่อย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>สถานะไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>คำสั่งการเปิดใช้งานไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>สถานะการตั้งค่า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>ความล่าช้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>กายภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>Handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>เวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>บัส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>ข้อมูล BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>ข้อมูลแผ่นฐาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>ข้อมูลระบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>ข้อมูลตู้เครื่อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>ชุดความจำทางกายภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>วันที่วางจำหน่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>ที่อยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>ขนาดการทำงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>ขนาด ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>คุณสมบัติ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>เวอร์ชัน BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>เวอร์ชันซอฟต์แวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>ชื่อผลิตภัณฑ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>เลขที่ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>ป้ายกำกับทรัพย์สิน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>คุณสมบัติ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>ตำแหน่งในตู้เครื่อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>ตัวควบคุมตู้เครื่อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>ตัวควบคุมวัตถุที่บรรจุอยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>ประเภทการตื่นขึ้น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>เลขที่ SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>วงศ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>ล็อก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>สถานะการเปิดเครื่อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>สถานะแหล่งจ่ายไฟ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>สถานะความร้อน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>สถานะความปลอดภัย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>ข้อมูลผู้ผลิตภัณฑ์ (OEM)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>ความสูง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>จำนวนสายไฟ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>องค์ประกอบที่บรรจุอยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>ตำแหน่ง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>ประเภทการแก้ไขข้อผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>ความจุสูงสุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>ตัวจัดการข้อมูลข้อผิดพลาด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>จำนวนอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>ขนาด BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>วันที่วางจำหน่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>ชื่อแผ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>เวอร์ชัน SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>รูปแบบการอธิบายภาษา</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>ภาษาที่ติดตั้งได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>ภาษาที่ติดตั้งอยู่ในปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>ที่อยู่ BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ขนาด MTU ACL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>ขนาด MTU SCO</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>ประเภทแพ็กเกจ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>นโยบายการเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>โหมดการเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>คลาส</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>คลาสบริการ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>ประเภทอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>เวอร์ชัน HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>เวอร์ชัน LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>ย่อยเวอร์ชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>อุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>สินค้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>คำอธิบาย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>ได้รับพลังงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>ค้นหาได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>สามารถจับคู่ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>Modalias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>กำลังค้นหา</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>โมดูลไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ไฟล์อุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ไฟล์อุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>เลขที่อุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>แอปพลิเคชัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>สถานะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>ชื่อทางตรรกะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansiversion</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>ผู้ดำเนินการ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>สถาปัตยกรรม CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>รุ่น CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>ส่วน CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>เวอร์ชัน CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>หนึ่ง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>สอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>สี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>หก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>แปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>เก้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>สิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>สิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>ยี่สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>ยี่สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>ยี่สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>ยี่สิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>ยี่สิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>สามสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>สามสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>สามสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>สามสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>สามสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>สี่สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>สี่สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>สี่สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>สี่สิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>สี่สิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>ห้าสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>ห้าสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>ห้าสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>ห้าสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>ห้าสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>หกสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>หกสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>หกสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>หกสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>หกสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>เจ็ดสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>เจ็ดสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>เจ็ดสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>เจ็ดสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>เจ็ดสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>แปดสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>แปดสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>แปดสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>แปดสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>แปดสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>เก้าสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>เก้าสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>เก้าสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>เก้าสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>เก้าสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>หนึ่งร้อย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>หนึ่งร้อยสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>หนึ่งร้อยสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>หนึ่งร้อยหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>หนึ่งร้อยแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>หนึ่งร้อยสิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>หนึ่งร้อยสิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>หนึ่งร้อยสิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>หนึ่งร้อยสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>หนึ่งร้อยสิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>หนึ่งร้อยยี่สิบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>หนึ่งร้อยยี่สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>หนึ่งร้อยยี่สิบสี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>หนึ่งร้อยยี่สิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>หนึ่งร้อยยี่สิบแปด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>หนึ่งร้อยยี่สิบสอง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>สองร้อยห้าสิบหก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>ความจุ GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>ผู้ผลิต GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>ประเภท GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>เวอร์ชัน EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>API EGL ลูกค้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>เวอร์ชัน GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>เวอร์ชัน GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>ไม่ทราบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>Uniq</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ประเภทฮาร์ดแวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>ไม่พบ CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>เมนบอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>ไม่พบเมนบอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>หน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>ไม่พบหน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>พื้นที่จัดเก็บ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>ไม่พบดิสก์</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>การกู้คืนไดรเวอร์ล้มเหลว!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>กรุณาลองอีกครั้งหรือให้ข้อเสนอแนะกับเรา</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>การสำรองข้อมูลไดรเวอร์ล้มเหลว!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>แอดAPTERการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>ไม่พบ GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>จอภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>ไม่พบจอภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>อแดปเตอร์เครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>ไม่พบอแดปเตอร์เครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>อแดปเตอร์เสียง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>ไม่พบอุปกรณ์เสียง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>บลูทูธ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>ไม่พบอุปกรณ์บลูทูธ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>อุปกรณ์ PCI อื่นๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>ไม่พบอุปกรณ์ PCI อื่นๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>พลังงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>ไม่พบแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>คีย์บอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>ไม่พบคีย์บอร์ด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>เมาส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>ไม่พบเมาส์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>เครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>ไม่พบเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>กล้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>ไม่พบกล้อง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>ไม่พบ CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>อุปกรณ์อื่นๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>ไม่พบอุปกรณ์อื่นๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>แฮนด์เลดจ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>รูปแบบการใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>ชุด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>ตำแหน่งบัญชี</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>รายละเอียดประเภท</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>หมายเลขส่วนประกอบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>ลำดับ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>เทคโนโลยีหน่วยความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>ความสามารถในการทำงานของโหมดความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>เวอร์ชันเฟิร์มแวร์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>IDผู้ผลิตโมดูล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>IDผลิตภัณฑ์โมดูล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>IDผู้ผลิตคอนโทรลเลอร์ระบบความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>IDผลิตภัณฑ์คอนโทรลเลอร์ระบบความจำ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>ขนาดความจำที่ไม่เปลี่ยนแปลง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>ขนาดความจำที่เปลี่ยนแปลงได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>ขนาดแคช</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>ขนาดตรรกะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>นิ้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>วันที่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>พอร์ต I/O</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>เครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>แบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>เส้นทางที่เป็นท้องถิ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>แหล่งจ่ายไฟ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>มีประวัติ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>มีสถิติ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ชาร์จได้</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>สถานะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>ระดับเตือนภัย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>พลังงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>พลังงานว่าง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>พลังงานเต็ม</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>พลังงานเต็มตามการออกแบบ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>อัตราพลังงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>แรงดันไฟฟ้า</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>เปอร์เซ็นต์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>เทคโนโลยี</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>ชื่อไอคอน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>ออนไลน์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>เวอร์ชันเดมอน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>อยู่ในโหมดแบตเตอรี่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>ฝาปิดปิด</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>ฝาปิดมีอยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>การกระทำสำคัญ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>จำนวนสำเนา</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>ยกเลิกงานหลังจาก</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>หยุดงานจนถึง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>ความสำคัญของงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>เวลาเปลี่ยนแปลงเครื่องหมาย</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>จำนวนหน้าต่อแผ่น</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>การกำหนดทิศทาง</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>โหมดพิมพ์สี</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>เครื่องพิมพ์กำลังรับงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>เครื่องพิมพ์ถูกแบ่งปัน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>เครื่องพิมพ์ชั่วคราว</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>แบรนด์และรุ่นของเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>เวลาเปลี่ยนสถานะเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>เหตุผลของสถานะเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>ประเภทเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI ที่รองรับของเครื่องพิมพ์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>ด้าน</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>ข้อมูลการเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>ขนาดซีกเก็บข้อมูลทางตรรกะ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>ขนาดซีกเก็บข้อมูล</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>ไจด์</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>เรขาคณิต (ตรรกะ)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>ผู้จัดการอุปกรณ์</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>ผู้จัดการอุปกรณ์เป็นเครื่องมือที่ใช้งานง่ายสำหรับดูข้อมูลอุปกรณ์และจัดการอุปกรณ์ต่าง ๆ</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>ไดรเวอร์ใหม่พร้อมใช้งาน! ติดตั้งหรืออัปเดตทันที</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>ดู</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>รวมโฟลเดอร์ย่อย</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ค้นหาไดรเวอร์ในเส้นทางนี้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'มีการอัปเดตไดรเวอร์ %1 ตัว' พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'เวลาตรวจสอบ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>กำลังดาวน์โหลดไดรเวอร์สำหรับ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'ความเร็วในการดาวน์โหลด: %1 ดาวน์โหลดแล้ว %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>กำลังติดตั้งไดรเวอร์สำหรับ %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'ไดรเวอร์ %1 ตัวติดตั้งสำเร็จ, ไดรเวอร์ %2 ตัวล้มเหลว'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'ไดรเวอร์ %1 ตัวติดตั้งสำเร็จ'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ไม่สามารถติดตั้งไดรเวอร์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>เกิดข้อผิดพลาดของเครือข่าย กำลังเชื่อมต่อใหม่...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'ความเร็วในการดาวน์โหลด: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>ไดรเวอร์ของคุณล่าสุดแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>ไดรเวอร์ทั้งหมดได้รับการสำรองข้อมูลแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>รวม %1 ไดรเวอร์, ไดรเวอร์ %2 ตัวได้รับการสำรองข้อมูลแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>คุณมีไดรเวอร์ %1 ตัวที่สามารถสำรองข้อมูลได้ แนะนำให้ทำทันที</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>คุณมีไดรเวอร์ %1 ตัวที่สามารถสำรองข้อมูลได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>กำลังสำรองข้อมูลไดรเวอร์ %1, รวม %2 ไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'กำลังสำรองข้อมูล: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'ไดรเวอร์ %1 ตัวสำรองข้อมูลสำเร็จ, ไดรเวอร์ %2 ตัวล้มเหลว'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ไม่สามารถสำรองข้อมูลไดรเวอร์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'ไดรเวอร์ %1 ตัวสำรองข้อมูลสำเร็จ'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>คุณมีไดรเวอร์ %1 ตัวที่สามารถกู้คืนได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>กรุณาเลือกไดรเวอร์ที่ต้องการกู้คืน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ไดรฟ์กำลังกู้คืน...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>กำลังกู้คืน: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>รีบูต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>กรุณา %1 เพื่อให้ไดรฟ์ที่ติดตั้งแล้วมีผลใช้ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>ดูเส้นทางสำรอง</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>สำรองทั้งหมด</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>ส่งคำติชม</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>กรุณาลองใหม่หรือ %1 ถึงเรา</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>ติดตั้งทั้งหมด</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>สแกนอีกครั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>ยกเลิก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>กำลังสแกนไดรฟ์ของอุปกรณ์ฮาร์ดแวร์ โปรดรอ...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>กำลังสแกน %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>การสแกนล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>เครือข่ายไม่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>กรุณาตรวจสอบการเชื่อมต่อเครือข่ายของคุณ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>กรุณาสแกนอีกครั้งหรือ %1 ถึงเรา</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>คุณกำลังติดตั้งไดรฟ์ ซึ่งจะถูกยกเลิกหากคุณออกจากโปรแกรม</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>คุณแน่ใจว่าต้องการออกจากโปรแกรมหรือไม่?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ยกเลิก</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>คุณกำลังสำรองไดรฟ์ ซึ่งจะถูกยกเลิกหากคุณออกจากโปรแกรม</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>คุณกำลังกู้คืนไดรฟ์ ซึ่งจะถูกยกเลิกหากคุณออกจากโปรแกรม</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>แอดอัพบลูทูธ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>อุปกรณ์จัดทำภาพ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>แอดอัพการแสดงผล</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>การ์ดเสียง</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>แอดอัพเครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>แอดอัพเครือข่ายไร้สาย</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>การติดตั้งสำเร็จ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>การติดตั้งล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>กำลังดาวน์โหลด</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>กำลังติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>ยังไม่ได้ติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>ล้าสมัย</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>รอ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>ยังไม่ได้สำรองข้อมูล</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>กำลังสำรองข้อมูล</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>การสำรองข้อมูลล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>สำรองข้อมูลสำเร็จ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>กำลังกู้คืน</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>ข้อผิดพลาดไม่ทราบสาเหตุ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>ข้อผิดพลาดเครือข่าย</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>ยกเลิก</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ไม่สามารถดึงไฟล์ไดรเวอร์ได้</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>สำรองข้อมูล</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>กู้คืน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ติดตั้ง</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>อัปเดตไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ถอนการติดตั้งไดรเวอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>อนุญาตให้ปลุกเครื่องคอมพิวเตอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>เปิดใช้งาน</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>อัปเดต</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>ส่งออก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>คัดลอก</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>ไม่สามารถใช้งานได้</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>กรุณาเลือกโฟลเดอร์ในท้องถิ่น</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>กำลังโหลด...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_tr.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_tr.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Geri bildirim</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Dahası</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Daralt</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Dahası</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Dahası</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Daralt</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Dahası</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Daralt</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Aygıt Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Yonga</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Modül Takma Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Fiziksel Kimlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Açıklama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Revizyon</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Bellek Adresi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Yonga Seti</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Takma ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Modül Takma Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Fiziksel Kimlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Azami Güç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Sürücü Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Bus Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Mantıksal Ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC Adresi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Bus Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Azami Güç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Modül Takma Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Fiziksel Kimlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>CPU ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>Çekirdek ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>İş Parçacığı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Mimari</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Cpu Ailesi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>İşlemci</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation> Çekirdekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Sanallaştırma</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Bayraklar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Eklentiler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 Önbellek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Önbellek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Önbellek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Önbellek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Önbellek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Adımlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Azami Hız</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Grafik Belleği</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Modül Takma Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Fiziksel Kimlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Bellek Adresi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>IO Port</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Bus Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Azami Çözünürlük</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Asgari Çözünürlük</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Mevcut Çözünürlük</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Açıklama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Dijital Çıkış</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Ekran Çıkışı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Bus Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Modül Takma Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Fiziksel Kimlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Azami Güç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Seri Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Arayüz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Bus Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Modül Takma Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Fiziksel Kimlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>En yüksek Geçerli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Özet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>CPU miktarı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Anakart</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Bellek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Görüntü Bağdaştırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Ses Bağdaştırıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Depolama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Diğer PCI Aygıtları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Pil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Ağ Bağdaştırıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Fare</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Klavye</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Ekran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Yazıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Kamera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Diğer Aygıtlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Aygıt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>OS</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Toplam Genişlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Konumlandırıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Seri Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Yapılandırılmış Voltaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Azami Voltaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Asgari Voltaj</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Yapılandırılmış Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Veri Genişliği</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Ekran Girişi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Arayüz Türü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Desteklenen Çözünürlük</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Mevcut Çözünürlük</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Görüntü Oranı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Birincil Ekran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Seri Numarası</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Satıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Medya Türü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Yetenekler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Modül Takma Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Fiziksel Kimlik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Yazılım Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Hız</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Açıklama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Seri Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Arayüz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Dönüş Hızı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Güncelleme için bir sürücü seçin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Bu klasörde sürücü bulunamadı</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Ses Aygıtı Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>CD-ROM Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>İşletim Sistemi Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>CPU Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Diğer Aygıt Bilgileri Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Güç Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Yazıcı Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Fare Bilgisi Yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Ağ Adaptörü Bilgisi Yükleniyor...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Aygıt Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Kısayolları göster</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Aygıt Yöneticisi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Donanım</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Sürücüler</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Ekran</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Özet</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Görüntü Bağdaştırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Ağ Bağdaştırıcı</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Pil</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Dahası</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Geçerli Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Sürücü Platformu Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Durum</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Eylem</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Yedeklenebilir Sürücüler</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Yedeklenen Sürücüler</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Güncelleniyor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Sonraki</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Uyarı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Sürücü kaldırıldıktan sonra cihaz kullanılamayacak</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Kaldırılıyor</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Güncelleme başarılı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Kaldırma başarılı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Güncelleştirme başarısız</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Kaldırma başarısız</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Sonraki</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Seçilen klasör mevcut değil, lütfen tekrar seçin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Güncelle</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Öncesi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Bozuk paket</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Benzersiz paket mimarisi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Seçilen dosya mevcut değil, lütfen tekrar seçin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Bu bir sürücü değil</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Yüklenemiyor - dijital imza yok</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Bilinmeyen hata</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Sürücü modülü bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Geçersiz modül biçimi</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Sürücü modülünün bağımlılıkları var</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Aygıt Adı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Sürüm mevcut</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Durum</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Eylem</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Yeni Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Geçerli Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Kayıp sürücüler (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Tarihi geçmiş sürücüler (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Güncel sürücüler (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Sürücü Kurulumu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Sürücü Yedekleme</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Sürücü Geri Yükleme</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Geri bildirim</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Geri yüklenecek herhangi bir sürücünüz yok, lütfen önce yedekleyin</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Yedekleme Sürücüsüne Git</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Geçerli Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Yedekleme Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Eylem</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Geri Yüklenebilir Sürücüler</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Özet</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Sürücü Kurulumu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Sürücü Yedekleme</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Sürücü Geri Yükleme</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Cihaz devre dışı bırakılamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Cihaz devre dışı bırakılamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Devre dışı bırakılamadı: cihaz SN&apos;si alınamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Sürücüleri güncelle</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Sürücüleri Kaldır</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Özet</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Etkin</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Bilgisayarı uyandırmasına izin ver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Devre dışı bırakılamadı: cihaz SN&apos;si alınamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Cihaz devre dışı bırakılamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Cihaz devre dışı bırakılamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Sürücüleri güncelle</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Sürücüleri Kaldır</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>AltÜretici</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>AltAygıt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Sürücü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Sürücü Durumu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Sürücü Etkinleştirme CMD&apos;si</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Yapılandırma Durumu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>gecikme</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>İşleyiciler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>ANAHTAR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>BIOS Bilgileri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Temel Pano Bilgileri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Sistem Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Ana Gövde Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Fiziksel Bellek Dizisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Yayın Tarihi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Çalışma Zamanı Boyutu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM Boyutu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Özellikleri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BİOS Revizyonu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Ürün Yazılımı Revizyonu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Ürün Adı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Seri Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Varlık Etiketi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Yenilikler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Ana Gövdedeki Konumu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Ana Gövde Tanıtıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>İçerilen Nesne Tanıtıcıları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Uyandırma Türü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>SKU Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Ailesi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Kilit</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Açılış Durumu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Güç Kaynağı Durumu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Termal Durumu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Güvenlik Durumu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM Bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Yükseklik</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Güç Kablosu Sayısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>İçerdiği Ögeler</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Konum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Hata Düzeltme Türü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Azami Kapasite</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Hata Bilgisi Tanıtıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Aygıt Sayısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM BOYUTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Yayın tarihi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Pano ismi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBİOS Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Dil Açıklama Biçimi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Kurulabilir Diller</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Şu Anki Yüklü Dil</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD Adresi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Paket türü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Bağlantı politikası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Bağlantı kipi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Sınıf</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Servis Sınıfları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Aygıt Sınıfı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Alt sürüm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Aygıt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Serial ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>ürün</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>açıklama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Dolu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Bulunabilir</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Eşleşebilir</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Keşfet</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Sürücü Modeli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Aygıt Dosyası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Aygıt Dosyaları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Aygıt Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Uygulama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>durum</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>mantıksal ad</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ansi sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU uygulayıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU mimarisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU varyantı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU bölümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU revizyonu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Bir</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>İki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Dokuz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>On</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>On iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>On dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>On altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>On sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Yirmi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Yirmi iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Yirmi dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Yirmi altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Yirmi sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Otuz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Otuz iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Otuz dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Otuz altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Otuz sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Kırk</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Kırk iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Kırk dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Kırk altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Kırk sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Elli</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Elli iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Elli dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Elli altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Elli sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Altmış</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Altmış iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Altmış dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Altmış altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Altmış sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Yetmiş</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Yetmiş iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Yetmiş dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Yetmiş altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Yetmiş sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Seksen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Seksen iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Seksen dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Seksen altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Seksen sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Doksan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Doksan iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Doksan dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Doksan altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Doksan sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Yüz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Yüz iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Yüz dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Yüz altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Yüz sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Yüz on</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Yüz on iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Yüz on dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Yüz on altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Yüz on sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Yüz yirmi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Yüz yirmi iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Yüz yirmi dört</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Yüz yirmi altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Yüz yirmi sekiz</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Yüz doksan iki</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>İki yüz elli altı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR kapasitesi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU satıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU türü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL istemci API&apos;ları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL sürümü</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Bilinmeyen</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Donanım Sınıfı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>CPU bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Anakart</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Anakart bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Bellek</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Bellek bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Depolama</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Disk bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Sürücü geri yükleme başarısız oldu!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Lütfen tekrar deneyin veya bize geri bildirimde bulunun</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Sürücü yedeklemesi başarısız oldu!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Görüntü Bağdaştırıcısı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>GPU bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Ekran</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Monitör bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Ağ Bağdaştırıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Ağ bağdaştırıcısı bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Ses Bağdaştırıcı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Ses aygıtı bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Bluetooth aygıtı bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Diğer PCI Aygıtları</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Diğer PCI aygıtları bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Güç</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Pil bulunamadı</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Ses Bağdaştırıcı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Ses aygıtı bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Bluetooth aygıtı bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Diğer PCI Aygıtları</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Diğer PCI aygıtları bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Güç</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Pil bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Klavye</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Klavye bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Fare</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Fare bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Yazıcı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Yazıcı bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Kamera</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Kamera bulunamadı</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>CD-ROM bulunamadı</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Fare</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Fare bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Yazıcı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Yazıcı bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Kamera</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Kamera bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>CD-ROM bulunamadı</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Diğer Aygıtlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Başka aygıt bulunamadı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Dizi Kolu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Form Yöntemi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Ayarla</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Yuva Konumlandırıcı</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Tür Ayrıntıları</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Parça Numarası</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Derece</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Bellek Teknolojisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Bellek Çalışma Kipi Özelliği</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Yazılım Sürümü</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Modül Üretici Kimliği</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Modül Ürün Kimliği</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Bellek Alt Sistem Kontrolcü Üretici Kimliği</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Bellek Alt Sistem Kontrolcü Ürün Kimliği</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Uçucu Olmayan Boyut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Uçucu Boyut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Önbellek Boyutu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Mantıksal Boyut</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>inç</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>kenarlar</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>bus bilgisi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>yerel sektör boyutu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>sektör boyutu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Geometri (Mantıksal)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Aygıt Yöneticisi</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Aygıt Yöneticisi, donanım bilgilerini görüntülemek ve aygıtları yönetmek için kullanışlı bir araçtır.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Yeni sürücüler mevcut! Bunları şimdi yükleyin veya güncelleyin.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Alt klasörler dahil</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Bu yoldaki sürücüleri arayın</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 sürücü güncellemeleri mevcut</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Kontrol edilen zaman: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>%1 için sürücüler indiriliyor...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>İndirme hızı: %1 İndirildi %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>%1 için sürücüler yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 sürücü yüklendi, %2 sürücü başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 sürücüler yüklü</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Sürücülerin yüklenmesi başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Ağ hatası. Yeniden bağlanılıyor...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>İndirme hızı: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Senin sürücülerin güncel</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Tüm sürücüler yedeklendi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Toplam %1 sürücüden, %2 tanesi yedeklendi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Yedeklenebilecek %1 sürücünüz var, bunu hemen yapmanız önerilir</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Yedeklenebilecek %1 sürücünüz var</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>%1 sürücüyü yedekliyor, toplam %2 sürücü</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Yedekleniyor: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 sürücü yedeklendi, %2 sürücü başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Sürücülerin yedeklenmesi başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 sürücü yedeklendi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Geri yüklenebilecek %1 sürücünüz var</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Lütfen geri yüklemek için bir sürücü seçin</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Sürücü geri yükleniyor...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Geri yükleniyor: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>Yeniden başlat</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Yüklü sürücülerin etkinleşmesi için lütfen %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Yedekleme yolunu görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Tümünü Yedekle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>geribildirim gönder</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Lütfen tekrar deneyin veya bize %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Hepsini Yükle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Tekrar tara</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Donanım aygıt sürücüleri taranıyor. Lütfen bekleyin...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>%1 Taranıyor</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Tarama başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Ağ kullanılamıyor</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>İnternet bağlantını kontrol et</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Lütfen tekrar tarayın veya bize %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Çıktığınızda kesintiye uğrayacak bir sürücü kuruyorsunuz.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Çıkış yapmak istediğinden emin misin?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Çıkış</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Çıkarsanız kesintiye uğrayacak olan sürücüleri yedekliyorsunuz.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Çıkarsanız kesintiye uğrayacak olan sürücüleri geri yüklüyorsunuz.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Sürücü dosyalarını edinme başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Güncelle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Yedekle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Geri yükle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Yükle</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Sürücüleri güncelle</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Sürücüleri kaldır</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Bilgisayarı uyandırmasına izin ver</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Etkin</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Dışa aktar</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Devre dışı</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Yok</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Yerel bir klasör seçin lütfen</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Yükleniyor...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_tzm.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_tzm.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tzm">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>تَرْجِمْ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>يَكْرَن</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>كُرْ</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>تَخْبِرْ تَفْرِيقَتْ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>تَرْجِعْ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>كُرْ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>تَنْكِسْ</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>تَكْرَن</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>مَتَمَكَنْ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>اسمْ تَفْرِيقَتْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>اسمْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>مُصَنِّعْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>كِبْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>كُفَاعِيَتْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>مسْتَعْمَلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>تَرْجِيْسْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>مُسْتَعْمَلْ مُرْجَعْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>تَرْجِمْ تَفْرِيقَتْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>مَتَمَكَنْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>تَكْرَن</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>اسمْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>مُصَنِّعْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>مُرْجَعْ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>مُصَنِّعْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>تَفْرِيقَتْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>كِبْسْتْ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>الِيَسْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>اسمْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>تَفَاعِلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>رَكْزْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>مُودَّلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>سُرْعَة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>تَكْوِينْ دَرْجَةْ قُوَّة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>رَكْزْ دَرْيْفَر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>دَرْيْفَر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>كَفَاتَيْنْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>مَكْتَبْ بُس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>إِسْمْ لُجِيْكَل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>مَكْ إِدْرِسْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>مَتَاحْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>تَكْرَنْ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>إِسْمْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>تَفَاعِلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>مُودَّلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>رَكْزْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>مَكْتَبْ بُس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>كَفَاتَيْنْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>دَرْيْفَر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>تَكْوِينْ دَرْجَةْ قُوَّة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>سُرْعَة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>مَتَاحْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>تَكْرَنْ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>إِسْمْ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>إِسْمْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>تَفَاعِلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>إِدْ كُبي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>إِدْ كُور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>تْرِيْدْزْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجوميبس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>الهيكلية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>عائلة المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>الوحدة(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>التقنيات الافتراضية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>العلميات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>التوسعات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>الذاكرة L3</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>الذاكرة L2</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>الذاكرة L1i</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>الذاكرة L1d</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>الخطوة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>الشركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>النموذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>ذاكرة الرسومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>هوية المادية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>عنوان الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>منفذ الإدخال/الإخراج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>معلومات الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>الدقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>الدقة الدنيا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>الإخراج الرقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>إخراج العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>IRQ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>المُصنَّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>الطاقة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>المُصنَّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>النماذج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>التيار الأقصى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>البرنامج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>المعالج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>عدد المعالجات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>اللوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>مُوصِل العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>مُوصِل الصوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>أجهزة PCI الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation>البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>مُوصِل الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>الماوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>الكيبورد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>الشاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>القرص الصلب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>الكاميرا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>الأجهزة الأخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>نظام التشغيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>العرض الكلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>الجهد المُضبط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>الجهد الأقصى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>الجهد الأدنى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>السرعة المُضبط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>عرض البيانات</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>الإدخال المعروض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>نوع الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>الدقة المدعومة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>الدقة الحالية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>نسبة العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>الشاشة الرئيسية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>المُصنِّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>معلومات الحافلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>نسخة البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>السرعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>معدل التفاوض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>المنفذ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>مُلْتِكَسْت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation>لينك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation>لَتَنسِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation>إي بي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation>فِورْمْوَرْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation>دُبلِكس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation>برودكاست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation>أوتُو نِغُوتِيَشْن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation>أدرسْتِ مِيمُوري</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation>إيرك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation>مِاك إيرك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation>إسم لوجيكي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation>مَتَوفِر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation>ديسبيل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation>إسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation>فِينْدَر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation>مودل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation>بُس إِنْفُو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation>فِيرْسِن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation>إينبوت/أووت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation>مِيمُوري</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation>إيرك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation>لَتَنسِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation>دِرِفَر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation>كابابيلِتِيس</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation>إسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation>فِينْدَر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation>مودل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation>فِيرْسِن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation>بُس إِنْفُو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>البرنامج التشغيلي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>القدرة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>القدرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>الجهد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>الشريحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>القدرة المُصمّمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>الجهد المُصمّم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>نسخة SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>رقم تسلسل SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>تاريخ إنتاج SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>كيمياء SBDS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>درجة الحرارة</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>المُصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>رقم التسلسل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>مُشتركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>الحالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>نوع الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>تَحْرِيْم</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>نوع الوسيلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>الحجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>القدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>نسخة البرمجيات الثابتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>السرعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>الوصف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>الواجهة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>معدل الدوران</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>اختر مُجَرّد للاختبار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>لا توجد مُجَرّدات في هذا المجلد</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>جارِ تحميل معلومات جهاز الصوت...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>جارِ تحميل معلومات BIOS...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>جارِ تحميل معلومات CD-ROM...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>جارِ تحميل معلومات نظام التشغيل...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>جارِ تحميل معلومات المعالج...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>جارِ تحميل معلومات أجهزة أخرى...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>جارِ تحميل معلومات الطاقة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>جارِ تحميل معلومات الطابعة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>جارِ تحميل معلومات الفأرة...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>جارِ تحميل معلومات بطاقة الشبكة...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>تَحْرِيْم</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>تَحْرِيْم</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>غير متاح</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>تيمووين تفاصيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>تيمووين ترجمات</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>تانيش</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>كيب</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>تيمووين</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>تيمووين</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>تيمووين</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>تيمووين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>التحديث فاشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>فشل إزالة التثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>أوكي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>التالي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>الملف المحدد غير موجود، من فضلك اختر مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>السابق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>حزمة مكسورة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>هيكل الحزمة غير متوافق</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>الملف المحدد غير موجود، من فضلك اختر مرة أخرى</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>ليس هذا ملف مدعوم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>غير قادر على التثبيت - لا توقيع رقمي</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>خطأ غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>لم يتم العثور على وحدة المودуль الخاصة بالمحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>صيغة المودуль غير صالحة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>لدي وحدة المودуль الخاصة بالمحرك اعتماديات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>تثبيت المحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>نسخ احتياطي للمحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>استعادة المحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>ملاحظات</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>لا يوجد محركات يمكن استعادتها، من فضلك أعد النسخ الاحتياطي أولاً</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>الانتقال إلى نسخة الاحتياطي للمحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>نسخة احتياطية</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>محركات قابلة للاستعادة</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>تثبيت المحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>نسخ احتياطي للمحرك</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>استعادة المحرك</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>تَكْرَرَتْ أَشْكَالَتْ تَمْكِينِ الدَّوْرَةِ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>تَكْرَرَتْ أَشْكَالَتْ إيقافِ الدَّوْرَةِ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>تَكْرَرَتْ أَشْكَالَتْ إيقافِهِ: لَمْ يَكُنْ مُمْكِنًا حَوْلِ كَرَتْ كُودِهِ الدَّوْرَةِ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>تحديث المُسَاعِدِين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>إلغاء تثبيت المُسَاعِدِين</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>نظرة عامة</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>تمكين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>تحديث المُسَاعِدِين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>إلغاء تثبيت المُسَاعِدِين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>تَمْكِينِهِ مِنْ تَحْيِيَةِ الحَاسُوبِ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>إيقاف</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>تَكْرَرَتْ أَشْكَالَتْ إيقافِهِ: لَمْ يَكُنْ مُمْكِنًا حَوْلِ كَرَتْ كُودِهِ الدَّوْرَةِ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>تَكْرَرَتْ أَشْكَالَتْ إيقافِ الدَّوْرَةِ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>تَكْرَرَتْ أَشْكَالَتْ تَمْكِينِ الدَّوْرَةِ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>تحديث المُسَاعِدِين</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>إلغاء تثبيت المُسَاعِدِين</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>البَرَنْدُر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>الدَّوْرَةِ الْئِتْفَالِيَّة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>الْمُسَاعِدِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>حَالةِ الْمُسَاعِدِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>أَمْرِ تَمْكِينِ الْمُسَاعِدِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>حَالةِ التَّصَمِيم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>الْمَسَافَةِ مِنْ التَّمْكِينِ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>الْفِيْسِ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>Sysfs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>_handlers</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>PROP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>EV</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>KEY</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>النسخة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>الحافلة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>معلومات BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>معلومات اللوحة الأساسية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>معلومات النظام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>معلومات الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>الذاكرة الفيزيائية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>تاريخ الإطلاق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>العنوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>حجم التشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>حجم الROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>خصائص</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>مراجعة BIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>مراجعة البرمجيات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>اسم المنتج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>رقم السريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>معلومة الأصول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>الميزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>الموقع في الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>الحassis</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>العناصر المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>نوع الاستيقاظ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>رقم SKU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>تيم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>قفل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>الحالة دي تشغيل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>الحالة دي توريد الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>الحالة دي الحرارة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>حالة الأمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>معلومات المصنّع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>الارتفاع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>عدد أسلاك الطاقة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>العناصر المحتوية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>الموقع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نوع تصحيح الأخطاء</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>السعة القصوى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>اليدentifier دي المعلومات دي الأخطاء</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>عدد الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>حجم BIOS ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>تاريخ الإصدار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>اسم اللوحة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>نسخة SMBIOS</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>صيغة وصف اللغة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>اللغات قابلة للتثبيت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>اللغة المثبتة حاليًا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>عنوان BD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>نوع الحزمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>سياسة الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>وضع الربط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>الصنف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>التصنيفات دي الخدمات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>كلاسيت دال ديوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>وERSION دال HCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>وERSION دال LMP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>سوبرفيشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>ديوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>ID دال سيريل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>توفير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>توصيف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>مغلق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>مكشوف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>مكشوف للكي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>موداليا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>مكشوف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>موديولس دال ديرفر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>فيل دال ديوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>فيلوس دال ديوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>أرقم دال ديوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>توفير</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>حالة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>اسم لوجيكي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>ansi وERSION</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>ميمبلمنتر دال CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>أركيتيكتور دال CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>ويفيانت دال CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>بارت دال CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>رفيشن دال CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>واحد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>دوي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>أربعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>ستة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>تام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>تامين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>ستين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>ستين وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>سبتين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>سبتين ودويش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>سبتين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>سبتين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>سبتين وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ثمانين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ثمانين ودويش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ثمانين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ثمانين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ثمانين وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>تسعين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>تسعين ودويش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>تسعين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>تسعين وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>تسعين وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>واحد مائة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>واحد مائة ودويش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>واحد مائة واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>واحد مائة وست</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>واحد مائة وثمان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>واحد مائة وعشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>واحد مائة وترىع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>واحد مائة واربعة عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>واحد مائة وست عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>واحد مائة وثمان عشر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>واحد مائة وعشرين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>واحد مائة وعشرين ودويش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>واحد مائة وعشرين واربع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>126</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>128</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>192</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>256</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>سعة GDDR</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>مصنّع GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>نوع GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>نسخة EGL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>واجهات EGL العميل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>نسخة GL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>نسخة GLSL</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>غير معروف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>أحادي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>فئة الأجهزة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>وحدة المعالجة المركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>لم يتم العثور على وحدة معالجة مركزية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>لوحة الأم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>لم يتم العثور على لوحة أم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>الذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>لم يتم العثور على ذاكرة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>التخزين</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>لم يتم العثور على محرك أقراص</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>فشل استعادة الراوتر!</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>يرجى المحاولة مرة أخرى أو إعطاؤنا ملاحظات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>فشل نسخ الراوتر!</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>مُعدّل العرض</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>لم يتم العثور على GPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>شاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>لم يتم العثور على شاشة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>وَيْفَرْتِي مُتَّصِلْ بِالْوَيْفَرْتِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>مَاتَ وَيْفَرْتِي مُتَّصِلْ بِالْوَيْفَرْتِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>مُتَّصِلْ بِالْمَاتَ رَمْزِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>مَاتَ مُتَّصِلْ بِالْمَاتَ رَمْزِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>بْلُوُتُهُ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>مَاتَ بْلُوُتُهُ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>أُخَرْ مَاتَ مُتَّصِلْ بِالْبِسي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>مَاتَ أُخَرْ مَاتَ مُتَّصِلْ بِالْبِسي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>الْكَهْرَامِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>مَاتَ كَهْرَامِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>الْكِبْرَدِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>مَاتَ كِبْرَدِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>الْمُسْهَوْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>مَاتَ مُسْهَوْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>الْمَاتَ رِنْتِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>مَاتَ مَاتَ رِنْتِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>الْكَامِرَ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>مَاتَ كَامِرَ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>الْكِدْ إِرْوم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>مَاتَ كِدْ إِرْوم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>أُخَرْ مَاتَ مُتَّصِلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>مَاتَ أُخَرْ مَاتَ مُتَّصِلْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>هَانْدِلْ مَاتَ أَرَيْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>سَتْرِي مَاتَ فَوْرْم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>تَوْيْتْ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>مَاتَ لُوكَتْرْ بَنْك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>تَوْيْتْ دِتَيْل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>نُمْرَ بَرْت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>رَنْك</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>تِكْنُولُو جِي مَاتَ مِمْرِي</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>Capability of the Memory Operating Mode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>Version of the Firmware</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>Manufacturer ID of the Module</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>Product ID of the Module</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>Manufacturer ID of the Memory Subsystem Controller</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>Product ID of the Memory Subsystem Controller</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>Size of the Non-Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>Size of the Volatile</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>Size of the Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>Size of the Logical</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>inch</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>Date</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>ioport</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>network</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>native-path</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>power supply</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>updated</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>has history</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>has statistics</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>rechargeable</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>state</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>warning-level</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation>energy</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>energy-empty</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>energy-full</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>energy-full-design</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>energy-rate</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>voltage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>percentage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>تيكناووجيا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>اسم العلامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>متصلا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>نسخة الديمون</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>على البطارية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>الغطاء مغلق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>الغطاء موجود</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>عملية حاسمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>إلغاء المهمة بعد</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>الاحتفاظ بالمهمة حتى</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>اولوية المهمة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>وقت تغيير العلامة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>عدد الصفحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>الاتجاه المطلوب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>وضع طابعة الألوان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>الطابعة تقبل المهام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>الطابعة مشاركة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>الطابعة مؤقتة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>نموذج وماركة الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>وقت تغيير حالة الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>أسباب حالة الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>نوع الطابعة</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>URI الطابعة المدعوم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>الجوانب</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>معلومات الباوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>حجم القطاعات المنطقية</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>حجم القطاعات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>gid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>هندسة (منطقية)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>مدير المعدات</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>مدير المعدات هو أداة مفيدة لعرض معلومات الأجهزة وإدارة المعدات.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>التحديثات الجديدة متاحة! تثبيت أو تحديثها الآن.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>عرض</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>أضف المجلدات الفرعية</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>ابحث عن مسارات التحديثات في هذا المسار</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 تحديثات معدات متاحة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'وقت التحقق: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>تنزيل معدات %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'سرعة التنزيل: %1 تم تنزيل %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>تثبيت معدات %1...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 معدات مثبتة، %2 معدات فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 معدات مثبتة'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>فشل تثبيت المعدات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>خطأ في الشبكة. إعادة الاتصال...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'سرعة التنزيل: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>تحديثات المعدات الخاصة بك محدثة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>تم نسخ جميع معدات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>إجمالي %1 معدات، من بينها %2 تم نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>لديك %1 معدات يمكن نسخها، يُنصح بأن تقوم بذلك فورًا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>لديك %1 معدات يمكن نسخها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>نسخ معدات %1، إجمالي %2 معدات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>'نسخ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>'%1 معدات نسخت، %2 معدات فشلت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>فشل نسخ المعدات</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>'%1 معدات نسخت'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>لديك %1 معدات يمكن استعادتها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>يرجى اختيار معدات لاستعادتها</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>Driver is restoring...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>Restoring: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>reboot</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>Please %1 for the installed drivers to take effect</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>View backup path</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>Backup All</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>submit feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>Please try again or %1 to us</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>Install All</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>Scan Again</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>Scanning hardware device drivers, please wait...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>Scanning %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>Scan failed</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>Network unavailable</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>Please check your network connection</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>Please scan again or %1 to us</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>You are installing a driver, which will be interrupted if you exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>Are you sure you want to exit?</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>Exit</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>You are backing up drivers, which will be interrupted if you exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>You are restoring drivers, which will be interrupted if you exit.</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>Bluetooth adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>Imaging device</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>Display adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>Sound card</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>Network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>Wireless network adapter</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>Installation successful</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>التركيب فشل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>تنزيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>تركيب</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>لم يُثبت</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>قدّم</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>تنتظر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>لم يُحفظ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>حفظ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>فشل الحفظ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>نجح الحفظ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>استعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>خطأ مجهول</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>خطأ في الشبكة</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>ألغي</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>فشل الحصول على ملفات الاقتران</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>نسخ احتياطي</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>استعادة</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>تركيب</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>تحديث ملفات الاقتران</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>إزالة ملفات الاقتران</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>اسمح له بتفريغ الحاسوب</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>تفعيل</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>تحديث</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>تصدير</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>نسخ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>تعطيل</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>مفيش</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>تالق تيغ مطروش لفدر</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>تلاقي...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ug.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>جەزىملەش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>تەرجىمە</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەش</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">تېخىمۇ كۆپ</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">يىمىرىلىش</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>تېخىمۇ كۆپ</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>تېخىمۇ كۆپ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>يىمىرىلىش</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>تېخىمۇ كۆپ</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>يىمىرىلىش</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>ئۈسكۈنىنىڭ ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>ئۆزەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>ئىچكى ساقلىغۇچ ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>ئۈزۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>ئۆزەك گورۇپىسى</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
-        <translation type="unfinished"/>
+        <translation>ئەلىاس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>مودېل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>ئەڭ چوڭ قۇۋۋەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>قوزغاتقۇچ نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>لوگىكىلىق ئىسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>مودېل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>ئەڭ چوڭ قۇۋۋەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>بىر تەرەپ قىلغۇچ كىملىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>يادرولۇق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>تېما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>قۇرۇلما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>بىر تەرەپ قىلغۇچ ئائىلىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>مودېل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>يادرو</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>مەۋھۇملاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>بايراق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>كېڭەيتىلمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
-        <translation type="unfinished"/>
+        <translation>L4 ھەجىمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d غەملەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>قەدەم بېسىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>چوققا سۈرئىتى</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>مودېل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>گرافىك ئەستە ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>ئىچكى ساقلىغۇچ ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>I/O ئېغىزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>ئەڭ چوڭ ئېنىقلىق دەرىجىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>ئەڭ تۆۋەن ئېنىقلىق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>نۆۋەتتىكى قارار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>چىقىرىشنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>ئۈزۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>مودېل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>ئەڭ چوڭ قۇۋۋەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>مودېل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>كۆرۈنمە يۈزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>ئەڭ چوڭ توك ئېقىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>ئومۇمىي چۈشەنچە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>بىر تەرەپ قىلغۇچ مىقدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>ئانا تاختا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>ماسلاشتۇرغۇچنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>ئاۋاز ماسلاشتۇرغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>باشقا PCI ئۈسكۈنىلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>باتارېيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>كۆك چىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>تور ماسلاشتۇرغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation>چاشقىنەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>كۇنۇپكا تاختىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>نازارەتچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>پىرىنتېر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>كامېرا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>باشقا ئۈسكۈنىلەر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>ئۈسكۈنە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>مەشغۇلات سىستېمىسى</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>تىپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>ئومۇمىي كەڭلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>ئورۇن بەلگىلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>تەڭشەلگەن توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>ئەڭ چوڭ توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>ئەڭ تۆۋەن توك بېسىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>تەڭشەلگەن سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>سان-سىپېر چوڭلۇقى</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>تىپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>كىرگۈزۈشنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>كۆرۈنمە يۈزى تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>قوللاش قارارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>نۆۋەتتىكى قارار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>كۆرسىتىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>دەسلەپكى كۆزەتكۈ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>تەرتىپ نومۇرى</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>تىپ</translation>
     </message>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>ياسىغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>مېدىيا تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>مودېلنىڭ باشقا نامى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>فىزىكىلىق كىملىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>يۇمشاق دېتال نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>سۈرئەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>كۆرۈنمە يۈزى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>ئايلىنىش نىسبىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>لازىملىق قوزغاتقۇچ پىروگراممىسنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>بۇ ھۆججەت قىسقۇچتا ھېچقانداق قوزغاتقۇچ تېپىلمىدى</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>ئاۋاز ئۈسكۈنىسى ئۇچۇرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>BIOS ئۇچۇرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>قوزغاتقۇچ ئۇچۇرلىرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>مەشغۇلات سىستېمىسى ئۇچۇرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>بىر تەرەپ قىلغۇچ ئۇچۇرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>باشقا ئۈسكۈنىلەر ئۇچۇرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>يۈكلەش ئۇچۇرى ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>پىرىنتېر ئۇچۇرلىرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>مائۇس ئۇچۇرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>تور ماسلاشتۇرغۇچ ئۇچۇرىنى يۈكلەۋاتىدۇ ...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>ئۈسكۈنە ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>تېزلەتمىلەرنى كۆرسەت</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>ياردەم</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>سىستېما</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>ئېكسپورت</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>ئۈسكۈنە باشقۇرغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>قاتتىق دېتال ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>قوزغاتقۇچ باشقۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>نازارەتچى</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>ئومۇمىي چۈشەنچە</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>ماسلاشتۇرغۇچنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>تور ماسلاشتۇرغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>باتارېيە</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>تېخىمۇ كۆپ</translation>
     </message>
@@ -1702,178 +1645,171 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>نۆۋەتتىكى نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى سەۋەپىسى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>مەشغۇلات</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>تەرجىمە قىلىنىدۇغان سىستېم ۋەزىپىسى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
+        <translation>تەرجىمە قىلغان سىستېم ۋەزىپىسى</translation>
     </message>
 </context>
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>يېڭىلاۋاتىدۇ </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>كىينكى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>دىققەت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>قوزغاتقۇچ ئۆچۈرۈلگەندىن كىيىن،بۇ ئۈسكىنىنى ئىشلەتكىلى بولمايدۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>چىقىرۋىتىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>ئۆچۈرۋاتىدۇ </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>قوزغاتقۇچ يېڭىلاش تامام</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>قوزغاتقۇچ ئوڭۇشلۇق ئۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation> قوزغاتقۇچ يېڭىلاش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>قوزغاتقۇچنى ئۆچۈرەلمىدى </translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>جەزىملەش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>كىينكى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>ھۆججەت قىسقۇچ مەۋجۇت ئەمەس،قايتا تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>كىينكى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>بولاق بۇزۇلغان</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>ماس كەلمەيدىغان قۇرۇلما</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>ھۆججەت مەۋجۇت ئەمەس،قايتا تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>بۇ قوزغىتىش ھۆججىتى ئەمەس</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>قاچىلانمىدى، قاچىلاش بولىقىدا رەقەملىك ئىمزا يوقكەن</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>نامەلۇم خاتالىق</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>بۇ قوزغاتقۇچ مودېلى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>مودۇل فورماتى ئۈنۈمسىز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>بۇ قوزغاتقۇچ مودېلى ئىشلىتىلگەن</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>ئۈسكۈنىنىڭ ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>قاچىلاشقا بولىدىغان نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>مەشغۇلات</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>يېڭىلاشقا بولىدىغان نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>نۆۋەتتىكى نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>قاچىلاشقا بولىدىغان قوزغاتقۇچ (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>يېڭىلاشقا بولىدىغان قوزغاتقۇچ (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>يېڭىلاش ھاجەتسىز قوزغاتقۇچ (%1)</translation>
     </message>
@@ -1939,132 +1870,126 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى نۇرغۇنلاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى تەرجىمە قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى ئاپتىلەش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>جەزىملەش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
-        <translation type="unfinished"/>
+        <translation>تەرجىمە</translation>
     </message>
 </context>
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى ئاپتىلەشىڭىز يوق، تەرجىمە قىلىڭىز</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
+        <translation>تەرجىمە قىلىش ۋەزىپىسىغا چۈش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>نۆۋەتتىكى نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
-        <translation type="unfinished"/>
+        <translation>تەرجىمە قىلغان نەشىرلىك</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>مەشغۇلات</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
+        <translation>ئاپتىلەشىدۇغان سىستېم ۋەزىپىسى</translation>
     </message>
 </context>
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>ئېكسپورت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>ئومۇمىي چۈشەنچە</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى نۇرغۇنلاشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى تەرجىمە قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى ئاپتىلەش</translation>
     </message>
 </context>
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>ئۈسكۈنىنى قوزغىتىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>ئۈسكۈنىنى چەكلىيەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>ئۈسكۈنە تەرتىپ نومۇرىنى ئئالالمىدى، چەكلەش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation> قوزغاتقۇچ يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>قوزغاتقۇچنى چىقىرۋىتىش</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>ئېكسپورت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>ئومۇمىي چۈشەنچە</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation>قوزغىتىش</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation>كومپيۇتېرنى ئويغىتىشقا رۇخسەت قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>ئۈسكۈنە تەرتىپ نومۇرىنى ئالالمىدى، چەكلەش مەغلۇپ بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>ئۈسكۈنىنى چەكلىيەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>ئۈسكۈنىنى قوزغىتىش مەغلۇب بولدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation> قوزغاتقۇچ يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>قوزغاتقۇچنى چىقىرۋىتىش</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation>قوشۇمچە ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation>قوشۇمچى ئۈسكىنە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>قوزغاتقۇ ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>قوزغاتقۇچ ئاكتىپلاش بۇيرۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation>ھالەتنى تەڭشەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation>كېچىكىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>بېجىرگۈچىلەر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>ئومۇمىي لىنىيە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>BIOS ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>ئانا تاختا ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>سىستېما ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>تەگلىك ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>فىزىكىلىق ساقلىغۇچ گورۇپىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>ئېلان قىلىنغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>ئادرېس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>ئىجرا ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>ئالاھىدىلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>زاپچاس يامىقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>مەھسۇلات ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>تەرتىپ نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>مۈلۈك بەلگىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>خاسلىقلار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>تەگلىك ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>ئاساسىي ماشىنا ساندۇقى پىروگراممىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>تىپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>مەزمۇننى ئۆز ئىچىگە ئالغان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>ئويغىنىش تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
         <source>SKU Number</source>
         <translation>SKU نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
         <source>Family</source>
         <translation>ئائىلە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>قۇلۇپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>قوزغىتىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>توك بىلەن تەمىنلەش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>قىززىق ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>بىخەتەرلىك ھالەتلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM ئۇچۇرلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>ئېگىزلىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>توك سىمىنىڭ سانى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>ئۆز ئىچىگە ئېلىنغان ئېلمىنىتلار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>ئورنى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>خاتالىق تۈزىتىش تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>ئەڭ چوڭ سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
         <source>Error Information Handle</source>
         <translation>خاتالىق ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>ئۈسكۈنىلەرنىڭ سانى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>ئېلان قىلىنغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>مۇدىرىيەت ئىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>تىل چۈشەندۈرۈش فورماتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>قاچىلىغىلى بولىدىغان تىللار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>ھازىر قاچىلانغان تىل</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>BD ئادرېسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>بولاق تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>ئۇلىنىش سىياسىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>ئۇلىنىش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>مۇلازىمەت دەرسلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>ئۈسكۈنە سىنىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>قوشۇمچە نەشىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>ئۈسكۈنە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>تەرتىپ نومۇر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>مەھسۇلات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>چۈشەندۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>تۆھپىكار</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>بايقاشقا بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>مۇۋاپىق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>بۇيرۇققا باشقا نام بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>ئىزدەۋاتىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>قوزغاتقۇچ مودۇلى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>ئۈسكۈنە ھۆججىتى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>ئۈسكۈنە ھۆججەتلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>ئۈسكۈنە نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>ئىلتىماس</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>ھالەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>لوگىكىلىق ئىسىم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ANSI نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>بىر تەرەپ قىلغۇچ پىروگراممىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>بىر تەرەپ قىلغۇچ قۇرۇلمىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>مەركىزى بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>بىر تەرەپ قىلغۇچ قىسمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>بىر تەرەپ قىلغۇچ تۈزىتىلگەن نۇسخىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>بىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
-        <translation type="unfinished"/>
+        <translation>تۆنۈك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>ئون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>ئون ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>ئون تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>ئون ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>ئون سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>يىگىرمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>يىگىرمە ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>يىگىرمە تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>يىگىرمە ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>يىگىرمە سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>ئوتتۇز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>ئوتتۇز ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>ئوتتۇز تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>ئوتتۇز ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>ئوتتۇز سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>قىرىق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>قىرىق ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>قىرىق تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>قىرىق ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>قىرىق سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>ئەللىك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>ئەللىك ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>ئەللىك تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>ئەللىك ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>ئەللىك سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>ئاتمىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>ئاتمىش ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>ئاتمىش تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>ئاتمىش ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>ئاتمىش سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>يەتمىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>يەتمىش ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>يەتمىش تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>يەتمىش ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>يەتمىش سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>سەكسەن</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>سەكسەن ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>سەكسەن تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>سەكسەن ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>سەكسەن سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>توقسان</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>توقسان ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>توقسان تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>توقسان ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>توقسان سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>يۈز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>يۈز ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>يۈز تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>يۈز ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>يۈز سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>يۈز ئون</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>يۈز ئون ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>يۈز ئون تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>يۈز ئون ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>يۈز ئون سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>يۈز يىگىرمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>بىر يۈز يىگىرمە ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>يۈز يىگىرمە تۆت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>يۈز يىگىرمە ئالتە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>بىر يۈز يىگىرمە سەككىز</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>بىر يۈز توقسان ئىككى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>256</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU ساتقۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL خېرىدار API لىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL نەشرى</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>نامەلۇم</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>قاتتىق دېتال سىنىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>بىر تەرەپ قىلغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>بىر تەرەپ قىلغۇچ تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>ئانا تاختا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>باش تاختا تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>ساقلىغۇ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>ئىچكى ساقلىغۇچ تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>دىسكا تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى ئاپتىلەشى ئەپەت</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
+        <translation>تەكرارلىق چەقىرىش ھەل قىلىڭ ۋە تەرجىمەنى بېرىڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسى تەرجىمە قىلىشى ئەپەت</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>ماسلاشتۇرغۇچنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>GPU تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>نازارەتچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>نازارەتچى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>تور ماسلاشتۇرغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>تور ماسلاشتۇرغۇچ تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>ئاۋاز ماسلاشتۇرغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>ئاۋاز ئۈسكۈنىسى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>كۆك چىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>كۆك چىش ئۈسكۈنىسى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>باشقا PCI ئۈسكۈنىلىرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>باشقا PCI ئۈسكۈنىلىرى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>توك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>باتارېيە تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>كۇنۇپكا تاختىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>ھېچقانداق كۇنۇپكا تاختىسى تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation>چاشقىنەك</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>مائۇس تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>پىرىنتېر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>پىرىنتېر تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>كامېرا</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>كامېرا تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>قوزغاتقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>قوزغاتقۇچ تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>باشقا ئۈسكۈنىلەر</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>باشقا ئۈسكۈنىلەر تېپىلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>گورۇپپا پىروگرامما</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>سىغىم شەكلى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>بېكىتىش</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>سىغم بەلگىلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>تەپسىلات تىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>بۆلەك نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>رەت تەرتىپى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>ئىچكى ساقلىغۇچ تېخنىكىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>ئىچكى ساقلىغۇچ مەشغۇلات ئىقتىدارى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>يۇمشاق دېتال نەشرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>مودېل ئىشلەپچىقارغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>IDمودۇل مەھسۇلات</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>ئىچكى ساقلىغۇچ سىستېمىسى كونتروللىغۇچ ئىشلەپچىقارغۇچى كىملىكى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>ئىچكى ساقلىغۇچ سىستېمىسى كونتروللىغۇچ مەھسۇلات IDسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>تۇراقسىز چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>ئۆزگىرىشچان چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>ساقلانما سىغىمى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>لوگىكىلىق چوڭلۇق</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>ئىنگىلىزچىسى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>چېسلا</translation>
     </message>
@@ -3692,315 +3453,296 @@
         <translation>يان تەرەپ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>مۇقىم ھالەتلىك ساقلىغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>مېخانىكىلىق ساقلىغۇچ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>باس ئۇچۇرى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>لوگىكىلىق سېكتور چوڭلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>ساھە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>كۆرسەتمە</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>گېئومېتىرىيە (لوگىكىلىق)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>ئۈسكۈنە باشقۇرغۇچى</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>ئۈسكۈنە باشقۇرغۇچى قاتتىق دېتال ئۇچۇرلىرىنى كۆرۈش ۋە ئۈسكۈنىلەرنى باشقۇرۇشتىكى قۇلايلىق قورال.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>قاچىلاش/يېڭىلاشقا بولىدىغان قوزغاتقۇچ بار</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>كۆرۈش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>ئۆز ئىچىگە ئالغان تارماق ھۆججەت قىسقۇچ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>قۇرغاتقۇچ ئورنىنى تاللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>يېڭىلاپ قاچىلاشقا بولىدىغان %1 بايقالدى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>تەكشۈرۈش ۋاقتى: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>%1 قوزغاتقۇچ چۈشۈۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>چۈشۈرۈش سۈرئىتى: %1 تاماملاندى %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>%1 قوزغاتقۇچ قاچىلىنىۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 قوزغاتقۇچ قاچىلاندى، %2 قاچىلانمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 قوزغاتقۇچ قاچىلاندى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>قوزغاتقۇچ قاچىلانمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>تور نورمالسىز، قايتا سىناڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>چۈشۈرۈش سۈرئىتى: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>قوزغاتقۇچ يېڭى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>ھەممە سىستېم ۋەزىپىسى تەرجىمە قىلغان</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 تۆنۈك سىستېم ۋەزىپىسى، ئۇلارنىڭ %2 تۆنۈكى تەرجىمە قىلغان</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
+        <translation>%1 تۆنۈك سىستېم ۋەزىپىسىنى تەرجىمە قىلىشى مۇمكىن، ئۇنى ئەمەل قىلىش ئۇچۇن ئەمەل قىلىڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 تۆنۈك سىستېم ۋەزىپىسىنى تەرجىمە قىلىشى مۇمكىن</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
+        <translation>%1 سىستېم ۋەزىپىسىنى تەرجىمە قىلىۋاتىدۇ، ھەممە %2 تۆنۈك سىستېم ۋەزىپىسى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
-        <translation type="unfinished"/>
+        <translation>تەرجىمە قىلىۋاتىدۇ: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
+        <translation>%1 تۆنۈك سىستېم ۋەزىپىسى تەرجىمە قىلغان، %2 تۆنۈك سىستېم ۋەزىپىسى ئەپەت</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم ۋەزىپىسىنى تەرجىمە قىلىش ئەپەت</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
+        <translation>%1 تۆنۈك سىستېم ۋەزىپىسى تەرجىمە قىلغان</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
+        <translation>ئەنە %1 ۋەزىپىنى ئەپەتلىك قىلغۇچىنىڭ ئەپەتلىك قىلىنىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلغۇچىنى ئەپەتلىك قىلىش چۈشىنىڭ ئىشلىتىشىڭىز ھەققىدە</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
+        <translation>ۋەزىپىنى ئەپەتلىك قىلغۇچى ئەپەتلىك قىلىدۇ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلىنىدۇ: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>كومپيۇتېرنى قايتا قوزغىتىش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>قوزغاتقۇچ قاچىلىنىپ بولدى، سەل تۇرۇپ %1 دىن كېيىن كۈچكە ئىگە بولىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
-        <translation type="unfinished"/>
+        <translation>ھەققىدە ئەپەتلىك قىلىنىدۇ ھەققىدە ھەققىدە</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
-        <translation type="unfinished"/>
+        <translation>ھەممىنى ئەپەتلىك قىلىڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation>ئىنكاس</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>قوزغاتقۇچ قاچىلانمىدى، قايتا سىناڭ ياكى بىزگە %1 يوللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>ھەممىنى قاچىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>قايتا تەكشۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>قاتتىق دېتاللارنى تەكشۈرۈۋاتىدۇ، سەل ساقلاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>تەكشۈرۈۋاتىدۇ %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>تەكشۈرەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>تور يوق</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>تور ئۇلىنىشىنى تەكشۈرۈڭ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>قايتا تەكشۈرۈڭ ياكى بىزگە %1 يوللاڭ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>قوزغاتقۇچ قاچىلىنىۋاتىدۇ، چېكىنسىڭىز ۋەزىپە توختاپ قالىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>راستلا چېكىنەمسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>سىز ۋەزىپىنى ئەپەتلىك قىلغۇچىنى ئەپەتلىك قىلىۋاتىسىز، سىز چыققاندا ئۇ چەقىرىلىدۇ.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
+        <translation>سىز ۋەزىپىنى ئەپەتلىك قىلغۇچىنى ئەپەتلىك قىلىۋاتىسىز، سىز چыققاندا ئۇ چەقىرىلىدۇ.</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="36"/>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>تەسۋىر ئۈسكۈنىسى</translation>
     </message>
@@ -4071,27 +3812,27 @@
     <message>
         <location filename="../src/Tool/commontools.cpp" line="73"/>
         <source>Not backed up</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلىنمىغان</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="74"/>
         <source>Backing up</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلىۋاتىدۇ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="75"/>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلىش مەغلۇب قىلىنغان</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="76"/>
         <source>Backup successful</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلىش مۇۋەффاقىيەت بەرگەن</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="77"/>
         <source>Restoring</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلىۋاتىدۇ</translation>
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="81"/>
@@ -4114,22 +3855,22 @@
         <translation>قوزغاتقۇچ ھۆججىتىگە ئېرىشەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
-        <translation type="unfinished"/>
+        <translation>ئەپەتلىك قىلىش</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>ئەپەتلىك قىلىش</translation>
     </message>
     <message>
         <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
         <source>Install</source>
         <translation>قاچىلاش</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>ئېكسپورت</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation> قوزغاتقۇچ يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>قوزغاتقۇچنى چىقىرۋىتىش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>كومپيۇتېرنى ئويغىتىشقا رۇخسەت قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>قوزغىتىش</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>يېڭىلاش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>ئېكسپورت</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>چەكلەش</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>ئىشلەتكىلى بولمايدۇ</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>يەرلىكتىكى ھۆججەت قىسقۇچنى تاللاڭ</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>يۈكلەۋاتىدۇ...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_uk.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_uk.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Відгуки</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">Більше</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Згорнути</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Більше</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>Більше</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Згорнути</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Більше</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Згорнути</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Назва пристрою</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Мікросхема</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Альт. назва модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>Фізичний ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Модифікація</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Адреса у пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Набір мікросхем</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Інша назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Альт. назва модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>Фізичний ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Максимальна потужність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Версія драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Дані щодо каналу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Логічна назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>MAC-адреса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Дані щодо каналу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Максимальна потужність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Альт. назва модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>Фізичний ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>Ід. проц.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID ядра</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Потоки</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>Архітектура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Сімейство проц.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>Процесор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Ядра</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Віртуалізація</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Прапорці</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Розширення</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>Кеш L4</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>Кеш L3</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>Кеш L2</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>Кеш L1i</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>Кеш L1d</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Модифікація</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>Макс. швидкість</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Графічна пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Альт. назва модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>Фізичний ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Адреса у пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Порт ВВ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Дані щодо каналу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Максимальна роздільність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Мінімальна роздільність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Поточна роздільність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Виведення на дисплей</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Дані щодо каналу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Альт. назва модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>Фізичний ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Максимальна потужність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Серійний номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Інтерфейс</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Дані щодо каналу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Альт. назва модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>Фізичний ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Максимальний струм</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>Огляд</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>Процесор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>Кількість процесорів</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>Материнська плата</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>Пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>Адаптер дисплея</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>Звуковий адаптер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>Сховище даних</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>Інші пристрої PCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>Акумулятор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>Адаптер мережі</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>Миша</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>Клавіатура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>Монітор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>Принтер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>Камера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Інші пристрої</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>Пристрій</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>ОС</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Загальна ширина</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Локатор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Серійний номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Поточне напруження</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Максимальна напруга</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Мінімальна напруга</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>Налаштована швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Ширина даних</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Вхід дисплея</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Тип інтерфейсу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Підтримувана роздільність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Поточна роздільність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Співвідношення розмірів</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Основний монітор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Серійний номер</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>Постачальник</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>Тип носія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Альт. назва модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>Фізичний ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Версія мікропрограми</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Швидкість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Серійний номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Інтерфейс</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Частота обертання</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>Виберіть драйвер для оновлення</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>У цій теці драйверів не знайдено</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Завантажуємо дані щодо звукових пристроїв…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Завантажуємо дані BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Завантажуємо дані щодо CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Завантажуємо дані щодо операційної системи…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Завантажуємо відомості щодо процесора…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Завантажуємо дані щодо інших пристроїв…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Завантажуємо дані щодо живлення…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Завантажуємо дані щодо принтерів…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Завантажуємо дані щодо миші…</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Завантажуємо дані щодо адаптера мережі…</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>Дані щодо пристрою</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Скорочення дисплея</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Керування пристроями</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Обладнання</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>Драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Монітор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Огляд</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Адаптер дисплея</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>Процесор</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Адаптер мережі</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Акумулятор</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Більше</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>Поточна версія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>Версія платформи драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Стан</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Дія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>Придатні до резервного копіювання драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>Драйвери з резервними копіями</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>Оновлення</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Далі</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Після вилучення драйвер неможливо буде отримати доступ до пристрою</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Вилучення</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Успішне оновлення</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Успішне вилучення</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Помилка під час оновлення</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Помилка під час вилучення</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Далі</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Вибраної теки не існує. Будь ласка, виберіть іншу теку</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>Пошкоджений пакунок</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Невідповідна архітектура пакунка</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>Вибраного файла не існує. Будь ласка, виберіть інший файл</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Не є драйвером</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Неможливо встановити: немає цифрового підпису</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Невідома помилка</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Модуль драйвера не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Некоректний формат модуля</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Модуль драйвера має залежності</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>Назва пристрою</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Доступна версія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>Розмір</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>Стан</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>Дія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Нова версія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Поточна версія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Не вистачає драйверів (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Застарілі драйвери (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>Актуальні драйвери (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>Встановлення драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>Резервне копіювання драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>Відновлення драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Відгуки</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>У вас немає жодного драйвера для відновлення. Будь ласка, спочатку створіть резервну копію</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Перейти до резервного драйвера</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Поточна версія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Резервна версія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Дія</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>Придатні до відновлення драйвери</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Огляд</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Встановлення драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>Резервне копіювання драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Відновлення драйвера</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Не вдалося увімкнути пристрій</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Не вдалося вимкнути пристрій</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Не вдалося вимкнути його: не можемо отримати серійний номер пристрою</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Оновити драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Вилучити драйвери</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>Огляд</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>Увімкнути</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>Дозволити пробуджувати комп&apos;ютер</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Не вдалося вимкнути його: не можемо отримати серійний номер пристрою</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>Не вдалося вимкнути пристрій</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>Не вдалося увімкнути пристрій</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>Оновити драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>Вилучити драйвери</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>Підрядчик</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>Підпристрій</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>Драйвер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>Стан драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>Команда активації драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>Стан налаштувань</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>латентність</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Фіз.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Обробники</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>КЛЮЧ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Версія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>Канал</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>Дані BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>Базові дані щодо плати</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>Системна інформація</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>Дані щодо основи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>Масив фізичної пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Дата випуску</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Динамічний розмір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Розмір ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Характеристики</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Модифікація BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Модифікація мікропрограми</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>Назва продукту</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>Серійний номер</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>Мітка активу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>Можливості</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Розташування на основі</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Обробник основи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>Обробники вміщених об&apos;єктів</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>Тип пробудження</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>Номер SKU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>Сімейство</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>Заблокувати</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>Стан завантаження</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>Стан живлення</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>Термічний стан</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>Стан безпеки</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>Дані щодо OEM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>Висота</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>Кількість ліній живлення</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>Включені елементи</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>Розташування</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>Тип виправлення помилок</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>Максимальна місткість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>Обробник відомостей щодо помилок</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>Кількість пристроїв</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>Розмір BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>Дата випуску</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>Назва плати</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>Версія SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>Формат опису мови</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>Придатні до встановлення мови</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Поточна встановлена мова</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Адреса BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>MTU ACL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>MTU SCO</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Тип пакета</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Правила зв&apos;язку</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Режим зв&apos;язку</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>Клас</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Класи служби</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Клас пристрою</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Версія HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Версія LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Підверсія</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>Пристрій</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>Послідовний ід.</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>продукт</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>опис</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Живлення</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Може визначатися</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Може пов&apos;язуватися</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Мод-прив&apos;язка</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Визначення</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>Модулі драйвера</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>Файл пристрою</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>Файли пристроїв</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>Номер пристрою</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Програма</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>стан</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>логічна назва</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>версія ANSI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Реалізатор процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Архітектура процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Варіант процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Частина процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Модифікація процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Одне</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Шістка</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Дев&apos;ять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Десятка</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Дванадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Чотирнадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Шістнадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Вісімнадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Двадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Двадцять два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Двадцять чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Двадцять шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Двадцять вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Тридцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Тридцять два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Тридцять чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Тридцять шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Тридцять вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Сорок</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Сорок два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Сорок чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Сорок шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Сорок вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>П’ятдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>П&apos;ятдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>П&apos;ятдесят чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>П&apos;ятдесят шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>П&apos;ятдесят вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Шістдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Шістдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Шістдесят чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Шістдесят шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Шістдесят вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Сімдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Сімдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Сімдесят чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Сімдесят шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Сімдесят вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Вісімдесят</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Вісімдесят два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Вісімдесят чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Вісімдесят шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Вісімдесят вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Дев&apos;яносто</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Дев&apos;яносто два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Дев&apos;яносто чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Дев&apos;яносто шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Дев&apos;яносто вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Сто</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Сто два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Сто чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Сто шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Сто вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Сто десять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Сто дванадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Сто чотирнадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Сто шістнадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Сто вісімнадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Сто двадцять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Сто двадцять два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Сто двадцять чотири</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Сто двадцять шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Сто двадцять вісім</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Сто дев&apos;яносто два</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Двісті п&apos;ятдесят шість</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Місткість GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Виробник графічного процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Тип графічного процесора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Версія EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>Клієнтські програмні інтерфейси EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Версія GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Версія GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>Невідомий</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>Клас обладнання</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>Процесор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>Процесорів не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>Материнська плата</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>Материнської плати не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>Пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>Пам&apos;яті не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>Сховище даних</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>Не знайдено дисків</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Не вдалося відновити драйвер!</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>Будь ласка, повторіть спробу або залиште відгук</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Не вдалося створити резервну копію драйвера!</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>Адаптер дисплея</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>Графічних процесорів не виявлено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>Монітор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>Моніторів не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>Адаптер мережі</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>Не знайдено адаптера мережі</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>Звуковий адаптер</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>Звукових пристроїв не знайдено</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>Не знайдено пристроїв Bluetooth</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>Інші пристрої PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>Не знайдено інших пристроїв PCI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>Живлення</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>Не знайдено акумулятора</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>Звуковий адаптер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>Звукових пристроїв не знайдено</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>Не знайдено пристроїв Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>Інші пристрої PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>Не знайдено інших пристроїв PCI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>Живлення</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>Не знайдено акумулятора</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>Клавіатура</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>Не знайдено клавіатури</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>Миша</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>Не знайдено миші</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>Принтер</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>Не знайдено принтерів</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>Камера</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>Не знайдено камери</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>CD-ROM</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>Не знайдено CD-ROM</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>Миша</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>Не знайдено миші</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>Принтер</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>Не знайдено принтерів</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>Не знайдено камери</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>Не знайдено CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>Інші пристрої</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>Інших пристроїв не знайдено</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Обробник масивів</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Формфактор</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Набір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Локатор банків</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Подробиці щодо типу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Номер частини</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Ранг</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Технологія пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Можливості режиму керування пам&apos;яттю</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Версія мікропрограми</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Ідентифікатор виробника модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Ідентифікатор продукту модуля</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Ідентифікатор виробника контролера підсистеми пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Ідентифікатор продукту контролера підсистеми пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Сталий розмір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Мінливий розмір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Розмір кешу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Логічний розмір</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>дюйм</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>боки</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>дані щодо каналу</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>розмір логічного сектора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>розмір сектора</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>guid</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Геометрія (логічна)</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>Керування пристроями</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>«Керування пристроями» — зручний інструмент для перегляду відомостей щодо обладнання та керування пристроями.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Випущено нові драйвери! Встановіть їх або оновіть їх зараз.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Переглянути</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Включити підтеки</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Шукати драйвери у цій теці</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>Доступні оновлення драйверів (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>Минуло часу: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Отримуємо драйвери до %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Швидкість отримання: %1 Отримано %2 з %3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Встановлюємо драйвери до %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>Встановлено %1 драйверів, %2 драйверів не вдалося встановити</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>Встановлено %1 драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Не вдалося встановити драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Помилка мережі. Відновлюємо з&apos;єднання…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Швидкість отримання: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Ваші драйвери є найновішими</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Створено резервні копії усіх драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Загалом %1 драйверів, для %2 драйверів створено резервні копії</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>У вас %1 драйверів, для яких можна створити резервні копії. Рекомендуємо зробити це негайно</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>У вас %1 драйверів, для яких можна створити резервні копії</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Створюємо резервну копію драйвера %1, загалом — %2 драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Резервне копіювання: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>Створено резервні копії %1 драйверів, помилки — %2 драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Не вдалося створити резервні копії драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>Створено резервні копії %1 драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>У вас %1 драйверів, які можна відновити з резервних копій</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Будь ласка, виберіть драйвер для відновлення</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Відновлюємо драйвер…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Відновлення: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>виконайте перезавантаження</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Будь ласка, %1, щоб встановлені драйвери запрацювали</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Переглянути шлях до резервних копій</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Створити резервні копії усього</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>надішліть відгук</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Будь ласка, повторіть спробу або %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Встановити усе</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>Повторити пошук</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Шукаємо драйвери пристроїв, будь ласка, зачекайте…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>Шукаємо у %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Помилка під час пошуку</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Немає доступу до мережі</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Будь ласка, перевірте, чи працює з&apos;єднання з мережею</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Будь ласка, повторіть пошук або %1</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Ви встановлюєте драйвер. Процедуру буде перервано, якщо ви вийдете з програми.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви справді хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Ви створюєте резервні копії драйверів. Процедуру буде перервано, якщо ви вийдете з програми.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Ви відновлюєте драйвери. Процедуру буде перервано, якщо ви вийдете з програми.</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>Не вдалося отримати файли драйверів</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Резервне копіювання</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Відновити</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Встановити</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Оновити драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Вилучити драйвери</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Дозволити пробуджувати комп&apos;ютер</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>Увімкнути</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>Експортувати</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>Вимкнути</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Недоступне</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Будь ласка, вкажіть локальну теку</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Завантаження…</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_ur.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_ur.ts
@@ -1,0 +1,3965 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ur">
+<context>
+    <name>BtnLabel</name>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+        <source>Feedback</source>
+        <translation>فیدبک</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>اک</translation>
+    </message>
+</context>
+<context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">More</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Collapse</translation>
+    </message>
+</context>
+<context>
+    <name>CmdButtonWidget</name>
+    <message>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+        <source>More</source>
+        <translation>زیاد</translation>
+    </message>
+</context>
+<context>
+    <name>CommonTools</name>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="85"/>
+        <source>EC_NOTIFY_NETWORK</source>
+        <translation>اخطار شبکہ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="86"/>
+        <source>EC_REINSTALL</source>
+        <translation>دوبارہ نصب کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="87"/>
+        <source>EC_6</source>
+        <translation>EC_6</translation>
+    </message>
+</context>
+<context>
+    <name>DetailButton</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <source>More</source>
+        <translation>زیاد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
+        <source>Collapse</source>
+        <translation>کچھ کریں</translation>
+    </message>
+</context>
+<context>
+    <name>DetailViewDelegate</name>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+        <source>Disable</source>
+        <translation>بند کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+        <source>Unavailable</source>
+        <translation>دستیاب نہیں</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceAudio</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <source>Device Name</source>
+        <translation>ڈیوائس نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+        <source>Chip</source>
+        <translation>چپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+        <source>Capabilities</source>
+        <translation>کیپیبیلٹیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <source>SysFS_Path</source>
+        <translation>سیس اف ڈرائیو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+        <source>Description</source>
+        <translation type="unfinished">Description</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+        <source>Revision</source>
+        <translation>ریویژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+        <source>KernelModeDriver</source>
+        <translation>کرنل مڈ ڈرائیو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+        <source>Memory Address</source>
+        <translation>میموری ایڈریس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+        <source>IRQ</source>
+        <translation>ای آر یو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+        <source>Unavailable</source>
+        <translation>دستیاب نہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+        <source>Disable</source>
+        <translation>بند کریں</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBaseInfo</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+        <source>Model</source>
+        <translation>مڈل</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBios</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+        <source>Version</source>
+        <translation>ویژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+        <source>Chipset</source>
+        <translation>چپسیٹ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceBluetooth</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <source>Alias</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <source>Vendor</source>
+        <translation>مصنوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <source>Version</source>
+        <translation>نسخہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <source>Model</source>
+        <translation>میڈیل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+        <source>Speed</source>
+        <translation>تیزی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+        <source>Maximum Power</source>
+        <translation>زیادہ توانائی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+        <source>Driver Version</source>
+        <translation>ڈرائیور نسخہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+        <source>Driver</source>
+        <translation>ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+        <source>Capabilities</source>
+        <translation>قدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+        <source>Bus Info</source>
+        <translation>بوس انس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+        <source>Logical Name</source>
+        <translation>منطقی نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+        <source>MAC Address</source>
+        <translation>MAC پتہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+        <source>Unavailable</source>
+        <translation>دستیاب نہ ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+        <source>Disable</source>
+        <translation>نافذ کریں</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCdrom</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+        <source>Vendor</source>
+        <translation>مصنوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+        <source>Model</source>
+        <translation>میڈیل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+        <source>Version</source>
+        <translation>نسخہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <source>Bus Info</source>
+        <translation>بوس انس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <source>Capabilities</source>
+        <translation>قدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+        <source>Driver</source>
+        <translation>ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+        <source>Maximum Power</source>
+        <translation>زیادہ توانائی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+        <source>Speed</source>
+        <translation>تیزی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+        <source>Unavailable</source>
+        <translation>دستیاب نہ ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+        <source>Disable</source>
+        <translation>نافذ کریں</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceComputer</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceCpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <source>Name</source>
+        <translation>مصنوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <source>Vendor</source>
+        <translation>CPU ہٹہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <source>CPU ID</source>
+        <translation>کور ہٹہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+        <source>Core ID</source>
+        <translation>ٹھانز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+        <source>Threads</source>
+        <translation>سائلوں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+        <source>BogoMIPS</source>
+        <translation>بوجومیپس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <source>Architecture</source>
+        <translation>آرکیٹیکچر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+        <source>CPU Family</source>
+        <translation>کیو پی فیملی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+        <source>Model</source>
+        <translation>مڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <source>Processor</source>
+        <translation>پرچیسر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+        <source>Core(s)</source>
+        <translation>کریکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+        <source>Virtualization</source>
+        <translation>ویرچوئلائزیشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+        <source>Flags</source>
+        <translation>فلاگس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+        <source>Extensions</source>
+        <translation>اکسنسنس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+        <source>L4 Cache</source>
+        <translation type="unfinished">L4 Cache</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+        <source>L3 Cache</source>
+        <translation>ایل 3 کیچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <source>L2 Cache</source>
+        <translation>ایل 2 کیچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <source>L1i Cache</source>
+        <translation>ایل 1 آئی کی چ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <source>L1d Cache</source>
+        <translation>ایل 1 ڈی کیچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <source>Stepping</source>
+        <translation>سٹیپنگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+        <source>Speed</source>
+        <translation>سپیڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <source>Max Speed</source>
+        <translation>مکس سپیڈ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceGpu</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+        <source>Vendor</source>
+        <translation>ورنر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+        <source>Model</source>
+        <translation>مڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+        <source>Version</source>
+        <translation>ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+        <source>Graphics Memory</source>
+        <translation>گرافکس میموری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <source>Physical ID</source>
+        <translation>فیزیکل آئی ڈی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <source>Memory Address</source>
+        <translation>میموری ایڈریس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <source>IO Port</source>
+        <translation>آئو پورٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+        <source>Bus Info</source>
+        <translation>بس انس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+        <source>Maximum Resolution</source>
+        <translation>مکسیمم ریزولوشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+        <source>Minimum Resolution</source>
+        <translation>مینیمم ریزولوشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+        <source>Current Resolution</source>
+        <translation>کرنٹ ریزولوشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+        <source>Driver</source>
+        <translation>ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+        <source>Description</source>
+        <translation>ڈسکریپشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+        <source>DP</source>
+        <translation>DP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+        <source>eDP</source>
+        <translation>eDP</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <source>HDMI</source>
+        <translation>HDMI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+        <source>VGA</source>
+        <translation>VGA</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+        <source>DVI</source>
+        <translation>DVI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+        <source>DigitalOutput</source>
+        <translation>انبوت دیجیٹل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+        <source>Display Output</source>
+        <translation>انبوت ڈسپلے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+        <source>Capabilities</source>
+        <translation>کیپیبلیٹیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+        <source>IRQ</source>
+        <translation>ای آر یو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+        <source>Unavailable</source>
+        <translation>دستیاب نہیں</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceImage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <source>Version</source>
+        <translation>ویژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <source>Model</source>
+        <translation>مودل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <source>Bus Info</source>
+        <translation>بس انس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+        <source>Speed</source>
+        <translation>سپیڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+        <source>Maximum Power</source>
+        <translation>مکسیمم پاور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+        <source>Driver</source>
+        <translation>ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>کیپیبلیٹیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+        <source>Serial Number</source>
+        <translation>سریل نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+        <source>Unavailable</source>
+        <translation>دستیاب نہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+        <source>Disable</source>
+        <translation>disable</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceInput</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+        <source>Vendor</source>
+        <translation>نکاتور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+        <source>Model</source>
+        <translation>مڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+        <source>Interface</source>
+        <translation>انٹرفیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+        <source>Bus Info</source>
+        <translation>BUS معلومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+        <source>Speed</source>
+        <translation>سپیڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+        <source>Maximum Current</source>
+        <translation>مکسیمم کررنت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+        <source>Driver</source>
+        <translation>ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+        <source>Capabilities</source>
+        <translation>قدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+        <source>Version</source>
+        <translation>نسخہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+        <source>Unavailable</source>
+        <translation>ناممکن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+        <source>Disable</source>
+        <translation>نامیکردی</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceManager</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <source>Overview</source>
+        <translation>اجمال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <source>CPU quantity</source>
+        <translation>مقدار CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <source>Motherboard</source>
+        <translation>مادر بورڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <source>Memory</source>
+        <translation>ذخیرہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <source>Display Adapter</source>
+        <translation>آئی ڈی ہیڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <source>Sound Adapter</source>
+        <translation>صوتی ہیڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <source>Storage</source>
+        <translation>ذخیرہ ایکثریت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <source>Other PCI Devices</source>
+        <translation>دوسرے PCI دستاویزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <source>Battery</source>
+        <translation> Battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <source>Bluetooth</source>
+        <translation>بلوتوث</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <source>Network Adapter</source>
+        <translation>نیٹ ورک ہیڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <source>Mouse</source>
+        <translation>ماؤس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <source>Keyboard</source>
+        <translation>کیبورڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <source>Monitor</source>
+        <translation>میٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <source>Printer</source>
+        <translation>پرنر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <source>Camera</source>
+        <translation>کیمرہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <source>Other Devices</source>
+        <comment>Other Input Devices</comment>
+        <translation>دوسرے دستاویزات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <source>Device</source>
+        <translation>دستاویز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <source>OS</source>
+        <translation>OS</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMemory</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <source>Vendor</source>
+        <translation>فروشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <source>Size</source>
+        <translation>حجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <source>Type</source>
+        <translation>تیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <source>Total Width</source>
+        <translation>کل چوڑائی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+        <source>Locator</source>
+        <translation>لوکیٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>سریل نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+        <source>Configured Voltage</source>
+        <translation>کانفیگرڈ ولٹیج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+        <source>Maximum Voltage</source>
+        <translation>مکسیمم ولٹیج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+        <source>Minimum Voltage</source>
+        <translation>مکسیمم ولٹیج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <source>Configured Speed</source>
+        <translation>کانفیگرڈ ڈیڑھی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <source>Data Width</source>
+        <translation>ڈیٹا چوڑائی</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceMonitor</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+        <source>Type</source>
+        <translation>تیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+        <source>Display Input</source>
+        <translation>ڈسپلے انپوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+        <source>Interface Type</source>
+        <translation>انٹرفیس تیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+        <source>Support Resolution</source>
+        <translation>سپورٹ ریزولیشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+        <source>Current Resolution</source>
+        <translation>کرنٹ ریزولیشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+        <source>Display Ratio</source>
+        <translation>ڈسپلے ریٹیو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+        <source>Primary Monitor</source>
+        <translation>پریمئر ڈسپلے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+        <source>Size</source>
+        <translation>سائز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+        <source>Serial Number</source>
+        <translation>سریل نمبر</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceNetwork</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+        <source>Type</source>
+        <translation>تیپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+        <source>Version</source>
+        <translation>ویریشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+        <source>Bus Info</source>
+        <translation>بس انس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+        <source>Capabilities</source>
+        <translation>کیپیبیلیٹیز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+        <source>Driver</source>
+        <translation>ڈرائیو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+        <source>Driver Version</source>
+        <translation>ڈرائیو ویریشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+        <source>Maximum Rate</source>
+        <translation>مکسیمم ریٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+        <source>Negotiation Rate</source>
+        <translation>نیوٹیئیشن ریٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+        <source>Port</source>
+        <translation>پورٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+        <source>Multicast</source>
+        <translation>مکسٹ کریسٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+        <source>Link</source>
+        <translation> لنک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+        <source>Latency</source>
+        <translation> لیٹنسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+        <source>IP</source>
+        <translation> آئی پی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+        <source>Firmware</source>
+        <translation> فرموwar</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+        <source>Duplex</source>
+        <translation> ڈپلکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+        <source>Broadcast</source>
+        <translation> بروڈکاسٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+        <source>Auto Negotiation</source>
+        <translation> آؤٹو نیوٹییشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+        <source>Memory Address</source>
+        <translation> ہمیٹری ایڈریس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+        <source>IRQ</source>
+        <translation> آئی آر کیو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+        <source>MAC Address</source>
+        <translation> امیک ایڈریس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+        <source>Logical Name</source>
+        <translation> لوجیکل نیم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+        <source>Unavailable</source>
+        <translation> دستیاب نہ ہو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+        <source>Disable</source>
+        <translation> ناکارہ کریں</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOtherPCI</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+        <source>Name</source>
+        <translation> نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+        <source>Vendor</source>
+        <translation> ونڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+        <source>Model</source>
+        <translation> میڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+        <source>Bus Info</source>
+        <translation> بس انس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+        <source>Version</source>
+        <translation> ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+        <source>Input/Output</source>
+        <translation> ان پوت/آؤٹ پوت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+        <source>Memory</source>
+        <translation> ہمیٹری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+        <source>IRQ</source>
+        <translation> آئی آر کیو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+        <source>Latency</source>
+        <translation> لیٹنسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+        <source>Driver</source>
+        <translation> ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+        <source>Capabilities</source>
+        <translation> کیپیبیلیٹیز</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceOthers</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+        <source>Name</source>
+        <translation> نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+        <source>Vendor</source>
+        <translation> ونڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+        <source>Model</source>
+        <translation> میڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+        <source>Version</source>
+        <translation> ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+        <source>Bus Info</source>
+        <translation> بس انس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+        <source>Capabilities</source>
+        <translation>قدرتاں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+        <source>Driver</source>
+        <translation>ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+        <source>Maximum Power</source>
+        <translation>مکسیمم پاور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+        <source>Speed</source>
+        <translation>سرعت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+        <source>Serial Number</source>
+        <translation>سریل نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+        <source>Unavailable</source>
+        <translation>دستیاب نہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+        <source>Disable</source>
+        <translation>Disable</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePower</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+        <source>Model</source>
+        <translation>میل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+        <source>Serial Number</source>
+        <translation>سریل نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+        <source>Type</source>
+        <translation>ٹائپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+        <source>Status</source>
+        <translation>حیثیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+        <source>Capacity</source>
+        <translation>کیپسیٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+        <source>Voltage</source>
+        <translation>ولٹیج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+        <source>Slot</source>
+        <translation>سات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+        <source>Design Capacity</source>
+        <translation>ڈیزائن کیپسیٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+        <source>Design Voltage</source>
+        <translation>ڈیزائن ولٹیج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+        <source>SBDS Version</source>
+        <translation>SBDS ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+        <source>SBDS Serial Number</source>
+        <translation>SBDS سریل نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+        <source>SBDS Manufacture Date</source>
+        <translation>SBDS تیاری کی تاریخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+        <source>SBDS Chemistry</source>
+        <translation>SBDS کیمیسٹری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+        <source>Temperature</source>
+        <translation>ٹمپریچر</translation>
+    </message>
+</context>
+<context>
+    <name>DevicePrint</name>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+        <source>Name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+        <source>Model</source>
+        <translation>میل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+        <source>Vendor</source>
+        <translation>وینڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+        <source>Serial Number</source>
+        <translation>سریل نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+        <source>Shared</source>
+        <translation>شیئر کیا گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+        <source>Status</source>
+        <translation>حیثیت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+        <source>Interface Type</source>
+        <translation>نوع واسطه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+        <source>Disable</source>
+        <translation>بلا</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceStorage</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <source>Vendor</source>
+        <translation>مزود</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <source>Media Type</source>
+        <translation>نوع وسائط</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <source>Size</source>
+        <translation>حجم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+        <source>Version</source>
+        <translation>نسخه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+        <source>Capabilities</source>
+        <translation>قدرات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+        <source>Module Alias</source>
+        <translation type="unfinished">Module Alias</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+        <source>Physical ID</source>
+        <translation type="unfinished">Physical ID</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+        <source>Firmware Version</source>
+        <translation>نسخه نرم‌افزار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+        <source>Speed</source>
+        <translation>تیزی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <source>Description</source>
+        <translation>توضيحات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+        <source>Serial Number</source>
+        <translation>شماره سريال</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+        <source>Interface</source>
+        <translation>واسطه</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+        <source>Rotation Rate</source>
+        <translation>نرخ چرخش</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+</context>
+<context>
+    <name>GetDriverNameWidget</name>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <source>Select a driver for update</source>
+        <translation>ایک ڈرائیو انتخاب کریں تاکہ اپ ڈیٹ کرے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+        <source>No drivers found in this folder</source>
+        <translation>اس فولڈر میں کوئی ڈرائیو نہیں ملا</translation>
+    </message>
+</context>
+<context>
+    <name>GetInfoPool</name>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+        <source>Loading Audio Device Info...</source>
+        <translation>آڈیو دستگاه اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+        <source>Loading BIOS Info...</source>
+        <translation>بیوس اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <source>Loading CD-ROM Info...</source>
+        <translation>CD-ROM اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+        <source>Loading Operating System Info...</source>
+        <translation>آپریٹنگ سسٹم اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+        <source>Loading CPU Info...</source>
+        <translation>CPU اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+        <source>Loading Other Devices Info...</source>
+        <translation>دوسرے دستگاہوں کی اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+        <source>Loading Power Info...</source>
+        <translation>پاور اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+        <source>Loading Printer Info...</source>
+        <translation>Printer اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+        <source>Loading Mouse Info...</source>
+        <translation>Mouse اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+        <source>Loading Network Adapter Info...</source>
+        <translation>نیٹ ورک اڈاپٹر اطلاعات لود کر رہے ہیں...</translation>
+    </message>
+</context>
+<context>
+    <name>LogTreeView</name>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <source>Disable</source>
+        <translation>بلا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewItemDelegate</name>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+        <source>Disable</source>
+        <translation>بلا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+        <source>Unavailable</source>
+        <translation>غير متوفر</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
+        <source>Device Info</source>
+        <comment>export file's name</comment>
+        <translation>ڈیوائس ایکسپورٹ فائل کا نام</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
+        <source>Display shortcuts</source>
+        <translation>کیوبرد کی کمیابی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
+        <source>Close</source>
+        <translation>بند کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
+        <source>Help</source>
+        <translation>مدد</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
+        <source>Copy</source>
+        <translation>کاپی کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
+        <source>System</source>
+        <translation>سسٹم</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
+        <source>Export</source>
+        <translation>ایکسپورٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
+        <source>Refresh</source>
+        <translation>ریفреш کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
+        <source>Device Manager</source>
+        <translation>ڈیوائس مینیجر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Hardware</source>
+        <translation>ہاردوائر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
+        <source>Drivers</source>
+        <translation>ڈرائیورز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Monitor</source>
+        <translation>میٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
+        <source>Overview</source>
+        <translation>اونریو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
+        <source>Display Adapter</source>
+        <translation>ڈسپلے ایئڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
+        <source>CPU</source>
+        <translation>سی پی یو</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
+        <source>Network Adapter</source>
+        <translation>نیٹورک ایئڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
+        <source>Battery</source>
+        <translation>بیٹری</translation>
+    </message>
+</context>
+<context>
+    <name>PageDetail</name>
+    <message>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
+        <source>More</source>
+        <translation>مزید</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverBackupInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <source>Driver Platform Version</source>
+        <translation>ڈرائیور پلیٹ فارم ورزن</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+        <source>Backupable Drivers</source>
+        <translation>بیک اپ کیے جانے والے ڈرائیورز</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+        <source>Backed up Drivers</source>
+        <translation>بیک اپ کیے گए ڈرائیورز</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverControl</name>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <source>Updating</source>
+        <translation>اپ ڈیٹ کر رہے ہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>انس</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+        <source>Next</source>
+        <translation>اگلی</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>Warning</source>
+        <translation>حذف</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <source>The device will be unavailable after the driver uninstallation</source>
+        <translation>ڈرائیور انسٹال کرنے کے بعد ڈیوائس دستیاب نہ ہوگا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <source>Uninstall</source>
+        <comment>button</comment>
+        <translation>اینسٹال کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+        <source>Uninstalling</source>
+        <translation>اینسٹال کر رہے ہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Update successful</source>
+        <translation>اپ ڈیٹ کامیاب ہوگیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+        <source>Uninstallation successful</source>
+        <translation>اینسٹال کامیاب ہوگیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Update failed</source>
+        <translation>اپ‌ڈیٹ فیل ہو گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+        <source>Uninstallation failed</source>
+        <translation>دیکھائی کے فیل ہو گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>اوک</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>اگلا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <source>The selected folder does not exist, please select again</source>
+        <translation>منتَخَبہ فولڈر موجود نہیں ہے، دوبارہ انتخاب کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>اپ‌ڈیٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+        <source>Previous</source>
+        <comment>button</comment>
+        <translation>پچھلے</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+        <source>Broken package</source>
+        <translation>برکن پیکیج</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+        <source>Unmatched package architecture</source>
+        <translation>میچ نہ ہونے والی پیکیج آرکیٹیکچر</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <source>The selected file does not exist, please select again</source>
+        <translation>منتَخَبہ فائل موجود نہیں ہے، دوبارہ انتخاب کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+        <source>It is not a driver</source>
+        <translation>یہ ایک ڈرائیور نہیں ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+        <source>Unable to install - no digital signature</source>
+        <translation>نصب نہیں کر سکتے - دیجیٹل سائنچر نہیں ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+        <source>Unknown error</source>
+        <translation>نامعلوم گری</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+        <source>The driver module was not found</source>
+        <translation>ڈرائیور مالٹو نمایاں نہیں ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+        <source>Invalid module format</source>
+        <translation>غیر معیاری مالٹو فارمیٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+        <source>The driver module has dependencies</source>
+        <translation>ڈرائیور مالٹو کے ذمہ دار ہیں</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverInstallInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <source>Device Name</source>
+        <translation type="unfinished">Device Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+        <source>Version Available</source>
+        <translation type="unfinished">Version Available</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <source>Size</source>
+        <translation type="unfinished">Size</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished">Status</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+        <source>New Version</source>
+        <translation type="unfinished">New Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+        <source>Missing drivers (%1)</source>
+        <translation type="unfinished">Missing drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+        <source>Outdated drivers (%1)</source>
+        <translation type="unfinished">Outdated drivers (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+        <source>Up-to-date drivers (%1)</source>
+        <translation type="unfinished">Up-to-date drivers (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverManager</name>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <source>Driver Install</source>
+        <translation>ڈرائیور نصب کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+        <source>Driver Backup</source>
+        <translation>ڈرائیور کا احتراز کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <source>Driver Restore</source>
+        <translation>ڈرائیور واپس کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+        <source>Feedback</source>
+        <translation>فیدبک</translation>
+    </message>
+</context>
+<context>
+    <name>PageDriverRestoreInfo</name>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+        <source>You do not have any drivers to restore, please backup first</source>
+        <translation>آپ کو کوئی ڈرائیور واپس کرنا نہیں ہے، پہلے احتراز کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+        <source>Go to Backup Driver</source>
+        <translation>احتراز ڈرائیور پر جائیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+        <source>Current Version</source>
+        <translation type="unfinished">Current Version</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+        <source>Backup Version</source>
+        <translation>احتراز کیا گیا نسخہ</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+        <source>Action</source>
+        <translation type="unfinished">Action</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+        <source>Restorable Drivers</source>
+        <translation>واپس کرے جا سکنے والے ڈرائیور</translation>
+    </message>
+</context>
+<context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
+        <source>Refresh</source>
+        <translation>نیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
+        <source>Export</source>
+        <translation>کاٹ کر رکھیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
+        <source>Overview</source>
+        <translation>تفصیل</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Install</source>
+        <translation>ڈرائیور نصب کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Backup</source>
+        <translation>ڈرائیور کا احتراز کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
+        <source>Driver Restore</source>
+        <translation>ڈرائیور واپس کریں</translation>
+    </message>
+</context>
+<context>
+    <name>PageMultiInfo</name>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+        <source>Failed to enable the device</source>
+        <translation>ڈیوائس کو چالو کرنے میں کامیاب نہ ہو سکا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+        <source>Failed to disable the device</source>
+        <translation>ڈیوائس کو تعطیل کرنے میں کامیاب نہ ہو سکا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>اس کو تعطیل کرنے میں کامیاب نہ ہو سکا: ڈیوائس SN حاصہ نہیں کیا جا سکتا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+        <source>Update Drivers</source>
+        <translation>ڈرائیور اپ ڈیٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+        <source>Uninstall Drivers</source>
+        <translation>ڈرائیور نصب ہٹا دیں</translation>
+    </message>
+</context>
+<context>
+    <name>PageOverview</name>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>دوبارہ لوڈ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
+        <source>Export</source>
+        <translation>نکالیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کاپی کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
+        <source>Overview</source>
+        <translation>Overview</translation>
+    </message>
+</context>
+<context>
+    <name>PageSingleInfo</name>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+        <source>Refresh</source>
+        <translation>دوبارہ لوڈ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+        <source>Export</source>
+        <translation>نکالیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+        <source>Copy</source>
+        <translation>کاپی کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+        <source>Enable</source>
+        <translation>چالو کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+        <source>Update drivers</source>
+        <translation>ڈرائیور اپ ڈیٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+        <source>Uninstall drivers</source>
+        <translation>ڈرائیور نصب ہٹا دیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+        <source>Allow it to wake the computer</source>
+        <translation>یہ کمپیوٹر کو بیدار کرنے کی اجازت دیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+        <source>Disable</source>
+        <translation>تعطیل کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <source>Failed to disable it: unable to get the device SN</source>
+        <translation>اس کو تعطیل کرنے میں کامیاب نہ ہو سکا: ڈیوائس SN حاصل نہیں کیا جا سکتا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+        <source>Failed to disable the device</source>
+        <translation>ڈیوائس کو تعطیل کرنے میں کامیاب نہ ہو سکا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+        <source>Failed to enable the device</source>
+        <translation>ڈیوائس کو چالو کرنے میں کامیاب نہ ہو سکا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+        <source>Update Drivers</source>
+        <translation>ڈرائیور اپ ڈیٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+        <source>Uninstall Drivers</source>
+        <translation>ڈرائیور نصب ہٹا دیں</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <source>SubVendor</source>
+        <translation>سیب وندر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <source>SubDevice</source>
+        <translation>سیب ڈیوائس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+        <source>Driver</source>
+        <translation>ڈرائیور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+        <source>Driver Status</source>
+        <translation>ڈرائیور کی حالت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+        <source>Driver Activation Cmd</source>
+        <translation>ڈرائیور چالو کرنے کا کمینڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <source>Config Status</source>
+        <translation>کانفیگ کی حالت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <source>latency</source>
+        <translation>延期</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+        <source>Phys</source>
+        <translation>فِزِکَل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+        <source>Sysfs</source>
+        <translation>سیسفس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <source>Handlers</source>
+        <translation>ہینڈلر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <source>PROP</source>
+        <translation>پروپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <source>EV</source>
+        <translation>ایف</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <source>KEY</source>
+        <translation>کی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+        <source>Version</source>
+        <translation>ویریئن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <source>Bus</source>
+        <translation>بس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <source>BIOS Information</source>
+        <translation>معلومات بیوس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <source>Base Board Information</source>
+        <translation>معلومات بیس بورڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <source>System Information</source>
+        <translation>معلومات سسٹم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <source>Chassis Information</source>
+        <translation>معلومات چسیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <source>Physical Memory Array</source>
+        <translation>فزیکل میموري آرے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+        <source>Release Date</source>
+        <translation>ریلیس ڈیٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+        <source>Address</source>
+        <translation>آڈریس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <source>Runtime Size</source>
+        <translation>رائٹ ٹائم سائز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <source>ROM Size</source>
+        <translation>روم سائز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+        <source>Characteristics</source>
+        <translation>چاракٹریسٹکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <source>BIOS Revision</source>
+        <translation>بیوس ریویشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+        <source>Firmware Revision</source>
+        <translation>فیرم چاہر ریویشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <source>Product Name</source>
+        <translation>پروڈکٹ نیم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <source>Serial Number</source>
+        <translation>سریل نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <source>Asset Tag</source>
+        <translation>اے سیٹ ٹیگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <source>Features</source>
+        <translation>فیچرز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+        <source>Location In Chassis</source>
+        <translation>لکیشن ان چسیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+        <source>Chassis Handle</source>
+        <translation>چسیس ہینڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <source>Type</source>
+        <translation>ٹائپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <source>Contained Object Handles</source>
+        <translation>کنٹینڈڈ اوبجیکٹ ہینڈلز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <source>UUID</source>
+        <translation>یو یو ڈی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <source>Wake-up Type</source>
+        <translation>ویک اپ ٹائپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <source>SKU Number</source>
+        <translation>SKU نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <source>Family</source>
+        <translation>خانوادہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <source>Lock</source>
+        <translation>لک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <source>Boot-up State</source>
+        <translation>حالت ریلاٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <source>Power Supply State</source>
+        <translation>حالت برق</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <source>Thermal State</source>
+        <translation>حالت گرمی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+        <source>Security Status</source>
+        <translation>حالت سیکیورٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <source>OEM Information</source>
+        <translation>معلومات OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation> بلندی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <source>Number Of Power Cords</source>
+        <translation>تعداد برق کی سیم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <source>Contained Elements</source>
+        <translation>شامل عناصر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>مقام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>نوع تصحیحی خطا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>مختلف سے زیادہ سہولت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>ہینڈل خطا معلومات</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>تعداد ڈیوائسز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>BIOS ROMSIZE</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>ریلیس ڈیٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>بورڈ نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+        <source>SMBIOS Version</source>
+        <translation>SMBIOS نسخہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <source>Language Description Format</source>
+        <translation>زبان توصیف فارمیٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <source>Installable Languages</source>
+        <translation>نصب کریگی زبانیں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+        <source>Currently Installed Language</source>
+        <translation>ہاں نصب زبان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <source>BD Address</source>
+        <translation>BD ایڈریس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <source>ACL MTU</source>
+        <translation>ACL MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+        <source>SCO MTU</source>
+        <translation>SCO MTU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+        <source>Packet type</source>
+        <translation>پیکٹ نوع</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+        <source>Link policy</source>
+        <translation>لینک پالیسی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <source>Link mode</source>
+        <translation>لینک مڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <source>Class</source>
+        <translation>کلاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+        <source>Service Classes</source>
+        <translation>سروس کلاسز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <source>Device Class</source>
+        <translation>کلاس ڈیوائس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <source>HCI Version</source>
+        <translation>ویژن ایچ سی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <source>LMP Version</source>
+        <translation>ویژن ایل ایم پی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <source>Subversion</source>
+        <translation>زبر ویژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <source>Device</source>
+        <translation>ڈیوائس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <source>Serial ID</source>
+        <translation>سریل آئی ڈی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+        <source>product</source>
+        <translation>محصول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+        <source>description</source>
+        <translation>تفصیل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <source>Powered</source>
+        <translation>Powered</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <source>Discoverable</source>
+        <translation>ڈکوریبل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <source>Pairable</source>
+        <translation>پیئریبل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <source>Modalias</source>
+        <translation>مودلیا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+        <source>Discovering</source>
+        <translation>ڈکورینگ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <source>Driver Modules</source>
+        <translation>ڈرائیور مودولز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <source>Device File</source>
+        <translation>ڈیوائس فائل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+        <source>Device Files</source>
+        <translation>ڈیوائس فائلز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <source>Device Number</source>
+        <translation>ڈیوائس نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+        <source>Application</source>
+        <translation>اپلیکیشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+        <source>status</source>
+        <translation>status</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <source>logical name</source>
+        <translation>لوجیکل نام</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <source>ansiversion</source>
+        <translation>انسا ویژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+        <source>CPU implementer</source>
+        <translation>CPU انسٹیمپر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+        <source>CPU architecture</source>
+        <translation>CPU ارچیٹیکچر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+        <source>CPU variant</source>
+        <translation>CPU واریئنٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+        <source>CPU part</source>
+        <translation>CPU پارٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+        <source>CPU revision</source>
+        <translation>CPU ریویژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <source>One</source>
+        <translation>ایک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <source>Two</source>
+        <translation>دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <source>Four</source>
+        <translation>چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <source>Six</source>
+        <translation>سیکھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <source>Eight</source>
+        <translation>آٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+        <source>Nine</source>
+        <translation>نौ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <source>Ten</source>
+        <translation>دس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <source>Twelve</source>
+        <translation>بائیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <source>Fourteen</source>
+        <translation>چوبیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <source>Sixteen</source>
+        <translation>سولہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <source>Eighteen</source>
+        <translation>آٹھ ٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <source>Twenty</source>
+        <translation>بیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <source>Twenty-two</source>
+        <translation>بیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <source>Twenty-four</source>
+        <translation>بیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <source>Twenty-six</source>
+        <translation>بیس چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <source>Twenty-eight</source>
+        <translation>بیس ہن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <source>Thirty</source>
+        <translation>تیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <source>Thirty-two</source>
+        <translation>تیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <source>Thirty-four</source>
+        <translation>تیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <source>Thirty-six</source>
+        <translation>تیس چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <source>Thirty-eight</source>
+        <translation>تیس ٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <source>Forty</source>
+        <translation>چارتیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <source>Forty-two</source>
+        <translation>چارتیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <source>Forty-four</source>
+        <translation>چارتیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <source>Forty-six</source>
+        <translation>چارتیس چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <source>Forty-eight</source>
+        <translation>چارتیس ٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <source>Fifty</source>
+        <translation>پچتیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <source>Fifty-two</source>
+        <translation>پچتیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <source>Fifty-four</source>
+        <translation>پچتیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <source>Fifty-six</source>
+        <translation>پچتیس چھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <source>Fifty-eight</source>
+        <translation>پچتیس ٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <source>Sixty</source>
+        <translation>سیتیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <source>Sixty-two</source>
+        <translation>سیتیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <source>Sixty-four</source>
+        <translation>سیتیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <source>Sixty-six</source>
+        <translation>سیکسٹی سکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <source>Sixty-eight</source>
+        <translation>سیکسٹی ایچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <source>Seventy</source>
+        <translation>سیونتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <source>Seventy-two</source>
+        <translation>سیونتی دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <source>Seventy-four</source>
+        <translation>سیونتی چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <source>Seventy-six</source>
+        <translation>سیونتی سکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <source>Seventy-eight</source>
+        <translation>سیونتی ایچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <source>Eighty</source>
+        <translation>ایتی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <source>Eighty-two</source>
+        <translation>ایتی دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <source>Eighty-four</source>
+        <translation>ایتی چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <source>Eighty-six</source>
+        <translation>ایتی سکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <source>Eighty-eight</source>
+        <translation>ایتی ایچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <source>Ninety</source>
+        <translation>نائیٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <source>Ninety-two</source>
+        <translation>نائیٹی دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <source>Ninety-four</source>
+        <translation>نائیٹی چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <source>Ninety-six</source>
+        <translation>نائیٹی سکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <source>Ninety-eight</source>
+        <translation>نائیٹی ایچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <source>One hundred</source>
+        <translation>ایک ہزار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <source>One hundred and Two</source>
+        <translation>ایک ہزار اور دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <source>One hundred and four</source>
+        <translation>ایک ہزار اور چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <source>One hundred and Six</source>
+        <translation>ایک ہزار اور سکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <source>One hundred and Eight</source>
+        <translation>ایک ہزار اور اٹھارہ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <source>One hundred and Ten</source>
+        <translation>ایک ہزار اور دس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+        <source>One hundred and Twelve</source>
+        <translation>ایک ہزار اور دو دس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+        <source>One hundred and Fourteen</source>
+        <translation>ایک ہزار اور چار دس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+        <source>One hundred and Sixteen</source>
+        <translation>ایک ہزار اور چھ دس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+        <source>One hundred and Eighteen</source>
+        <translation>ایک ہزار اور اٹھارہ دس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+        <source>One hundred and Twenty</source>
+        <translation>ایک ہزار اور بیس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+        <source>One hundred and Twenty-two</source>
+        <translation>ایک ہزار اور بیس دو</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+        <source>One hundred and Twenty-four</source>
+        <translation>ایک ہزار اور بیس چار</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+        <source>One hundred and Twenty-six</source>
+        <translation>ایکصد اور ٹوینٹی سکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+        <source>One hundred and Twenty-eight</source>
+        <translation>ایکصد اور ٹوینٹی ایٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+        <source>One hundred and Ninety-two</source>
+        <translation>ایکصد اور نائنتی توان</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+        <source>Two hundred and fifty-six</source>
+        <translation>ٹویو ہنڈرڈ اور فائfty سکس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <source>GDDR capacity</source>
+        <translation>گDDR کی کیپسٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <source>GPU vendor</source>
+        <translation>GPU ونڈر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <source>GPU type</source>
+        <translation>GPU ٹائپ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+        <source>EGL version</source>
+        <translation>EGL ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+        <source>EGL client APIs</source>
+        <translation>EGL کلینٹ APIs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+        <source>GL version</source>
+        <translation>GL ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+        <source>GLSL version</source>
+        <translation>GLSL ورژن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+        <source>Unknown</source>
+        <translation>نامعلوم</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+        <source>Uniq</source>
+        <translation>ایکیک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <source>MSC</source>
+        <translation>MSC</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <source>Hardware Class</source>
+        <translation>ہارڈوئر کلاس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <source>No CPU found</source>
+        <translation>کوئی CPU نہ ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>Motherboard</source>
+        <translation>ماؤثر بورڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <source>No motherboard found</source>
+        <translation>کوئی ماؤثر بورڈ نہ ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>Memory</source>
+        <translation>میموری</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <source>No memory found</source>
+        <translation>کوئی میموری نہ ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>Storage</source>
+        <translation>سٹوریج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <source>No disk found</source>
+        <translation>کوئی ڈسک نہ ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+        <source>Driver restore failed!</source>
+        <translation>ڈرائیور ریسٹور فیل! </translation>
+    </message>
+    <message>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <source>Please try again or give us feedback</source>
+        <translation>براہ کرم دوبارہ کوشش کریں یا ہمیں فیڈ بیک دیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+        <source>Driver backup failed!</source>
+        <translation>ڈرائیور بک اپ فیل! </translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>Display Adapter</source>
+        <translation>ڈسپلے ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <source>No GPU found</source>
+        <translation>کوئی GPU نہ ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>Monitor</source>
+        <translation>میٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <source>No monitor found</source>
+        <translation>کوئی میٹر نہ ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>Network Adapter</source>
+        <translation>نیٹ ورک ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <source>No network adapter found</source>
+        <translation>کوئی نیٹ ورک ایڈاپٹر نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>Sound Adapter</source>
+        <translation>صوت ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <source>No audio device found</source>
+        <translation>کوئی آڈیو دستگی نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>Bluetooth</source>
+        <translation>بلوٹوٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <source>No Bluetooth device found</source>
+        <translation>کوئی بلوٹوٹھ دستگی نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>Other PCI Devices</source>
+        <translation>دیگر PCI دستگیاں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <source>No other PCI devices found</source>
+        <translation>کوئی دیگر PCI دستگی نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>Power</source>
+        <translation>پاور</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <source>No battery found</source>
+        <translation>کوئی بیٹری نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>Keyboard</source>
+        <translation>کیبورڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <source>No keyboard found</source>
+        <translation>کوئی کیبورڈ نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>Mouse</source>
+        <translation>ماؤس</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <source>No mouse found</source>
+        <translation>کوئی ماؤس نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>Printer</source>
+        <translation>پرنر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <source>No printer found</source>
+        <translation>کوئی پرنر نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>Camera</source>
+        <translation>کیمیڑا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <source>No camera found</source>
+        <translation>کوئی کیمیڑا نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>CD-ROM</source>
+        <translation>CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <source>No CD-ROM found</source>
+        <translation>کوئی CD-ROM نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>Other Devices</source>
+        <translation>دیگر دستگیاں</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <source>No other devices found</source>
+        <translation>کوئی دیگر دستگی نہیں ملا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <source>Array Handle</source>
+        <translation>آرے ہینڈل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <source>Form Factor</source>
+        <translation>فورم فیکٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <source>Set</source>
+        <translation>سیٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <source>Bank Locator</source>
+        <translation>بنک لیکٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <source>Type Detail</source>
+        <translation>ٹائپ ڈیٹائل</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <source>Part Number</source>
+        <translation>پارٹ نمبر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+        <source>Rank</source>
+        <translation>رینک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+        <source>Memory Technology</source>
+        <translation>میموری ٹیکنالوجی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+        <source>Memory Operating Mode Capability</source>
+        <translation>کیپیٹیٹی آپریٹنگ مڈ ن کمپیوٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+        <source>Firmware Version</source>
+        <translation>فرم ور کیویشن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+        <source>Module Manufacturer ID</source>
+        <translation>مودول مانوفیکچرر آئی ڈی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+        <source>Module Product ID</source>
+        <translation>مودول پروڈکٹ آئی ڈی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+        <source>Memory Subsystem Controller Manufacturer ID</source>
+        <translation>میموري سبسسیم کنٹرولر مانوفیکچرر آئی ڈی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+        <source>Memory Subsystem Controller Product ID</source>
+        <translation>میموري سبسسیم کنٹرولر پروڈکٹ آئی ڈی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+        <source>Non-Volatile Size</source>
+        <translation>نن-وولیٹل سائز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+        <source>Volatile Size</source>
+        <translation>وولیٹل سائز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <source>Cache Size</source>
+        <translation>کیش سائز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <source>Logical Size</source>
+        <translation>لوجیکل سائز</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <source>inch</source>
+        <translation>انچ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <source>Date</source>
+        <translation>تاریخ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+        <source>ioport</source>
+        <translation>آئو پورٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+        <source>network</source>
+        <translation>نیٹ ورک</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+        <source>battery</source>
+        <translation>Battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+        <source>native-path</source>
+        <translation>نیٹیو پٹھ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+        <source>power supply</source>
+        <translation>پاور سپلائی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+        <source>updated</source>
+        <translation>اپ ڈیٹ کیا گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+        <source>has history</source>
+        <translation>تاریخ رکھتا ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+        <source>has statistics</source>
+        <translation>اسٹیٹسٹکس رکھتا ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+        <source>rechargeable</source>
+        <translation>ریچارج ہوتا ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+        <source>state</source>
+        <translation>حالت</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+        <source>warning-level</source>
+        <translation>ویننگ لیول</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+        <source>energy</source>
+        <translation> năng lượng</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+        <source>energy-empty</source>
+        <translation>اِنرژی خالی</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+        <source>energy-full</source>
+        <translation>اِنرژی بھرا ہوا</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+        <source>energy-full-design</source>
+        <translation>اِنرژی بھرا ہوا ڈیزائن</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+        <source>energy-rate</source>
+        <translation>اِنرژی ریٹ</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+        <source>voltage</source>
+        <translation>ولٹیج</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+        <source>percentage</source>
+        <translation>Percentage</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+        <source>technology</source>
+        <translation>technology</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+        <source>icon-name</source>
+        <translation>icon-name</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+        <source>daemon-version</source>
+        <translation>daemon-version</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+        <source>on-battery</source>
+        <translation>on-battery</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+        <source>lid-is-closed</source>
+        <translation>lid-is-closed</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+        <source>lid-is-present</source>
+        <translation>lid-is-present</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+        <source>critical-action</source>
+        <translation>critical-action</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+        <source>copies</source>
+        <translation>copies</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+        <source>job-cancel-after</source>
+        <translation>job-cancel-after</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+        <source>job-hold-until</source>
+        <translation>job-hold-until</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+        <source>job-priority</source>
+        <translation>job-priority</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+        <source>marker-change-time</source>
+        <translation>marker-change-time</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+        <source>number-up</source>
+        <translation>number-up</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+        <source>orientation-requested</source>
+        <translation>orientation-requested</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+        <source>print-color-mode</source>
+        <translation>print-color-mode</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+        <source>printer-is-accepting-jobs</source>
+        <translation>printer-is-accepting-jobs</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+        <source>printer-is-shared</source>
+        <translation>printer-is-shared</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+        <source>printer-is-temporary</source>
+        <translation>printer-is-temporary</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+        <source>printer-make-and-model</source>
+        <translation>printer-make-and-model</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+        <source>printer-state-change-time</source>
+        <translation>printer-state-change-time</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+        <source>printer-state-reasons</source>
+        <translation>printer-state-reasons</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+        <source>printer-type</source>
+        <translation>printer-type</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+        <source>printer-uri-supported</source>
+        <translation>printer-uri-supported</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+        <source>sides</source>
+        <translation>sides</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <source>SSD</source>
+        <translation>SSD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <source>HDD</source>
+        <translation>HDD</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <source>bus info</source>
+        <translation>bus info</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+        <source>logicalsectorsize</source>
+        <translation>logicalsectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+        <source>sectorsize</source>
+        <translation>sectorsize</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+        <source>guid</source>
+        <translation>Guid</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <source>Geometry (Logical)</source>
+        <translation>میٹرکس (لوجیکل)</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="93"/>
+        <source>Device Manager</source>
+        <translation>ڈیوائس مینیجر</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="96"/>
+        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+        <translation>ڈیوائس مینیجر ایک مددگار ادا دیکھنے اور ڈیوائس کی مدیریت کرنے کے لیے ایک اہم ادا ہے۔</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="162"/>
+        <source>New drivers available! Install or update them now.</source>
+        <translation>نیا ڈرائیور دستیاب ہے! اب اسٹال یا اپ ڈیٹ کریں۔</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="163"/>
+        <source>View</source>
+        <translation>دیکھیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+        <source>Include subfolders</source>
+        <translation>سبس فولڈر شامل کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+        <source>Search for drivers in this path</source>
+        <translation>اس راستہ میں ڈرائیور تلاش کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+        <source>%1 driver updates available</source>
+        <translation>'%1 ڈرائیور اپ ڈیٹس دستیاب ہیں'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <source>Time checked: %1</source>
+        <translation>'چیک کیا گیا وقت: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+        <source>Downloading drivers for %1...</source>
+        <translation>%1 کے لیے ڈرائیور ڈاؤن لوڈ کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+        <source>Download speed: %1 Downloaded %2/%3</source>
+        <translation>'ڈاؤن لوڈ سپیڈ: %1 ڈاؤن لوڈ: %2/%3'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+        <source>Installing drivers for %1...</source>
+        <translation>%1 کے لیے ڈرائیور اسٹال کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+        <source>%1 drivers installed, %2 drivers failed</source>
+        <translation>'%1 ڈرائیور اسٹال ہوئے، %2 ڈرائیور فیل ہوئے'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+        <source>%1 drivers installed</source>
+        <translation>'%1 ڈرائیور اسٹال ہوئے'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+        <source>Failed to install drivers</source>
+        <translation>ڈرائیور اسٹال کرنا ممکن نہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+        <source>Network error. Reconnecting...</source>
+        <translation>نیٹ ورک گرہ، دوبارہ کنیکشن کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+        <source>Download speed: %1</source>
+        <translation>'ڈاؤن لوڈ سپیڈ: %1'</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+        <source>Your drivers are up to date</source>
+        <translation>آپ کے ڈرائیور تازہ ہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+        <source>All drivers have been backed up</source>
+        <translation>ہر ڈرائیور کا بیک اپ کر لیا گیا ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <source>A total of %1 drivers, of which %2 have been backed up</source>
+        <translation>%1 کے کل ڈرائیور، جن میں سے %2 کا بیک اپ کر لیا گیا ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+        <translation>آپ %1 ڈرائیورز ہیں جو بک اپ کیے جا سکتے ہیں، ایک فوری طور پر کرنے کی تجویز ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+        <source>You have %1 drivers that can be backed up</source>
+        <translation>آپ %1 ڈرائیورز ہیں جو بک اپ کیے جا سکتے ہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+        <source>Backing up the %1 driver, a total of %2 drivers</source>
+        <translation>%1 ڈرائیور کا بک اپ کررہے ہیں، کل %2 ڈرائیورز</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+        <source>Backing up: %1</source>
+        <translation>بک اپ کررہے ہیں: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+        <source>%1 drivers backed up, %2 drivers failed</source>
+        <translation>%1 ڈرائیورز بک اپ کیے گئے، %2 ڈرائیورز ناکام ہوئے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+        <source>Failed to backup drivers</source>
+        <translation>ڈرائیورز کا بک اپ ناکام ہوگیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+        <source>%1 drivers backed up</source>
+        <translation>%1 ڈرائیورز بک اپ کیے گئے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+        <source>You have %1 drivers that can be restored</source>
+        <translation>آپ %1 ڈرائیورز ہیں جو بحال کیے جا سکتے ہیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+        <source>Please select a driver to restore</source>
+        <translation>بحال کرنے کے لیے ایک ڈرائیور کا انتخاب کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+        <source>Driver is restoring...</source>
+        <translation>ڈرائیوئر ریکوری کر رہے ہیں...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+        <source>Restoring: %1</source>
+        <translation>ریکوری کر رہے ہیں: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+        <source>reboot</source>
+        <translation>ریبوٹ کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+        <source>Please %1 for the installed drivers to take effect</source>
+        <translation>کیجئے %1 اسٹالڈ ڈرائیوئر کے اثر کے لئے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+        <source>View backup path</source>
+        <translation>Backup پٹھ کا دیکھو</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+        <source>Backup All</source>
+        <translation>ہر چیز کا Backup</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <source>submit feedback</source>
+        <translation>فیڈ بیک جمع کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+        <source>Please try again or %1 to us</source>
+        <translation>کوشش کریں یا %1 ہم تک بھیجیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+        <source>Install All</source>
+        <translation>ہر چیز کی انسٹال کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <source>Scan Again</source>
+        <translation>دوبارہ سکن ہو</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+        <source>Cancel</source>
+        <translation>انسٹال کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+        <source>Scanning hardware device drivers, please wait...</source>
+        <translation>ہارڈ ویئر ڈرائیوئر کی سکن ہو رہی ہے، بھیا کریں...</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <source>Scanning %1</source>
+        <translation>سکن کر رہے ہیں %1</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+        <source>Scan failed</source>
+        <translation>سکن فیل ہو گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+        <source>Network unavailable</source>
+        <translation>نیٹ ورک دستیاب نہی ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+        <source>Please check your network connection</source>
+        <translation>کیجئے اپنی نیٹ ورک کنیکشن کا چیک کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+        <source>Please scan again or %1 to us</source>
+        <translation>دوبارہ سکن کریں یا %1 ہم تک بھیجیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
+        <source>You are installing a driver, which will be interrupted if you exit.</source>
+        <translation>آپ ایک ڈرائیوئر انسٹال کر رہے ہیں، جو اگر آپ ختم کریں تو متوقف ہو جائے گا۔</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <source>Are you sure you want to exit?</source>
+        <translation>آپ ختم کرنا چاہتے ہیں؟</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <source>Exit</source>
+        <comment>button</comment>
+        <translation>ختم کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ختم کریں</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
+        <source>You are backing up drivers, which will be interrupted if you exit.</source>
+        <translation>آپ ڈرائیوئر کا بیک اپ کر رہے ہیں، جو اگر آپ ختم کریں تو متوقف ہو جائے گا۔</translation>
+    </message>
+    <message>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
+        <source>You are restoring drivers, which will be interrupted if you exit.</source>
+        <translation>آپ ڈرائیوئر کی ریکوری کر رہے ہیں، جو اگر آپ ختم کریں تو متوقف ہو جائے گا۔</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="36"/>
+        <source>Bluetooth adapter</source>
+        <translation>بلوٹوٹھ ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="37"/>
+        <source>Imaging device</source>
+        <translation>ایمیج کنگ ڈیوائس</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="38"/>
+        <source>Display adapter</source>
+        <translation>ڈسپلے ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="40"/>
+        <source>Sound card</source>
+        <translation>صوت کارڈ</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="42"/>
+        <source>Network adapter</source>
+        <translation>نیٹ ورک ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="46"/>
+        <source>Wireless network adapter</source>
+        <translation>وائرلس نیٗٹ ورک ایڈاپٹر</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="66"/>
+        <source>Installation successful</source>
+        <translation>انسٹالیشن کامیاب ہو گئی</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="67"/>
+        <source>Installation failed</source>
+        <translation>نصب ناکام</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="68"/>
+        <source>Downloading</source>
+        <translation>تبدیل کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="69"/>
+        <source>Installing</source>
+        <translation>نصب کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="70"/>
+        <source>Not installed</source>
+        <translation>نہ نصب ہے</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="71"/>
+        <source>Out-of-date</source>
+        <translation>قدیم</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="72"/>
+        <source>Waiting</source>
+        <translation>انتظار کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="73"/>
+        <source>Not backed up</source>
+        <translation>نہ ریکارڈ کیا گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="74"/>
+        <source>Backing up</source>
+        <translation>ریکارڈ کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="75"/>
+        <source>Backup failed</source>
+        <translation>ریکارڈ ناکام</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="76"/>
+        <source>Backup successful</source>
+        <translation>ریکارڈ کامیاب</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="77"/>
+        <source>Restoring</source>
+        <translation>بھاری کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="81"/>
+        <source>Unknown error</source>
+        <translation>نامعلوم گلٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="82"/>
+        <source>Network error</source>
+        <translation>نیٹ ورک گلٹی</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="83"/>
+        <source>Canceled</source>
+        <translation>رکھ دیا گیا</translation>
+    </message>
+    <message>
+        <location filename="../src/Tool/commontools.cpp" line="84"/>
+        <source>Failed to get driver files</source>
+        <translation>ڈرائیور فائل حاصل ناکام</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
+        <source>Update</source>
+        <translation>اپ ڈیٹ کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
+        <source>Backup</source>
+        <translation>ریکارڈ کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
+        <source>Restore</source>
+        <translation>بھاری کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <source>Install</source>
+        <translation>ناسب کرنا</translation>
+    </message>
+    <message>
+        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+        <source>Overview</source>
+        <translation type="unfinished">Overview</translation>
+    </message>
+</context>
+<context>
+    <name>TableWidget</name>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <source>Disable</source>
+        <translation>بند کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <source>Refresh</source>
+        <translation>آپ ڈیٹ کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <source>Export</source>
+        <translation>نکال کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+        <source>Update drivers</source>
+        <translation>ڈرائیور اپ ڈیٹ کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+        <source>Uninstall drivers</source>
+        <translation>ڈرائیور نصب کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+        <source>Allow it to wake the computer</source>
+        <translation>یہ کمپیوٹر بیدار کرنے کی اجازت دیں</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <source>Enable</source>
+        <translation>فعال کرنا</translation>
+    </message>
+</context>
+<context>
+    <name>TextBrowser</name>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+        <source>Refresh</source>
+        <translation>آپ ڈیٹ کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+        <source>Export</source>
+        <translation>نکال کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+        <source>Copy</source>
+        <translation>کپی کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+        <source>Disable</source>
+        <translation>بند کرنا</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+        <source>Unavailable</source>
+        <translation>نہیں دستیاب</translation>
+    </message>
+</context>
+<context>
+    <name>UrlChooserEdit</name>
+    <message>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+        <source>Select a local folder please</source>
+        <translation>کچھ لوکل فولڈر کا انتخاب کریں</translation>
+    </message>
+</context>
+<context>
+    <name>WaitingWidget</name>
+    <message>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+        <source>Loading...</source>
+        <translation>لوڈ کر رہے ہیں...</translation>
+    </message>
+</context>
+</TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_vi.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_vi.ts
@@ -1,27 +1,42 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="vi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>Phản hồi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>OK</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <source>More</source>
+        <translation type="unfinished">Thêm</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <source>Collapse</source>
+        <translation type="unfinished">Thu gọn</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>Thêm</translation>
     </message>
@@ -47,28 +62,12 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
         <source>More</source>
         <translation>Thêm</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>Thu gọn</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>Thêm</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>Thu gọn</translation>
     </message>
@@ -77,7 +76,6 @@
     <name>DetailViewDelegate</name>
     <message>
         <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
         <source>Disable</source>
         <translation>Khóa</translation>
     </message>
@@ -90,79 +88,77 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>Tên thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>Chip</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>Công năng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>Alias mô-đun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>ID vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>Mô tả</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>Địa chỉ bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>không khả dụng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>Tắt</translation>
     </message>
@@ -188,17 +184,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>Chipset</translation>
     </message>
@@ -206,87 +202,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>Mô hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>Alias của mô-đun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>ID vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>Tốc độ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>Độ mạnh tối đa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>Phiên bản trình-drivers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>Trình-drivers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>Công năng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>Thông tin về giao diện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>Tên lógic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>Địa chỉ MAC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>không khả dụng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>DISABLE</translation>
     </message>
@@ -294,67 +290,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>Mô hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>Thông tin giao diện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>Khả năng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>Đriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>Năng lượng cực đại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>Tốc độ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>Alias mô đun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>ID vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>Không khả dụng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>DISABLE</translation>
     </message>
@@ -362,7 +358,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
@@ -370,117 +366,112 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>ID CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>ID lõi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>Số luồng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>BogoMIPS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
         <source>Architecture</source>
         <translation>Kiến trúc</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>Gia đình CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>Mô hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
         <source>Processor</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>Core(s)</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>Hiệu năng ảo hóa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>Biên dịch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>Phần mở rộng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2 Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1i Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1d Cache</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>Stepping</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>Tốc độ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
         <source>Max Speed</source>
         <translation>Tốc độ tối đa</translation>
     </message>
@@ -488,127 +479,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>Mô hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>Bộ nhớ đồ họa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>Alias mô đun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>ID vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>Địa chỉ bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>Kết nối I/O</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>Thông tin bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>Độ phân giải tối đa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>Độ phân giải tối thiểu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>Độ phân giải hiện tại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>Mô tả</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>Đầu ra số hóa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>Đầu ra màn hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>Công năng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>IRQ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>Không khả dụng</translation>
     </message>
@@ -616,72 +607,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>Mô hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>Thông tin giao diện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>Alias mô đun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>ID vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>Tốc độ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>Năng lượng tối đa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>Công năng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>Số seri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>Không khả dụng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>Khóa</translation>
     </message>
@@ -689,72 +680,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>Mô hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>Giao diện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>Thông tin giao thông</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>Biệt danh mô-đun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>ID vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>Tốc độ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>Tổng dòng điện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>Năng lực</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>Không khả dụng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>Khóa</translation>
     </message>
@@ -762,140 +753,108 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
         <source>Overview</source>
         <translation>Tổng quan</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
         <source>CPU quantity</source>
         <translation>Số lượng CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
         <source>Motherboard</source>
         <translation>Mainboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
         <source>Memory</source>
         <translation>Bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
         <source>Display Adapter</source>
         <translation>Khung hiển thị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
         <source>Sound Adapter</source>
         <translation>Khung âm thanh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
         <source>Storage</source>
         <translation>Lưu trữ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
         <source>Other PCI Devices</source>
         <translation>Thiết bị PCI khác</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
         <source>Battery</source>
         <translation>Pin</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
         <source>Network Adapter</source>
         <translation>Kết nối mạng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
         <source>Mouse</source>
         <translation> Chuột</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
         <source>Keyboard</source>
         <translation>Bàn phím</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
         <source>Monitor</source>
         <translation>Màn hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
         <source>Printer</source>
         <translation>In</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
         <source>Camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>Thiết bị khác</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
         <source>Device</source>
         <translation>Thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
         <source>OS</source>
         <translation>Hệ điều hành</translation>
     </message>
@@ -903,73 +862,67 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
         <source>Size</source>
         <translation>Kích thước</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
         <source>Type</source>
         <translation>Loại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
         <source>Speed</source>
         <translation>Tốc độ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>Độ rộng tổng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>Số-seri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>Tension cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>Tension tối đa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>Tension tối thiểu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
         <source>Configured Speed</source>
         <translation>Tốc độ cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>Độ rộng dữ liệu</translation>
     </message>
@@ -977,57 +930,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>Loại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>Nhập màn hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>Loại giao diện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>Độ phân giải hỗ trợ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>Độ phân giải hiện tại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>Tỷ lệ màn hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>Màn hình chính</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>Kích thước</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>Số serail</translation>
     </message>
@@ -1036,19 +989,16 @@
     <name>DeviceNetwork</name>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
         <source>Type</source>
         <translation>Loại</translation>
     </message>
@@ -1115,32 +1065,32 @@
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>Trễ pha</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
         <source>IP</source>
-        <translation type="unfinished"/>
+        <translation>IP</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
         <source>Firmware</source>
-        <translation type="unfinished"/>
+        <translation>Firmware</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
         <source>Duplex</source>
-        <translation type="unfinished"/>
+        <translation>Đuplex</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
         <source>Broadcast</source>
-        <translation type="unfinished"/>
+        <translation>Báo hiệu</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
         <source>Auto Negotiation</source>
-        <translation type="unfinished"/>
+        <translation>Tự thương lượng</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
@@ -1203,7 +1153,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
         <source>Input/Output</source>
-        <translation type="unfinished"/>
+        <translation>Vào/Xuất</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
@@ -1218,7 +1168,7 @@
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
         <source>Latency</source>
-        <translation type="unfinished"/>
+        <translation>Trễ pha</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
@@ -1428,81 +1378,77 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
         <source>Vendor</source>
         <translation>Nhà sản xuất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
         <source>Media Type</source>
         <translation>Loại phương tiện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
         <source>Size</source>
         <translation>Kích thước</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>Hỗ trợ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>Biên dịch mô-đun</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>ID vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>Phiên bản firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>Tốc độ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>Mô tả</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>Số ser</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>Giao diện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>Tốc độ quay</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>Không khả dụng</translation>
     </message>
@@ -1510,13 +1456,12 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
         <source>Select a driver for update</source>
         <translation>Chọn trình điều khiển để cập nhật</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>Không tìm thấy trình điều khiển trong thư mục này</translation>
     </message>
@@ -1524,52 +1469,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>Đang tải thông tin thiết bị âm thanh...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>Đang tải thông tin BIOS...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>Đang tải thông tin CD-ROM...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>Đang tải thông tin hệ điều hành...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>Đang tải thông tin CPU...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>Đang tải thông tin các thiết bị khác...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>Đang tải thông tin nguồn điện...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>Đang tải thông tin máy in...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>Đang tải thông tin chuột...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>Đang tải thông tin适配器...</translation>
     </message>
@@ -1577,14 +1522,12 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
         <source>Disable</source>
         <translation>Khung không khả dụng</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>Khung không khả dụng</translation>
     </message>
@@ -1592,12 +1535,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>Khóa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>Không khả dụng</translation>
     </message>
@@ -1605,88 +1548,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
         <comment>export file's name</comment>
         <translation>Thông tin thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>Hiển thị phím tắt</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>Đóng</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>Trợ giúp</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation> Sao chép</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>Hệ thống</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation> Xuất</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>Tải lại</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>Quản lý thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>Phần cứng</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>Theo dõi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>Tổng quan</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>Kết hợp màn hình</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>Kết hợp mạng</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>Pin</translation>
     </message>
@@ -1694,7 +1637,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>Thêm</translation>
     </message>
@@ -1702,40 +1645,37 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Current Version</source>
         <translation>Phiên bản hiện tại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
         <source>Driver Platform Version</source>
         <translation>Phiên bản nền tảng H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>Trạng thái</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>Hành động</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>H/GPL có thể sao lưu</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>H/GPL đã sao lưu</translation>
     </message>
@@ -1743,137 +1683,133 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
         <source>Updating</source>
         <translation>Cập nhật</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Hủy bỏ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>Tiếp theo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>Lưu ý</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>Thiết bị sẽ không khả dụng sau khi gỡ cài đặt H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>Gỡ cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>Đang gỡ cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>Cập nhật thành công</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>Gỡ cài đặt thành công</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>Cập nhật thất bại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>Gỡ cài đặt thất bại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>Đồng ý</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>Tiếp theo</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>Thư mục đã chọn không tồn tại, vui lòng chọn lại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>Cập nhật</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>Trước đây</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation> gói phần mềm bị hỏng</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>Kết cấu gói phần mềm không phù hợp</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
         <source>The selected file does not exist, please select again</source>
         <translation>File đã chọn không tồn tại, vui lòng chọn lại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>Đó không phải là một driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>Không thể cài đặt - không có chữ ký số</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>Lỗi không xác định</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>Không tìm thấy module driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>Định dạng module không hợp lệ</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>Module driver có phụ thuộc</translation>
     </message>
@@ -1881,57 +1817,52 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
         <source>Device Name</source>
         <translation>Tên thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>Phiên bản sẵn có</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
         <source>Size</source>
         <translation>Kích thước</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
         <source>Status</source>
         <translation>Trạng thái</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
         <source>Action</source>
         <translation>Hành động</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>Phiên bản mới</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>Phiên bản hiện tại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>Driver thiếu (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>Driver cũ (%1</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>H/GPL mới nhất (%1</translation>
     </message>
@@ -1939,33 +1870,27 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
         <source>Driver Install</source>
         <translation>Cài đặt H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
         <source>Driver Backup</source>
         <translation> Sao chép H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
         <source>Driver Restore</source>
         <translation>Khôi phục H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>Phản hồi</translation>
     </message>
@@ -1973,37 +1898,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>Bạn không có bất kỳ H/GPL nào để khôi phục, vui lòng sao chép trước</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>Đi đến sao chép H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>Tên</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>Phiên bản hiện tại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>Phiên bản sao chép</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>Hành động</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>H/GPL có thể khôi phục</translation>
     </message>
@@ -2011,32 +1936,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>Tải lại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation> Xuất</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>Tổng quan</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>Cài đặt H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation> Sao chép H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>Khôi phục H/GPL</translation>
     </message>
@@ -2044,27 +1969,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>Không thể kích hoạt thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>Không thể vô hiệu hóa thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>Không thể vô hiệu hóa nó: không thể lấy mã SN của thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>Cập nhật H/GPL</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>Gỡ cài đặt H/GPL</translation>
     </message>
@@ -2072,22 +1997,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>Tải lại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation> Xuất</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation> Sao chép</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation> Tóm tắt</translation>
     </message>
@@ -2111,7 +2036,6 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
         <source>Enable</source>
         <translation> Kích hoạt</translation>
     </message>
@@ -2131,33 +2055,32 @@
         <translation> Cho phép nó thức tỉnh máy tính</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation> Khóa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation> Không thể khóa nó: không thể lấy số seri thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation> Không thể khóa thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation> Không thể kích hoạt thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation> Cập nhật Driver</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation> Gỡ cài đặt Driver</translation>
     </message>
@@ -2165,1314 +2088,1152 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
         <source>SubVendor</source>
         <translation> SubVendor</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
         <source>SubDevice</source>
         <translation> SubDevice</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation> Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation> Trạng thái Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation> Command kích hoạt Driver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
         <source>Config Status</source>
         <translation> Trạng thái cấu hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
         <source>latency</source>
         <translation> thời gian ủi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation> Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation> Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>Người xử lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>Phiên bản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
         <source>Bus</source>
         <translation>Bus</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
         <source>BIOS Information</source>
         <translation>Thông tin BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
         <source>Base Board Information</source>
         <translation>Thông tin bảng cơ sở</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
         <source>System Information</source>
         <translation>Thông tin hệ thống</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
         <source>Chassis Information</source>
         <translation>Thông tin vỏ máy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
         <source>Physical Memory Array</source>
         <translation>Mảng bộ nhớ vật lý</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>Ngày phát hành</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>Kích thước chạy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>Kích thước ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>Tính năng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>Phiên bản BIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>Phiên bản firmware</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
         <source>Product Name</source>
         <translation>Tên sản phẩm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
         <source>Serial Number</source>
         <translation>Số serail</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
         <source>Asset Tag</source>
         <translation>Nhãn tài sản</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
         <source>Features</source>
         <translation>Đặc điểm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>Vị trí trong vỏ máy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>Xử lý vỏ máy</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
         <source>Type</source>
         <translation>Loại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
-        <source>UUID</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
-        <source>Wake-up Type</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
-        <source>SKU Number</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
-        <source>Family</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
-        <source>Lock</source>
-        <translation type="unfinished"/>
+        <translation>Các tay cầm đối tượng chứa</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
-        <source>Boot-up State</source>
-        <translation type="unfinished"/>
+        <source>UUID</source>
+        <translation>UUID</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
-        <source>Power Supply State</source>
-        <translation type="unfinished"/>
+        <source>Wake-up Type</source>
+        <translation>Loại thức tỉnh</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
-        <source>Thermal State</source>
-        <translation type="unfinished"/>
+        <source>SKU Number</source>
+        <translation>SốSKU</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
-        <source>Security Status</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
-        <source>OEM Information</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
-        <source>Height</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
-        <source>Number Of Power Cords</source>
-        <translation type="unfinished"/>
+        <source>Family</source>
+        <translation>Gia đình</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
-        <source>Contained Elements</source>
-        <translation type="unfinished"/>
+        <source>Lock</source>
+        <translation>Khóa</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
-        <source>Location</source>
-        <translation type="unfinished"/>
+        <source>Boot-up State</source>
+        <translation>Trạng thái khởi động</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
-        <source>Error Correction Type</source>
-        <translation type="unfinished"/>
+        <source>Power Supply State</source>
+        <translation>Trạng thái nguồn cung cấp</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
-        <source>Maximum Capacity</source>
-        <translation type="unfinished"/>
+        <source>Thermal State</source>
+        <translation>Trạng thái nhiệt</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
-        <source>Error Information Handle</source>
-        <translation type="unfinished"/>
+        <source>Security Status</source>
+        <translation>Trạng thái bảo mật</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
-        <source>Number Of Devices</source>
-        <translation type="unfinished"/>
+        <source>OEM Information</source>
+        <translation>Thông tin OEM</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+        <source>Height</source>
+        <translation>Chiều cao</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
-        <source>BIOS ROMSIZE</source>
-        <translation type="unfinished"/>
+        <source>Number Of Power Cords</source>
+        <translation>Số dây nguồn</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
-        <source>Release date</source>
-        <translation type="unfinished"/>
+        <source>Contained Elements</source>
+        <translation>Các phần tử chứa</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
-        <source>Board name</source>
-        <translation type="unfinished"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+        <source>Location</source>
+        <translation>Vị trí</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <source>Error Correction Type</source>
+        <translation>Loại sửa lỗi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <source>Maximum Capacity</source>
+        <translation>Khả năng chứa tối đa</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <source>Error Information Handle</source>
+        <translation>Cổng thông tin lỗi</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <source>Number Of Devices</source>
+        <translation>Số thiết bị</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+        <source>BIOS ROMSIZE</source>
+        <translation>Kích thước BIOS ROM</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <source>Release date</source>
+        <translation>Ngày phát hành</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+        <source>Board name</source>
+        <translation>Tên bo mạch</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
-        <translation type="unfinished"/>
+        <translation>Phiên bản SMBIOS</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
-        <translation type="unfinished"/>
+        <translation>Định dạng Mô tả Ngôn ngữ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
-        <translation type="unfinished"/>
+        <translation>Ngôn ngữ có thể cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>Ngôn ngữ đang cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>Địa chỉ BD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>Loại gói</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>Chính sách kết nối</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>Chế độ kết nối</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
         <source>Class</source>
         <translation>Lớp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>Dịch vụ lớp</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>Lớp thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>Phiên bản HCI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>Phiên bản LMP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>Phiên bản phụ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
         <source>Device</source>
         <translation>Thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
         <source>Serial ID</source>
         <translation>ID seri</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>Sản phẩm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>Mô tả</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>Bị kích hoạt</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>Có thể khám phá</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>Có thể ghép nối</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>Modalias</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>Đang khám phá</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
         <source>Driver Modules</source>
         <translation>Module trình-drivers</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
         <source>Device File</source>
         <translation>File thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>File thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
         <source>Device Number</source>
         <translation>Số thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>Ứng dụng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>trạng thái</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
         <source>logical name</source>
         <translation>tên logico</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
         <source>ansiversion</source>
         <translation>ansiversion</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>Nhà sản xuất CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>Kiến trúc CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>Phiên bản CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>Phần CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>Lần sửa đổi CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>Một</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>Hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>Bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>Sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>Tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>Chín</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>Mười</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>Mười hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>Mười bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>Mười sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>Mười tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>Hai mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>Hai mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>Hai mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>Hai mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>Mười tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>Ba mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>Ba mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>Ba mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>Ba mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>Ba mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>Bốn mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>Bốn mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>Bốn mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>Bốn mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>Bốn mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>Lăm mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>Lăm mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>Lăm mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>Lăm mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>Lăm mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>Sáu mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>Sáu mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>Sáu mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>Sáu mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>Sáu mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>Bảy mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>Bảy mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>Bảy mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>Bảy mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>Tám mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>Tám mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>Tám mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>Tám mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>Tám mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>Tám mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>Chín mươi</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>Chín mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>Chín mươi bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>Chín mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>Chín mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>Một trăm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>Một trăm hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>Một trăm bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>Một trăm sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>Một trăm tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>Một trăm mười</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>Một trăm mười hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>Một trăm mười bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>Một trăm mười sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>Một trăm mười tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>Một trăm-twenty</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>Một trăm-twenty hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>Một trăm-twenty bốn</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>Một trăm-twenty sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>Một trăm tám mươi tám</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>Một trăm chín mươi hai</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>Hai trăm năm mươi sáu</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>Độ lớn bộ nhớ GDDR</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>Nhà sản xuất GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>Loại GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>Phiên bản EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>APIs khách của EGL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>Phiên bản GL</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>Phiên bản GLSL</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
         <source>Unknown</source>
         <translation>Không rõ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <source>Hardware Class</source>
         <translation>Lớp phần cứng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
         <source>No CPU found</source>
         <translation>Không tìm thấy CPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>Motherboard</source>
         <translation>Mainboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
         <source>No motherboard found</source>
         <translation>Không tìm thấy mainboard</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>Memory</source>
         <translation>Bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
         <source>No memory found</source>
         <translation>Không tìm thấy bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>Storage</source>
         <translation>Ổ lưu trữ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
         <source>No disk found</source>
         <translation>Không tìm thấy ổ đĩa</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>Khôi phục trình điều khiển thất bại</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
         <source>Please try again or give us feedback</source>
         <translation>Xin hãy thử lại hoặc cho chúng tôi biết ý kiến của bạn</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>Sao lưu trình điều khiển thất bại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>Display Adapter</source>
         <translation>Kết nối màn hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
         <source>No GPU found</source>
         <translation>Không tìm thấy GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>Monitor</source>
         <translation>Màn hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
         <source>No monitor found</source>
         <translation>Không tìm thấy màn hình</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>Network Adapter</source>
         <translation>Kết nối mạng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
         <source>No network adapter found</source>
         <translation>Không tìm thấy kết nối mạng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>Sound Adapter</source>
         <translation>Kết nối âm thanh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <source>No audio device found</source>
         <translation>Không tìm thấy thiết bị âm thanh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
         <source>No Bluetooth device found</source>
         <translation>Không tìm thấy thiết bị Bluetooth</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>Other PCI Devices</source>
         <translation>Thiết bị PCI khác</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
         <source>No other PCI devices found</source>
         <translation>Không tìm thấy thiết bị PCI khác</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>Power</source>
         <translation>Năng lượng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
         <source>No battery found</source>
         <translation>Không tìm thấy pin</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>Keyboard</source>
         <translation>Bàn phím</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
         <source>No keyboard found</source>
         <translation>Không tìm thấy bàn phím</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>Mouse</source>
         <translation> Chuột</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <source>No mouse found</source>
         <translation>Không tìm thấy chuột</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>Printer</source>
         <translation>In</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
         <source>No printer found</source>
         <translation>Không tìm thấy máy in</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>Camera</source>
         <translation>Đầu đọc hình ảnh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
         <source>No camera found</source>
         <translation>Không tìm thấy đầu đọc hình ảnh</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>CD-ROM</source>
         <translation>CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
         <source>No CD-ROM found</source>
         <translation>Không tìm thấy CD-ROM</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>Other Devices</source>
         <translation>Thiết bị khác</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
         <source>No other devices found</source>
         <translation>Không tìm thấy thiết bị khác</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>Ký hiệu mảng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>Kiểu dáng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>Set</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>Địa chỉ bộ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>Chi tiết loại</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>Số phần tử</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>Số hạng</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>Kỹ thuật bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>Kết quả hoạt động bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>Phiên bản phần mềm máy chủ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>Mã nhà sản xuất module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>Mã sản phẩm module</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>Mã nhà sản xuất bộ điều khiển hệ thống bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>Mã sản phẩm bộ điều khiển hệ thống bộ nhớ</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>Kích thước không biến mất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>Kích thước biến mất</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>Kích thước bộ nhớ đệm</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>Kích thước logic</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
         <source>inch</source>
         <translation>inch</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>Ngày</translation>
     </message>
@@ -3692,313 +3453,294 @@
         <translation>phía</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
         <source>SSD</source>
         <translation>SSD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
         <source>HDD</source>
         <translation>HDD</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
         <source>bus info</source>
         <translation>thông tin giao diện</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>kích thước sector logics</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>kích thước sector</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>GUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>Độ dài (lô gíc]</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
         <source>Device Manager</source>
         <translation>Quản lý thiết bị</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>Quản lý thiết bị là công cụ tiện lợi để xem thông tin về phần cứng và quản lý các thiết bị.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>Có các trình điều khiển mới! Cài đặt hoặc cập nhật chúng ngay.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>Xem</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>Bao gồm thư mục con</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>Tìm trình điều khiển trong đường dẫn này</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>%1 bản cập nhật trình điều khiển sẵn có</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
         <source>Time checked: %1</source>
         <translation>Thời gian kiểm tra: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>Tải trình điều khiển cho %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>Tốc độ tải: %1 Tải %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>Cài đặt trình điều khiển cho %1...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>%1 trình điều khiển đã cài đặt, %2 trình điều khiển thất bại</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>%1 trình điều khiển đã cài đặt</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>Không thể cài đặt trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>Lỗi mạng. Kết nối lại...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>Tốc độ tải: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>Các trình điều khiển của bạn đã cập nhật</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>Tất cả các trình điều khiển đã được sao lưu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>Tổng cộng %1 trình điều khiển, trong đó %2 đã được sao lưu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>Bạn có %1 trình điều khiển có thể sao lưu, đề nghị thực hiện ngay</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>Bạn có %1 trình điều khiển có thể sao lưu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>Đang sao lưu trình điều khiển %1, tổng cộng %2 trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>Đang sao lưu: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>%1 trình điều khiển đã sao lưu, %2 trình điều khiển thất bại</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>Không thể sao lưu trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1 trình điều khiển đã sao lưu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>Bạn có %1 trình điều khiển có thể khôi phục</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>Vui lòng chọn trình điều khiển để khôi phục</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>Đang khôi phục trình điều khiển...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>Khôi phục: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>đặt lại</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>Vui lòng %1 để các trình điều khiển đã cài đặt có hiệu lực</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>Xem đường dẫn sao lưu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>Sao lưu tất cả</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
         <source>submit feedback</source>
         <translation> gử ý kiến phản hồi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>Vui lòng thử lại hoặc %1 cho chúng tôi</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>Cài đặt tất cả</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
         <source>Scan Again</source>
         <translation>Quét lại</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>Hủy bỏ</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>Đang quét trình điều khiển thiết bị phần cứng, vui lòng chờ...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
         <source>Scanning %1</source>
         <translation>Đang quét %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>Quét thất bại</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>Mạng không khả dụng</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>Vui lòng kiểm tra kết nối mạng</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>Vui lòng quét lại hoặc %1 cho chúng tôi</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>Bạn đang cài đặt một trình điều khiển, sẽ bị ngắt nếu bạn thoát.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
         <source>Are you sure you want to exit?</source>
         <translation>Bạn có chắc chắn muốn thoát không? </translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>Thoát</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>Hủy bỏ</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>Bạn đang sao lưu trình điều khiển, sẽ bị ngắt nếu bạn thoát.</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>Bạn đang khôi phục trình điều khiển, sẽ bị ngắt nếu bạn thoát.</translation>
     </message>
@@ -4009,7 +3751,6 @@
     </message>
     <message>
         <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
         <source>Imaging device</source>
         <translation>Thiết bị sao chép</translation>
     </message>
@@ -4114,22 +3855,22 @@
         <translation>Không thể lấy file trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>Cập nhật</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>Sao lưu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>Khôi phục</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>Cài đặt</translation>
     </message>
@@ -4142,39 +3883,37 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
         <source>Disable</source>
         <translation>Khóa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>Làm mới</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation> Xuất khẩu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>Cập nhật trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>Gỡ cài đặt trình điều khiển</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>Cho phép nó thức tỉnh máy tính</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
         <source>Enable</source>
         <translation>Kích hoạt</translation>
     </message>
@@ -4182,27 +3921,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>Làm mới</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation> Xuất khẩu</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation> Sao chép</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation> Khóa</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>Không có sẵn</translation>
     </message>
@@ -4210,7 +3949,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>Chọn một thư mục địa phương</translation>
     </message>
@@ -4218,7 +3957,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>Đang tải...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_CN.ts
@@ -1,27 +1,44 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>BtnLabel</name>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
         <source>OK</source>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
         <source>Feedback</source>
         <translation>反馈</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
 </context>
 <context>
+    <name>BtnWidget</name>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+        <source>More</source>
+        <translation type="unfinished">更多</translation>
+    </message>
+    <message>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+        <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+        <source>Collapse</source>
+        <translation type="unfinished">收起</translation>
+    </message>
+</context>
+<context>
     <name>CmdButtonWidget</name>
     <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
+        <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
@@ -47,28 +64,13 @@
 <context>
     <name>DetailButton</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
         <location filename="../src/Page/PageDetail.cpp" line="47"/>
+        <location filename="../src/Page/PageDetail.cpp" line="50"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>收起</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
+        <location filename="../src/Page/PageDetail.cpp" line="48"/>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
@@ -90,79 +92,79 @@
 <context>
     <name>DeviceAudio</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
         <source>Device Name</source>
         <translation>设备名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
         <source>Chip</source>
         <translation>芯片</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
         <source>SysFS_Path</source>
         <translation>SysFS_Path</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
         <source>Revision</source>
         <translation>修订版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
         <source>KernelModeDriver</source>
         <translation>KernelModeDriver</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
         <source>Memory Address</source>
         <translation>内存地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
         <source>IRQ</source>
         <translation>中断</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -188,17 +190,17 @@
 <context>
     <name>DeviceBios</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
         <source>Chipset</source>
         <translation>芯片组</translation>
     </message>
@@ -206,87 +208,87 @@
 <context>
     <name>DeviceBluetooth</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
         <source>Alias</source>
         <translation>别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
         <source>Driver Version</source>
         <translation>驱动版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
         <source>Logical Name</source>
         <translation>逻辑名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
         <source>MAC Address</source>
         <translation>物理地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -294,67 +296,67 @@
 <context>
     <name>DeviceCdrom</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -362,7 +364,7 @@
 <context>
     <name>DeviceComputer</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
@@ -370,117 +372,117 @@
 <context>
     <name>DeviceCpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
         <source>CPU ID</source>
         <translation>处理器ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
         <source>Core ID</source>
         <translation>核心ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
         <source>Threads</source>
         <translation>线程数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
         <source>BogoMIPS</source>
         <translation>运行速度（Bogomips）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
         <source>Architecture</source>
         <translation>架构</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
         <source>CPU Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
         <source>Processor</source>
         <translation>逻辑处理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
         <source>Core(s)</source>
         <translation>核</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
         <source>Virtualization</source>
         <translation>虚拟化</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
         <source>Flags</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
         <source>Extensions</source>
         <translation>扩展指令集</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
         <source>L4 Cache</source>
         <translation>L4 缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
         <source>L3 Cache</source>
         <translation>L3缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
         <source>L2 Cache</source>
         <translation>L2缓存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
         <source>L1i Cache</source>
         <translation>L1缓存（指令）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
         <source>L1d Cache</source>
         <translation>L1缓存（数据）</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
         <source>Stepping</source>
         <translation>步进</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Speed</source>
         <translation>频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
         <source>Max Speed</source>
         <translation>最大频率</translation>
     </message>
@@ -488,127 +490,127 @@
 <context>
     <name>DeviceGpu</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
         <source>Graphics Memory</source>
         <translation>显存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
         <source>Memory Address</source>
         <translation>内存地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
         <source>IO Port</source>
         <translation>I/O端口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
         <source>Maximum Resolution</source>
         <translation>最大分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
         <source>Minimum Resolution</source>
         <translation>最小分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
         <source>Current Resolution</source>
         <translation>当前分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
         <source>DP</source>
         <translation>DP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
         <source>eDP</source>
         <translation>eDP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
         <source>HDMI</source>
         <translation>HDMI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
         <source>VGA</source>
         <translation>VGA</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
         <source>DVI</source>
         <translation>DVI</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
         <source>DigitalOutput</source>
         <translation>DigitalOutput</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
         <source>Display Output</source>
         <translation>显示输出</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
         <source>IRQ</source>
         <translation>中断</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
@@ -616,72 +618,72 @@
 <context>
     <name>DeviceImage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
         <source>Maximum Power</source>
         <translation>最大功率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -689,72 +691,72 @@
 <context>
     <name>DeviceInput</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
         <source>Model</source>
         <translation>型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
         <source>Bus Info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
         <source>Speed</source>
         <translation>频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
         <source>Maximum Current</source>
         <translation>最大电流</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
@@ -762,140 +764,140 @@
 <context>
     <name>DeviceManager</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
         <source>Overview</source>
         <translation>概况</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
         <source>CPU</source>
         <translation>处理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
         <source>CPU quantity</source>
         <translation>CPU数量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
         <source>Motherboard</source>
         <translation>主板</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
         <source>Display Adapter</source>
         <translation>显示适配器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
         <source>Sound Adapter</source>
         <translation>音频适配器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
         <source>Storage</source>
         <translation>存储设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
         <source>Other PCI Devices</source>
         <translation>其他PCI设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
         <source>Battery</source>
         <translation>电池</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
         <source>Bluetooth</source>
         <translation>蓝牙</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
         <source>Network Adapter</source>
         <translation>网络适配器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
         <source>Mouse</source>
         <translation>鼠标</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
         <source>Keyboard</source>
         <translation>键盘</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
         <source>Monitor</source>
         <translation>显示设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
         <source>CD-ROM</source>
         <translation>光驱</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
         <source>Printer</source>
         <translation>打印机</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
         <source>Camera</source>
         <translation>图像设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
         <source>Other Devices</source>
         <comment>Other Input Devices</comment>
         <translation>其他设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
         <source>OS</source>
         <translation>操作系统</translation>
     </message>
@@ -903,73 +905,73 @@
 <context>
     <name>DeviceMemory</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
         <source>Total Width</source>
         <translation>总位宽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
         <source>Locator</source>
         <translation>插槽</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
         <source>Configured Voltage</source>
         <translation>配置电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
         <source>Maximum Voltage</source>
         <translation>最高电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
         <source>Minimum Voltage</source>
         <translation>最低电压</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
         <source>Configured Speed</source>
         <translation>配置频率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
         <source>Data Width</source>
         <translation>数据位宽</translation>
     </message>
@@ -977,57 +979,57 @@
 <context>
     <name>DeviceMonitor</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
         <source>Display Input</source>
         <translation>显示输入</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
         <source>Interface Type</source>
         <translation>接口类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
         <source>Support Resolution</source>
         <translation>支持分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
         <source>Current Resolution</source>
         <translation>当前分辨率</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
         <source>Display Ratio</source>
         <translation>显示比例</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
         <source>Primary Monitor</source>
         <translation>主显示器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
@@ -1428,81 +1430,81 @@
 <context>
     <name>DeviceStorage</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
         <source>Vendor</source>
         <translation>制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
         <source>Media Type</source>
         <translation>介质类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
         <source>Capabilities</source>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
         <source>Module Alias</source>
         <translation>模块别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
         <source>Physical ID</source>
         <translation>物理ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
         <source>Firmware Version</source>
         <translation>固件版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
         <source>Interface</source>
         <translation>接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
         <source>Rotation Rate</source>
         <translation>转速</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
@@ -1510,13 +1512,13 @@
 <context>
     <name>GetDriverNameWidget</name>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
         <source>Select a driver for update</source>
         <translation>选择需要更新的驱动程序</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
+        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
         <source>No drivers found in this folder</source>
         <translation>所选文件夹未检测到驱动文件</translation>
     </message>
@@ -1524,52 +1526,52 @@
 <context>
     <name>GetInfoPool</name>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
         <source>Loading Audio Device Info...</source>
         <translation>获取音频设备信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
         <source>Loading BIOS Info...</source>
         <translation>获取BIOS信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
         <source>Loading CD-ROM Info...</source>
         <translation>获取光驱信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
         <source>Loading Operating System Info...</source>
         <translation>获取操作系统信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
         <source>Loading CPU Info...</source>
         <translation>获取处理器信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
         <source>Loading Other Devices Info...</source>
         <translation>获取其他设备信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
         <source>Loading Power Info...</source>
         <translation>获取电池信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
         <source>Loading Printer Info...</source>
         <translation>获取打印机信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
         <source>Loading Mouse Info...</source>
         <translation>获取鼠标信息...</translation>
     </message>
     <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
+        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
         <source>Loading Network Adapter Info...</source>
         <translation>获取网络适配器信息...</translation>
     </message>
@@ -1577,14 +1579,14 @@
 <context>
     <name>LogTreeView</name>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="125"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
+        <location filename="../src/Widget/logtreeview.cpp" line="104"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
@@ -1592,12 +1594,12 @@
 <context>
     <name>LogViewItemDelegate</name>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
+        <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
@@ -1605,88 +1607,88 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
+        <location filename="../src/Page/MainWindow.cpp" line="250"/>
         <source>Device Info</source>
-        <comment>export file's name</comment>
+        <comment>export file&apos;s name</comment>
         <translation>设备信息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
+        <location filename="../src/Page/MainWindow.cpp" line="321"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
+        <location filename="../src/Page/MainWindow.cpp" line="322"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
+        <location filename="../src/Page/MainWindow.cpp" line="323"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
+        <location filename="../src/Page/MainWindow.cpp" line="324"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
+        <location filename="../src/Page/MainWindow.cpp" line="328"/>
         <source>System</source>
         <translation>系统</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
+        <location filename="../src/Page/MainWindow.cpp" line="335"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
+        <location filename="../src/Page/MainWindow.cpp" line="336"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
+        <location filename="../src/Page/MainWindow.cpp" line="340"/>
         <source>Device Manager</source>
         <translation>设备管理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Hardware</source>
         <translation>硬件信息</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
+        <location filename="../src/Page/MainWindow.cpp" line="409"/>
         <source>Drivers</source>
         <translation>驱动管理</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Monitor</source>
         <translation>显示设备</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
+        <location filename="../src/Page/MainWindow.cpp" line="561"/>
         <source>Overview</source>
         <translation>概况</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
+        <location filename="../src/Page/MainWindow.cpp" line="565"/>
         <source>Display Adapter</source>
         <translation>显示适配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
+        <location filename="../src/Page/MainWindow.cpp" line="569"/>
         <source>CPU</source>
         <translation>处理器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
+        <location filename="../src/Page/MainWindow.cpp" line="573"/>
         <source>Network Adapter</source>
         <translation>网络适配器</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
+        <location filename="../src/Page/MainWindow.cpp" line="579"/>
         <source>Battery</source>
         <translation>电池</translation>
     </message>
@@ -1694,7 +1696,7 @@
 <context>
     <name>PageDetail</name>
     <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
+        <location filename="../src/Page/PageDetail.cpp" line="319"/>
         <source>More</source>
         <translation>更多</translation>
     </message>
@@ -1702,40 +1704,40 @@
 <context>
     <name>PageDriverBackupInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Current Version</source>
         <translation>当前版本</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
         <source>Driver Platform Version</source>
         <translation>驱动平台版本</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
         <source>Action</source>
         <translation>操作</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
         <source>Backupable Drivers</source>
         <translation>可备份驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
+        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
         <source>Backed up Drivers</source>
         <translation>已备份驱动</translation>
     </message>
@@ -1743,137 +1745,137 @@
 <context>
     <name>PageDriverControl</name>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
         <source>Updating</source>
         <translation>正在更新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>Warning</source>
         <translation>注意</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
         <source>The device will be unavailable after the driver uninstallation</source>
         <translation>将从系统中卸载此驱动程序，卸载后该设备不可用</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
         <source>Uninstall</source>
         <comment>button</comment>
         <translation>卸 载</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
         <source>Uninstalling</source>
         <translation>正在卸载</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Update successful</source>
         <translation>驱动更新成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
         <source>Uninstallation successful</source>
         <translation>驱动卸载成功</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Update failed</source>
         <translation>驱动更新失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
         <source>Uninstallation failed</source>
         <translation>驱动卸载失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
         <source>OK</source>
         <comment>button</comment>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
         <source>Next</source>
         <comment>button</comment>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
         <source>The selected folder does not exist, please select again</source>
         <translation>所选文件夹不存在，请重新选择</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
         <source>Update</source>
         <comment>button</comment>
         <translation>更 新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
         <source>Previous</source>
         <comment>button</comment>
         <translation>上一步</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
         <source>Broken package</source>
         <translation>包文件损坏</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
         <source>Unmatched package architecture</source>
         <translation>包文件与系统架构不匹配</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
         <source>The selected file does not exist, please select again</source>
         <translation>所选文件不存在，请重新选择</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
         <source>It is not a driver</source>
         <translation>该文件不是驱动文件</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
         <source>Unable to install - no digital signature</source>
         <translation>无法安装，安装包无数字签名</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
         <source>Unknown error</source>
         <translation>未知错误</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
         <source>The driver module was not found</source>
         <translation>未发现该驱动模块</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
         <source>Invalid module format</source>
         <translation>模块格式无效</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
+        <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
         <source>The driver module has dependencies</source>
         <translation>驱动模块被依赖</translation>
     </message>
@@ -1881,57 +1883,57 @@
 <context>
     <name>PageDriverInstallInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Device Name</source>
         <translation>设备名称</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
         <source>Version Available</source>
         <translation>可安装版本</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
         <source>Action</source>
         <translation>操作</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
         <source>New Version</source>
         <translation>可更新版本</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
         <source>Current Version</source>
         <translation>当前版本</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
         <source>Missing drivers (%1)</source>
         <translation>可安装驱动 (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
         <source>Outdated drivers (%1)</source>
         <translation>可更新驱动 (%1)</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
+        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
         <source>Up-to-date drivers (%1)</source>
         <translation>无需更新驱动 (%1)</translation>
     </message>
@@ -1939,33 +1941,33 @@
 <context>
     <name>PageDriverManager</name>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
         <source>Driver Install</source>
         <translation>驱动安装</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
         <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
         <source>Driver Backup</source>
         <translation>驱动备份</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
         <source>Driver Restore</source>
         <translation>驱动还原</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
         <source>OK</source>
         <translation>确 定</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
         <source>Feedback</source>
         <translation>反馈</translation>
     </message>
@@ -1973,37 +1975,37 @@
 <context>
     <name>PageDriverRestoreInfo</name>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
         <source>You do not have any drivers to restore, please backup first</source>
         <translation>您没有驱动可以还原，请先备份</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
         <source>Go to Backup Driver</source>
         <translation>前往备份驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
         <source>Current Version</source>
         <translation>当前版本</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
         <source>Backup Version</source>
         <translation>备份版本</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
         <source>Action</source>
         <translation>操作</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
+        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
         <source>Restorable Drivers</source>
         <translation>可还原驱动</translation>
     </message>
@@ -2011,32 +2013,32 @@
 <context>
     <name>PageListView</name>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
+        <location filename="../src/Page/PageListView.cpp" line="24"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
+        <location filename="../src/Page/PageListView.cpp" line="25"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
+        <location filename="../src/Page/PageListView.cpp" line="27"/>
         <source>Overview</source>
         <translation>概况</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Install</source>
         <translation>驱动安装</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Backup</source>
         <translation>驱动备份</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
+        <location filename="../src/Page/PageListView.cpp" line="123"/>
         <source>Driver Restore</source>
         <translation>驱动还原</translation>
     </message>
@@ -2044,27 +2046,27 @@
 <context>
     <name>PageMultiInfo</name>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
         <source>Failed to enable the device</source>
         <translation>启用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
         <source>Failed to disable the device</source>
         <translation>禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>无法获取设备序列号，禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
         <source>Update Drivers</source>
         <translation>更新驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
         <source>Uninstall Drivers</source>
         <translation>卸载驱动</translation>
     </message>
@@ -2072,22 +2074,22 @@
 <context>
     <name>PageOverview</name>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
+        <location filename="../src/Page/PageOverview.cpp" line="42"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
+        <location filename="../src/Page/PageOverview.cpp" line="43"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
+        <location filename="../src/Page/PageOverview.cpp" line="44"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
+        <location filename="../src/Page/PageOverview.cpp" line="89"/>
         <source>Overview</source>
         <translation>概况</translation>
     </message>
@@ -2111,7 +2113,7 @@
     </message>
     <message>
         <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
         <source>Enable</source>
         <translation>启用</translation>
     </message>
@@ -2131,33 +2133,33 @@
         <translation>允许唤起电脑</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
         <source>Failed to disable it: unable to get the device SN</source>
         <translation>无法获取设备序列号，禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
         <source>Failed to disable the device</source>
         <translation>禁用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
         <source>Failed to enable the device</source>
         <translation>启用失败</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
         <source>Update Drivers</source>
         <translation>更新驱动</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
+        <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
         <source>Uninstall Drivers</source>
         <translation>卸载驱动</translation>
     </message>
@@ -2165,1314 +2167,1314 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
         <source>SubVendor</source>
         <translation>子制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
         <source>SubDevice</source>
         <translation>子设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
         <source>Driver</source>
         <translation>驱动</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
         <source>Driver Status</source>
         <translation>驱动状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
         <source>Driver Activation Cmd</source>
         <translation>驱动激活命令</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
         <source>Config Status</source>
         <translation>配置状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
         <source>latency</source>
         <translation>延迟</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
         <source>Phys</source>
         <translation>Phys</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
         <source>Sysfs</source>
         <translation>Sysfs</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
         <source>Handlers</source>
         <translation>处理程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
         <source>PROP</source>
         <translation>PROP</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
         <source>EV</source>
         <translation>EV</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
         <source>KEY</source>
         <translation>KEY</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
         <source>Version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
         <source>Bus</source>
         <translation>总线</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
         <source>BIOS Information</source>
         <translation>BIOS信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
         <source>Base Board Information</source>
         <translation>主板信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
         <source>System Information</source>
         <translation>系统信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
         <source>Chassis Information</source>
         <translation>机箱信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
         <source>Physical Memory Array</source>
         <translation>内存插槽信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
         <source>Release Date</source>
         <translation>发布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
         <source>Runtime Size</source>
         <translation>运行内存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
         <source>ROM Size</source>
         <translation>ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
         <source>Characteristics</source>
         <translation>特性</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
         <source>BIOS Revision</source>
         <translation>BIOS修订版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
         <source>Firmware Revision</source>
         <translation>固件修订版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
         <source>Product Name</source>
         <translation>产品名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
         <source>Serial Number</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
         <source>Asset Tag</source>
         <translation>资产编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
         <source>Features</source>
         <translation>特征</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
         <source>Location In Chassis</source>
         <translation>机箱内位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
         <source>Chassis Handle</source>
         <translation>机箱程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
         <source>Contained Object Handles</source>
         <translation>包含对象程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
         <source>UUID</source>
         <translation>UUID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
         <source>Wake-up Type</source>
         <translation>唤醒类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
         <source>SKU Number</source>
         <translation>SKU号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
         <source>Family</source>
         <translation>家族</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
         <source>Lock</source>
         <translation>锁</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
         <source>Boot-up State</source>
         <translation>开机状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
         <source>Power Supply State</source>
         <translation>供电状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
         <source>Thermal State</source>
         <translation>散热状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
         <source>Security Status</source>
         <translation>安全状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
         <source>OEM Information</source>
         <translation>OEM信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
         <source>Height</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
         <source>Number Of Power Cords</source>
         <translation>电源线数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
         <source>Contained Elements</source>
         <translation>包含组件数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
         <source>Location</source>
         <translation>位置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
         <source>Error Correction Type</source>
         <translation>纠错类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
         <source>Maximum Capacity</source>
         <translation>最大容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
         <source>Error Information Handle</source>
         <translation>错误信息程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
         <source>Number Of Devices</source>
         <translation>卡槽数量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
         <source>BIOS ROMSIZE</source>
         <translation>BIOS ROM大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
         <source>Release date</source>
         <translation>发布日期</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
         <source>Board name</source>
         <translation>主板名称</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
         <source>SMBIOS Version</source>
         <translation>SMBIOS版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
         <source>Language Description Format</source>
         <translation>语言描述格式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
         <source>Installable Languages</source>
         <translation>可安装语言数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+        <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
         <source>Currently Installed Language</source>
         <translation>当前安装语言</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
         <source>BD Address</source>
         <translation>蓝牙设备地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
         <source>ACL MTU</source>
         <translation>ACL MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
         <source>SCO MTU</source>
         <translation>SCO MTU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
         <source>Packet type</source>
         <translation>数据包类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
         <source>Link policy</source>
         <translation>连接策略</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
         <source>Link mode</source>
         <translation>连接模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
         <source>Class</source>
         <translation>类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
         <source>Service Classes</source>
         <translation>服务类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
         <source>Device Class</source>
         <translation>设备类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
         <source>HCI Version</source>
         <translation>HCI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
         <source>LMP Version</source>
         <translation>LMP版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
         <source>Subversion</source>
         <translation>子版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
         <source>Serial ID</source>
         <translation>序列号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
         <source>product</source>
         <translation>产品</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
         <source>description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
         <source>Powered</source>
         <translation>供电</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
         <source>Discoverable</source>
         <translation>可发现</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
         <source>Pairable</source>
         <translation>可配对</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
         <source>Modalias</source>
         <translation>设置命令别名</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
         <source>Discovering</source>
         <translation>搜索中</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
         <source>Driver Modules</source>
         <translation>驱动模块</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
         <source>Device File</source>
         <translation>设备文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
         <source>Device Files</source>
         <translation>设备文件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
         <source>Device Number</source>
         <translation>设备编号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
         <source>Application</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
         <source>status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
         <source>logical name</source>
         <translation>逻辑地址</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
+        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
         <source>ansiversion</source>
         <translation>ANSI版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
         <source>CPU implementer</source>
         <translation>CPU程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
         <source>CPU architecture</source>
         <translation>CPU架构</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
         <source>CPU variant</source>
         <translation>CPU变量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
         <source>CPU part</source>
         <translation>CPU部件</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
         <source>CPU revision</source>
         <translation>CPU版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
         <source>One</source>
         <translation>单</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
         <source>Two</source>
         <translation>双</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
         <source>Four</source>
         <translation>四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
         <source>Six</source>
         <translation>六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
         <source>Eight</source>
         <translation>八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
         <source>Nine</source>
         <translation>九</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
         <source>Ten</source>
         <translation>十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
         <source>Twelve</source>
         <translation>十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
         <source>Fourteen</source>
         <translation>十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
         <source>Sixteen</source>
         <translation>十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
         <source>Eighteen</source>
         <translation>十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
         <source>Twenty</source>
         <translation>二十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
         <source>Twenty-two</source>
         <translation>二十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
         <source>Twenty-four</source>
         <translation>二十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
         <source>Twenty-six</source>
         <translation>二十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
         <source>Twenty-eight</source>
         <translation>二十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
         <source>Thirty</source>
         <translation>三十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
         <source>Thirty-two</source>
         <translation>三十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
         <source>Thirty-four</source>
         <translation>三十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
         <source>Thirty-six</source>
         <translation>三十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
         <source>Thirty-eight</source>
         <translation>三十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
         <source>Forty</source>
         <translation>四十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
         <source>Forty-two</source>
         <translation>四十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
         <source>Forty-four</source>
         <translation>四十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
         <source>Forty-six</source>
         <translation>四十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
         <source>Forty-eight</source>
         <translation>四十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
         <source>Fifty</source>
         <translation>五十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
         <source>Fifty-two</source>
         <translation>五十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
         <source>Fifty-four</source>
         <translation>五十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
         <source>Fifty-six</source>
         <translation>五十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
         <source>Fifty-eight</source>
         <translation>五十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
         <source>Sixty</source>
         <translation>六十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
         <source>Sixty-two</source>
         <translation>六十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
         <source>Sixty-four</source>
         <translation>六十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
         <source>Sixty-six</source>
         <translation>六十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
         <source>Sixty-eight</source>
         <translation>六十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
         <source>Seventy</source>
         <translation>七十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
         <source>Seventy-two</source>
         <translation>七十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
         <source>Seventy-four</source>
         <translation>七十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
         <source>Seventy-six</source>
         <translation>七十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
         <source>Seventy-eight</source>
         <translation>七十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
         <source>Eighty</source>
         <translation>八十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
         <source>Eighty-two</source>
         <translation>八十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
         <source>Eighty-four</source>
         <translation>八十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
         <source>Eighty-six</source>
         <translation>八十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
         <source>Eighty-eight</source>
         <translation>八十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
         <source>Ninety</source>
         <translation>九十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
         <source>Ninety-two</source>
         <translation>九十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
         <source>Ninety-four</source>
         <translation>九十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
         <source>Ninety-six</source>
         <translation>九十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
         <source>Ninety-eight</source>
         <translation>九十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
         <source>One hundred</source>
         <translation>一百</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
         <source>One hundred and Two</source>
         <translation>一百零二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
         <source>One hundred and four</source>
         <translation>一百零四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
         <source>One hundred and Six</source>
         <translation>一百零六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
         <source>One hundred and Eight</source>
         <translation>一百零八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
         <source>One hundred and Ten</source>
         <translation>一百一十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
         <source>One hundred and Twelve</source>
         <translation>一百一十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
         <source>One hundred and Fourteen</source>
         <translation>一百一十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
         <source>One hundred and Sixteen</source>
         <translation>一百一十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
         <source>One hundred and Eighteen</source>
         <translation>一百一十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
         <source>One hundred and Twenty</source>
         <translation>一百二十</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
         <source>One hundred and Twenty-two</source>
         <translation>一百二十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
         <source>One hundred and Twenty-four</source>
         <translation>一百二十四</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
         <source>One hundred and Twenty-six</source>
         <translation>一百二十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
         <source>One hundred and Twenty-eight</source>
         <translation>一百二十八</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
         <source>One hundred and Ninety-two</source>
         <translation>一百九十二</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
         <source>Two hundred and fifty-six</source>
         <translation>二百五十六</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
         <source>GDDR capacity</source>
         <translation>GDDR容量</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
         <source>GPU vendor</source>
         <translation>GPU供应商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
         <source>GPU type</source>
         <translation>GPU类型</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
         <source>EGL version</source>
         <translation>EGL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
         <source>EGL client APIs</source>
         <translation>EGL接口</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
         <source>GL version</source>
         <translation>GL版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
         <source>GLSL version</source>
         <translation>GLSL版本</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
         <source>Uniq</source>
         <translation>Uniq</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
         <source>MSC</source>
         <translation>MSC</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
+        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
         <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
         <source>Hardware Class</source>
         <translation>硬件类别</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>CPU</source>
         <translation>处理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
         <source>No CPU found</source>
         <translation>未发现处理器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>Motherboard</source>
         <translation>主板</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
         <source>No motherboard found</source>
         <translation>未发现主板</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
         <source>No memory found</source>
         <translation>未发现内存</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>Storage</source>
         <translation>存储设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
         <source>No disk found</source>
         <translation>未发现磁盘</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
         <source>Driver restore failed!</source>
         <translation>驱动还原失败！</translation>
     </message>
     <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
         <source>Please try again or give us feedback</source>
         <translation>请重试，或反馈给我们</translation>
     </message>
     <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
+        <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
         <source>Driver backup failed!</source>
         <translation>驱动备份失败！</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
         <source>Display Adapter</source>
         <translation>显示适配器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
         <source>No GPU found</source>
         <translation>未发现GPU</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>Monitor</source>
         <translation>显示设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
         <source>No monitor found</source>
         <translation>未发现显示设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
         <source>Network Adapter</source>
         <translation>网络适配器</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
         <source>No network adapter found</source>
         <translation>未发现网络适配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>音频适配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>未发现音频设备</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>蓝牙</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>未发现蓝牙设备</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>其他PCI设备</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>未发现其他PCI设备</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>电池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>未发现电池</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+        <source>Sound Adapter</source>
+        <translation>音频适配器</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <source>No audio device found</source>
+        <translation>未发现音频设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+        <source>Bluetooth</source>
+        <translation>蓝牙</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+        <source>No Bluetooth device found</source>
+        <translation>未发现蓝牙设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>Other PCI Devices</source>
+        <translation>其他PCI设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+        <source>No other PCI devices found</source>
+        <translation>未发现其他PCI设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>Power</source>
+        <translation>电池</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+        <source>No battery found</source>
+        <translation>未发现电池</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <location filename="../src/Tool/commontools.cpp" line="39"/>
         <source>Keyboard</source>
         <translation>键盘</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
         <source>No keyboard found</source>
         <translation>未发现键盘</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>鼠标</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>未发现鼠标</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>打印机</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>未发现打印机</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>图像设备</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>未发现图像设备</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>光驱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>未发现光驱</translation>
     </message>
     <message>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
         <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/Tool/commontools.cpp" line="41"/>
+        <source>Mouse</source>
+        <translation>鼠标</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <source>No mouse found</source>
+        <translation>未发现鼠标</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <location filename="../src/Tool/commontools.cpp" line="43"/>
+        <source>Printer</source>
+        <translation>打印机</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+        <source>No printer found</source>
+        <translation>未发现打印机</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>Camera</source>
+        <translation>图像设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+        <source>No camera found</source>
+        <translation>未发现图像设备</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>CD-ROM</source>
+        <translation>光驱</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+        <source>No CD-ROM found</source>
+        <translation>未发现光驱</translation>
+    </message>
+    <message>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <location filename="../src/Tool/commontools.cpp" line="45"/>
         <location filename="../src/Tool/commontools.cpp" line="47"/>
         <source>Other Devices</source>
         <translation>其他设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
         <source>No other devices found</source>
         <translation>未发现其他设备</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
         <source>Array Handle</source>
         <translation>数组程序</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
         <source>Form Factor</source>
         <translation>尺寸型号</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
         <source>Set</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
         <source>Bank Locator</source>
         <translation>内存通道</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
         <source>Type Detail</source>
         <translation>类型详情</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
         <source>Part Number</source>
         <translation>部件号码</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
         <source>Rank</source>
         <translation>位列</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
         <source>Memory Technology</source>
         <translation>内存技术</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
         <source>Memory Operating Mode Capability</source>
         <translation>内存操作模式</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
         <source>Firmware Version</source>
         <translation>固件版本</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
         <source>Module Manufacturer ID</source>
         <translation>组件制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
         <source>Module Product ID</source>
         <translation>组件产品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
         <source>Memory Subsystem Controller Manufacturer ID</source>
         <translation>内存子系统控制器制造商</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
         <source>Memory Subsystem Controller Product ID</source>
         <translation>内存子系统控制器产品ID</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
         <source>Non-Volatile Size</source>
         <translation>不易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
         <source>Volatile Size</source>
         <translation>易丢失大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
         <source>Cache Size</source>
         <translation>缓存大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
         <source>Logical Size</source>
         <translation>逻辑大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+        <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
         <source>inch</source>
         <translation>英寸</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
+        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
@@ -3692,313 +3694,313 @@
         <translation>打印面数</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
         <source>SSD</source>
         <translation>固态</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
         <source>HDD</source>
         <translation>机械</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
         <source>bus info</source>
         <translation>总线信息</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
         <source>logicalsectorsize</source>
         <translation>逻辑分区大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
         <source>sectorsize</source>
         <translation>扇区大小</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
         <source>guid</source>
         <translation>全局唯一标识符</translation>
     </message>
     <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
+        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
         <source>Geometry (Logical)</source>
         <translation>几何数据（逻辑）</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
+        <location filename="../src/main.cpp" line="93"/>
+        <location filename="../src/main.cpp" line="95"/>
         <source>Device Manager</source>
         <translation>设备管理器</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="92"/>
+        <location filename="../src/main.cpp" line="96"/>
         <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
         <translation>设备管理器是查看、管理硬件设备的工具软件。</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="148"/>
+        <location filename="../src/main.cpp" line="162"/>
         <source>New drivers available! Install or update them now.</source>
         <translation>您有驱动可进行安装/更新</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="149"/>
+        <location filename="../src/main.cpp" line="163"/>
         <source>View</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
         <source>Include subfolders</source>
         <translation>包括子文件夹</translation>
     </message>
     <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
+        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
         <source>Search for drivers in this path</source>
         <translation>选择驱动所在位置</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
         <source>%1 driver updates available</source>
         <translation>发现%1个驱动可安装更新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
         <source>Time checked: %1</source>
         <translation>检测时间: %1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
         <source>Downloading drivers for %1...</source>
         <translation>正在下载%1驱动…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
         <source>Download speed: %1 Downloaded %2/%3</source>
         <translation>下载速度：%1 已完成 %2/%3</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
         <source>Installing drivers for %1...</source>
         <translation>正在安装%1驱动…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
         <source>%1 drivers installed, %2 drivers failed</source>
         <translation>驱动安装成功%1个，失败%2个</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
         <source>%1 drivers installed</source>
         <translation>共成功安装%1个驱动</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
         <source>Failed to install drivers</source>
         <translation>驱动安装失败</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
         <source>Network error. Reconnecting...</source>
         <translation>网络异常，重试中</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
         <source>Download speed: %1</source>
         <translation>下载速度：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
         <source>Your drivers are up to date</source>
         <translation>驱动已是最新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
         <source>All drivers have been backed up</source>
         <translation>驱动已全部备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
         <source>A total of %1 drivers, of which %2 have been backed up</source>
         <translation>总计%1个驱动，其中%2个已备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
         <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
         <translation>您有%1个驱动可以备份，建议立即备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
         <source>You have %1 drivers that can be backed up</source>
         <translation>您有%1个驱动可以备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
         <source>Backing up the %1 driver, a total of %2 drivers</source>
         <translation>正在备份第%1个驱动，共%2个</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
         <source>Backing up: %1</source>
         <translation>正在备份：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
         <source>%1 drivers backed up, %2 drivers failed</source>
         <translation>驱动备份成功%1个，失败%2个</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
         <source>Failed to backup drivers</source>
         <translation>备份失败</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
         <source>%1 drivers backed up</source>
         <translation>%1个驱动已备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
         <source>You have %1 drivers that can be restored</source>
         <translation>您有%1个驱动可以还原</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
         <source>Please select a driver to restore</source>
         <translation>请选择驱动还原</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
         <source>Driver is restoring...</source>
         <translation>驱动还原中…</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
         <source>Restoring: %1</source>
         <translation>正在还原：%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
         <source>reboot</source>
         <translation>重启电脑</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
         <source>Please %1 for the installed drivers to take effect</source>
         <translation>驱动已安装完成，请稍后%1生效</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
         <source>View backup path</source>
         <translation>查看备份路径</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
         <source>Backup All</source>
         <translation>一键备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
         <source>submit feedback</source>
         <translation>反馈</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
         <source>Please try again or %1 to us</source>
         <translation>驱动未安装成功，请重试或%1给我们</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
         <source>Install All</source>
         <translation>一键安装</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
         <source>Scan Again</source>
         <translation>重新检测</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
         <source>Scanning hardware device drivers, please wait...</source>
         <translation>正在进行硬件驱动扫描，请耐心等待...</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
         <source>Scanning %1</source>
         <translation>正在扫描%1</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
         <source>Scan failed</source>
         <translation>检测失败</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
         <source>Network unavailable</source>
         <translation>无网络</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
         <source>Please check your network connection</source>
         <translation>请检查网络连接</translation>
     </message>
     <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
+        <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
         <source>Please scan again or %1 to us</source>
         <translation>请重新检测或%1给我们</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
+        <location filename="../src/Page/MainWindow.cpp" line="689"/>
         <source>You are installing a driver, which will be interrupted if you exit.</source>
         <translation>当前正在安装驱动，退出应用后任务将会中断</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
+        <location filename="../src/Page/MainWindow.cpp" line="690"/>
+        <location filename="../src/Page/MainWindow.cpp" line="703"/>
+        <location filename="../src/Page/MainWindow.cpp" line="716"/>
         <source>Are you sure you want to exit?</source>
         <translation>确认是否退出应用？</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
+        <location filename="../src/Page/MainWindow.cpp" line="693"/>
+        <location filename="../src/Page/MainWindow.cpp" line="706"/>
+        <location filename="../src/Page/MainWindow.cpp" line="719"/>
         <source>Exit</source>
         <comment>button</comment>
         <translation>退 出</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
+        <location filename="../src/Page/MainWindow.cpp" line="694"/>
+        <location filename="../src/Page/MainWindow.cpp" line="707"/>
+        <location filename="../src/Page/MainWindow.cpp" line="720"/>
         <source>Cancel</source>
         <comment>button</comment>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
+        <location filename="../src/Page/MainWindow.cpp" line="702"/>
         <source>You are backing up drivers, which will be interrupted if you exit.</source>
         <translation>当前正在备份驱动，退出应用后任务将会中断</translation>
     </message>
     <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
+        <location filename="../src/Page/MainWindow.cpp" line="715"/>
         <source>You are restoring drivers, which will be interrupted if you exit.</source>
         <translation>当前正在还原驱动，退出应用后任务将会中断</translation>
     </message>
@@ -4114,22 +4116,22 @@
         <translation>驱动文件获取异常</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
+        <location filename="../src/Widget/driveritem.cpp" line="249"/>
         <source>Update</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
+        <location filename="../src/Widget/driveritem.cpp" line="254"/>
         <source>Backup</source>
         <translation>备份</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
+        <location filename="../src/Widget/driveritem.cpp" line="259"/>
         <source>Restore</source>
         <translation>还原</translation>
     </message>
     <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
+        <location filename="../src/Widget/driveritem.cpp" line="245"/>
         <source>Install</source>
         <translation>安装</translation>
     </message>
@@ -4142,39 +4144,40 @@
 <context>
     <name>TableWidget</name>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="212"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="41"/>
         <source>Update drivers</source>
         <translation>更新驱动</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="42"/>
         <source>Uninstall drivers</source>
         <translation>卸载驱动</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="43"/>
         <source>Allow it to wake the computer</source>
         <translation>允许唤起电脑</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+        <location filename="../src/Widget/TableWidget.cpp" line="330"/>
         <source>Enable</source>
         <translation>启用</translation>
     </message>
@@ -4182,27 +4185,27 @@
 <context>
     <name>TextBrowser</name>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
         <source>Disable</source>
         <translation>禁用</translation>
     </message>
     <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
+        <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
@@ -4210,7 +4213,7 @@
 <context>
     <name>UrlChooserEdit</name>
     <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
+        <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
         <source>Select a local folder please</source>
         <translation>请选择本地文件夹</translation>
     </message>
@@ -4218,7 +4221,7 @@
 <context>
     <name>WaitingWidget</name>
     <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
+        <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
         <source>Loading...</source>
         <translation>正在载入...</translation>
     </message>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_HK.ts
@@ -1,4226 +1,4229 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
-<context>
-    <name>BtnLabel</name>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
-        <source>OK</source>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>確 定</translation>
-    </message>
-</context>
-<context>
-    <name>CmdButtonWidget</name>
-    <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-</context>
-<context>
-    <name>CommonTools</name>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
-        <source>EC_NOTIFY_NETWORK</source>
-        <translation>EC_NOTIFY_NETWORK</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
-        <source>EC_REINSTALL</source>
-        <translation>EC_REINSTALL</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
-        <source>EC_6</source>
-        <translation>EC_6</translation>
-    </message>
-</context>
-<context>
-    <name>DetailButton</name>
-    <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
-        <location filename="../src/Page/PageDetail.cpp" line="47"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>收起</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
-        <source>Collapse</source>
-        <translation>收起</translation>
-    </message>
-</context>
-<context>
-    <name>DetailViewDelegate</name>
-    <message>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceAudio</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
-        <source>Device Name</source>
-        <translation>設備名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
-        <source>Chip</source>
-        <translation>晶片</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
-        <source>SysFS_Path</source>
-        <translation>SysFS_Path</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
-        <source>Revision</source>
-        <translation>修訂版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
-        <source>KernelModeDriver</source>
-        <translation>KernelModeDriver</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
-        <source>Memory Address</source>
-        <translation>內存地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceBaseInfo</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceBios</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
-        <source>Chipset</source>
-        <translation>晶片組</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceBluetooth</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
-        <source>Alias</source>
-        <translation>別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
-        <source>Driver Version</source>
-        <translation>驅動版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
-        <source>Logical Name</source>
-        <translation>邏輯名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
-        <source>MAC Address</source>
-        <translation>物理地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceCdrom</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceComputer</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceCpu</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
-        <source>CPU ID</source>
-        <translation>處理器ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
-        <source>Core ID</source>
-        <translation>核心ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
-        <source>Threads</source>
-        <translation>線程數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
-        <source>BogoMIPS</source>
-        <translation>BogoMIPS</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
-        <source>Architecture</source>
-        <translation>架構</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
-        <source>CPU Family</source>
-        <translation>家族</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
-        <source>Processor</source>
-        <translation>邏輯處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
-        <source>Core(s)</source>
-        <translation>核</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
-        <source>Virtualization</source>
-        <translation>虛擬化</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
-        <source>Flags</source>
-        <translation>特性</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
-        <source>Extensions</source>
-        <translation>擴展指令集</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
-        <source>L4 Cache</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
-        <source>L3 Cache</source>
-        <translation>L3緩存</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
-        <source>L2 Cache</source>
-        <translation>L2緩存</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
-        <source>L1i Cache</source>
-        <translation>L1緩存（指令）</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
-        <source>L1d Cache</source>
-        <translation>L1緩存（數據）</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
-        <source>Stepping</source>
-        <translation>步進</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
-        <source>Speed</source>
-        <translation>頻率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
-        <source>Max Speed</source>
-        <translation>最大頻率</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceGpu</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
-        <source>Graphics Memory</source>
-        <translation>顯存</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
-        <source>Memory Address</source>
-        <translation>內存地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
-        <source>IO Port</source>
-        <translation>I/O端口</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
-        <source>Maximum Resolution</source>
-        <translation>最大解像度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
-        <source>Minimum Resolution</source>
-        <translation>最小解像度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
-        <source>Current Resolution</source>
-        <translation>當前解像度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
-        <source>DP</source>
-        <translation>DP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
-        <source>eDP</source>
-        <translation>eDP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
-        <source>HDMI</source>
-        <translation>HDMI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
-        <source>VGA</source>
-        <translation>VGA</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
-        <source>DVI</source>
-        <translation>DVI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
-        <source>DigitalOutput</source>
-        <translation>DigitalOutput</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
-        <source>Display Output</source>
-        <translation>顯示輸出</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceImage</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceInput</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
-        <source>Interface</source>
-        <translation>接口</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
-        <source>Speed</source>
-        <translation>頻率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
-        <source>Maximum Current</source>
-        <translation>最大電流</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceManager</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
-        <source>CPU</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
-        <source>CPU quantity</source>
-        <translation>CPU數量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
-        <source>Motherboard</source>
-        <translation>主板</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
-        <source>Memory</source>
-        <translation>內存</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
-        <source>Display Adapter</source>
-        <translation>顯示適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
-        <source>Sound Adapter</source>
-        <translation>音頻適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
-        <source>Storage</source>
-        <translation>存儲設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
-        <source>Other PCI Devices</source>
-        <translation>其他PCI設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
-        <source>Battery</source>
-        <translation>電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
-        <source>Bluetooth</source>
-        <translation>藍牙</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
-        <source>Network Adapter</source>
-        <translation>網絡適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
-        <source>Mouse</source>
-        <translation>鼠標</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
-        <source>Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
-        <source>Monitor</source>
-        <translation>顯示設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
-        <source>CD-ROM</source>
-        <translation>光驅</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
-        <source>Printer</source>
-        <translation>打印機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
-        <source>Camera</source>
-        <translation>圖像設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
-        <source>Other Devices</source>
-        <comment>Other Input Devices</comment>
-        <translation>其他設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
-        <source>Device</source>
-        <translation>設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
-        <source>OS</source>
-        <translation>操作系統</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceMemory</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
-        <source>Size</source>
-        <translation>大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
-        <source>Total Width</source>
-        <translation>總位寬</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
-        <source>Locator</source>
-        <translation>插槽</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
-        <source>Configured Voltage</source>
-        <translation>配置電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
-        <source>Maximum Voltage</source>
-        <translation>最高電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
-        <source>Minimum Voltage</source>
-        <translation>最低電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
-        <source>Configured Speed</source>
-        <translation>配置頻率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
-        <source>Data Width</source>
-        <translation>數據位寬</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceMonitor</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
-        <source>Display Input</source>
-        <translation>顯示輸入</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
-        <source>Interface Type</source>
-        <translation>接口類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
-        <source>Support Resolution</source>
-        <translation>支持解像度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
-        <source>Current Resolution</source>
-        <translation>當前解像度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
-        <source>Display Ratio</source>
-        <translation>顯示比例</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
-        <source>Primary Monitor</source>
-        <translation>主顯示器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
-        <source>Size</source>
-        <translation>大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceNetwork</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
-        <source>Driver Version</source>
-        <translation>驅動版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
-        <source>Maximum Rate</source>
-        <translation>最大速率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
-        <source>Negotiation Rate</source>
-        <translation>協商速率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
-        <source>Port</source>
-        <translation>端口</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
-        <source>Multicast</source>
-        <translation>組播</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
-        <source>Link</source>
-        <translation>連接</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
-        <source>Latency</source>
-        <translation>延遲</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
-        <source>IP</source>
-        <translation>IP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
-        <source>Firmware</source>
-        <translation>固件</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
-        <source>Duplex</source>
-        <translation>雙工</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
-        <source>Broadcast</source>
-        <translation>廣播</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
-        <source>Auto Negotiation</source>
-        <translation>自動協商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
-        <source>Memory Address</source>
-        <translation>內存地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
-        <source>MAC Address</source>
-        <translation>物理地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
-        <source>Logical Name</source>
-        <translation>邏輯名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceOtherPCI</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
-        <source>Input/Output</source>
-        <translation>輸入/輸出</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
-        <source>Memory</source>
-        <translation>內存</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
-        <source>Latency</source>
-        <translation>延遲</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceOthers</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
-        <source>Bus Info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DevicePower</name>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
-        <source>Capacity</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
-        <source>Voltage</source>
-        <translation>電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
-        <source>Slot</source>
-        <translation>插槽</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
-        <source>Design Capacity</source>
-        <translation>設計容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
-        <source>Design Voltage</source>
-        <translation>設計電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
-        <source>SBDS Version</source>
-        <translation>SBDS版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
-        <source>SBDS Serial Number</source>
-        <translation>SBDS序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
-        <source>SBDS Manufacture Date</source>
-        <translation>SBDS製造日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
-        <source>SBDS Chemistry</source>
-        <translation>SBDS材料</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
-        <source>Temperature</source>
-        <translation>溫度</translation>
-    </message>
-</context>
-<context>
-    <name>DevicePrint</name>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
-        <source>Shared</source>
-        <translation>已共享</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
-        <source>URI</source>
-        <translation>URI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
-        <source>Interface Type</source>
-        <translation>接口類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceStorage</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
-        <source>Media Type</source>
-        <translation>介質類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
-        <source>Size</source>
-        <translation>大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
-        <source>Module Alias</source>
-        <translation>模塊別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
-        <source>Firmware Version</source>
-        <translation>固件版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
-        <source>Interface</source>
-        <translation>接口</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
-        <source>Rotation Rate</source>
-        <translation>轉速</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>GetDriverNameWidget</name>
-    <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
-        <source>Select a driver for update</source>
-        <translation>選擇需要更新的驅動程序</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
-        <source>No drivers found in this folder</source>
-        <translation>所選文件夾未檢測到驅動文件</translation>
-    </message>
-</context>
-<context>
-    <name>GetInfoPool</name>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
-        <source>Loading Audio Device Info...</source>
-        <translation>獲取音頻設備訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
-        <source>Loading BIOS Info...</source>
-        <translation>獲取BIOS訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
-        <source>Loading CD-ROM Info...</source>
-        <translation>獲取光驅訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
-        <source>Loading Operating System Info...</source>
-        <translation>獲取操作系統訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
-        <source>Loading CPU Info...</source>
-        <translation>獲取處理器訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
-        <source>Loading Other Devices Info...</source>
-        <translation>獲取其他設備訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
-        <source>Loading Power Info...</source>
-        <translation>獲取電池訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
-        <source>Loading Printer Info...</source>
-        <translation>獲取打印機訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
-        <source>Loading Mouse Info...</source>
-        <translation>獲取鼠標訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
-        <source>Loading Network Adapter Info...</source>
-        <translation>獲取網絡適配器訊息...</translation>
-    </message>
-</context>
-<context>
-    <name>LogTreeView</name>
-    <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>LogViewItemDelegate</name>
-    <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
-        <source>Device Info</source>
-        <comment>export file's name</comment>
-        <translation>設備訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
-        <source>Display shortcuts</source>
-        <translation>顯示快捷鍵</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
-        <source>Close</source>
-        <translation>關閉</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
-        <source>Help</source>
-        <translation>幫助</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
-        <source>System</source>
-        <translation>系統</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
-        <source>Export</source>
-        <translation>導出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
-        <source>Refresh</source>
-        <translation>刷新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
-        <source>Device Manager</source>
-        <translation>設備管理器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
-        <source>Hardware</source>
-        <translation>硬件訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
-        <source>Drivers</source>
-        <translation>驅動管理</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
-        <source>Monitor</source>
-        <translation>顯示設備</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
-        <source>Display Adapter</source>
-        <translation>顯示適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
-        <source>CPU</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
-        <source>Network Adapter</source>
-        <translation>網絡適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
-        <source>Battery</source>
-        <translation>電池</translation>
-    </message>
-</context>
-<context>
-    <name>PageDetail</name>
-    <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-</context>
-<context>
-    <name>PageDriverBackupInfo</name>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
-        <source>Current Version</source>
-        <translation>當前版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
-        <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
-        <source>Action</source>
-        <translation>操作</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
-        <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
-        <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageDriverControl</name>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
-        <source>Updating</source>
-        <translation>正在更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
-        <source>Next</source>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>Warning</source>
-        <translation>注意</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>The device will be unavailable after the driver uninstallation</source>
-        <translation>將從系統中卸載此驅動程序，卸載後該設備不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
-        <source>Uninstall</source>
-        <comment>button</comment>
-        <translation>卸 載</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
-        <source>Uninstalling</source>
-        <translation>正在卸載</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
-        <source>Update successful</source>
-        <translation>驅動更新成功</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
-        <source>Uninstallation successful</source>
-        <translation>驅動卸載成功</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
-        <source>Update failed</source>
-        <translation>驅動更新失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
-        <source>Uninstallation failed</source>
-        <translation>驅動卸載失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
-        <source>Next</source>
-        <comment>button</comment>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
-        <source>The selected folder does not exist, please select again</source>
-        <translation>所選文件夾不存在，請重新選擇</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
-        <source>Update</source>
-        <comment>button</comment>
-        <translation>更 新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
-        <source>Previous</source>
-        <comment>button</comment>
-        <translation>上一步</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
-        <source>Broken package</source>
-        <translation>包文件損壞</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
-        <source>Unmatched package architecture</source>
-        <translation>包文件與系統架構不匹配</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
-        <source>The selected file does not exist, please select again</source>
-        <translation>所選文件不存在，請重新選擇</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
-        <source>It is not a driver</source>
-        <translation>該文件不是驅動文件</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
-        <source>Unable to install - no digital signature</source>
-        <translation>無法安裝，安裝包無數字簽名</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
-        <source>Unknown error</source>
-        <translation>未知錯誤</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
-        <source>The driver module was not found</source>
-        <translation>未發現該驅動模塊</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
-        <source>Invalid module format</source>
-        <translation>模塊格式無效</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
-        <source>The driver module has dependencies</source>
-        <translation>驅動模塊被依賴</translation>
-    </message>
-</context>
-<context>
-    <name>PageDriverInstallInfo</name>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
-        <source>Device Name</source>
-        <translation>設備名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
-        <source>Version Available</source>
-        <translation>可安裝版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
-        <source>Size</source>
-        <translation>大小</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
-        <source>Action</source>
-        <translation>操作</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
-        <source>New Version</source>
-        <translation>可更新版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
-        <source>Current Version</source>
-        <translation>當前版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
-        <source>Missing drivers (%1)</source>
-        <translation>可安裝驅動 (%1)</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
-        <source>Outdated drivers (%1)</source>
-        <translation>可更新驅動 (%1)</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
-        <source>Up-to-date drivers (%1)</source>
-        <translation>無需更新驅動 (%1)</translation>
-    </message>
-</context>
-<context>
-    <name>PageDriverManager</name>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
-        <source>Driver Install</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
-        <source>Driver Backup</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
-        <source>Driver Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
-        <source>OK</source>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageDriverRestoreInfo</name>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
-        <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
-        <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
-        <source>Current Version</source>
-        <translation>當前版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
-        <source>Backup Version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
-        <source>Action</source>
-        <translation>操作</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
-        <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageListView</name>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
-        <source>Refresh</source>
-        <translation>刷新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
-        <source>Export</source>
-        <translation>導出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
-        <source>Driver Install</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
-        <source>Driver Backup</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
-        <source>Driver Restore</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageMultiInfo</name>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
-        <source>Failed to enable the device</source>
-        <translation>啟用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <source>Failed to disable the device</source>
-        <translation>禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
-        <source>Failed to disable it: unable to get the device SN</source>
-        <translation>無法獲取設備序列號，禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
-        <source>Update Drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
-        <source>Uninstall Drivers</source>
-        <translation>卸載驅動</translation>
-    </message>
-</context>
-<context>
-    <name>PageOverview</name>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
-        <source>Refresh</source>
-        <translation>刷新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
-        <source>Export</source>
-        <translation>導出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-</context>
-<context>
-    <name>PageSingleInfo</name>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
-        <source>Refresh</source>
-        <translation>刷新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
-        <source>Export</source>
-        <translation>導出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
-        <source>Enable</source>
-        <translation>啟用</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
-        <source>Update drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
-        <source>Uninstall drivers</source>
-        <translation>卸載驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
-        <source>Allow it to wake the computer</source>
-        <translation>允許喚起電腦</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
-        <source>Failed to disable it: unable to get the device SN</source>
-        <translation>無法獲取設備序列號，禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
-        <source>Failed to disable the device</source>
-        <translation>禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
-        <source>Failed to enable the device</source>
-        <translation>啟用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
-        <source>Update Drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
-        <source>Uninstall Drivers</source>
-        <translation>卸載驅動</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
-        <source>SubVendor</source>
-        <translation>子製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
-        <source>SubDevice</source>
-        <translation>子設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
-        <source>Driver Status</source>
-        <translation>驅動狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
-        <source>Driver Activation Cmd</source>
-        <translation>驅動啟動命令</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
-        <source>Config Status</source>
-        <translation>配置狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
-        <source>latency</source>
-        <translation>延遲</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
-        <source>Phys</source>
-        <translation>Phys</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
-        <source>Sysfs</source>
-        <translation>Sysfs</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
-        <source>Handlers</source>
-        <translation>進程</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
-        <source>PROP</source>
-        <translation>PROP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
-        <source>EV</source>
-        <translation>EV</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
-        <source>KEY</source>
-        <translation>KEY</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
-        <source>Bus</source>
-        <translation>總線</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
-        <source>BIOS Information</source>
-        <translation>BIOS訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
-        <source>Base Board Information</source>
-        <translation>主板訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
-        <source>System Information</source>
-        <translation>系統訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
-        <source>Chassis Information</source>
-        <translation>機箱訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
-        <source>Physical Memory Array</source>
-        <translation>物理內存數組</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
-        <source>Release Date</source>
-        <translation>發佈日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
-        <source>Address</source>
-        <translation>地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
-        <source>Runtime Size</source>
-        <translation>運行內存大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
-        <source>ROM Size</source>
-        <translation>ROM大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
-        <source>Characteristics</source>
-        <translation>特性</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
-        <source>BIOS Revision</source>
-        <translation>BIOS修訂版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
-        <source>Firmware Revision</source>
-        <translation>固件修訂版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
-        <source>Product Name</source>
-        <translation>產品名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
-        <source>Serial Number</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
-        <source>Asset Tag</source>
-        <translation>資產編號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
-        <source>Features</source>
-        <translation>特徵</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
-        <source>Location In Chassis</source>
-        <translation>機箱內位置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
-        <source>Chassis Handle</source>
-        <translation>機箱程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
-        <source>Contained Object Handles</source>
-        <translation>包含對象程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
-        <source>UUID</source>
-        <translation>UUID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
-        <source>Wake-up Type</source>
-        <translation>喚醒類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
-        <source>SKU Number</source>
-        <translation>SKU號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
-        <source>Family</source>
-        <translation>家族</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
-        <source>Lock</source>
-        <translation>鎖</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
-        <source>Boot-up State</source>
-        <translation>開機狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
-        <source>Power Supply State</source>
-        <translation>供電狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
-        <source>Thermal State</source>
-        <translation>散熱狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
-        <source>Security Status</source>
-        <translation>安全狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
-        <source>OEM Information</source>
-        <translation>OEM訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
-        <source>Height</source>
-        <translation>高度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
-        <source>Number Of Power Cords</source>
-        <translation>電源線數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
-        <source>Contained Elements</source>
-        <translation>包含組件數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
-        <source>Location</source>
-        <translation>位置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
-        <source>Error Correction Type</source>
-        <translation>糾錯類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
-        <source>Maximum Capacity</source>
-        <translation>最大容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
-        <source>Error Information Handle</source>
-        <translation>錯誤訊息程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
-        <source>Number Of Devices</source>
-        <translation>卡槽數量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
-        <source>BIOS ROMSIZE</source>
-        <translation>BIOS ROM大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
-        <source>Release date</source>
-        <translation>發佈日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
-        <source>Board name</source>
-        <translation>主板名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
-        <source>SMBIOS Version</source>
-        <translation>SMBIOS版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
-        <source>Language Description Format</source>
-        <translation>語言描述格式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
-        <source>Installable Languages</source>
-        <translation>可安裝語言數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
-        <source>Currently Installed Language</source>
-        <translation>當前安裝語言</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
-        <source>BD Address</source>
-        <translation>藍牙設備地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
-        <source>ACL MTU</source>
-        <translation>ACL MTU</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
-        <source>SCO MTU</source>
-        <translation>SCO MTU</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
-        <source>Packet type</source>
-        <translation>數據包類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
-        <source>Link policy</source>
-        <translation>連接策略</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
-        <source>Link mode</source>
-        <translation>連接模式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
-        <source>Class</source>
-        <translation>類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
-        <source>Service Classes</source>
-        <translation>服務類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
-        <source>Device Class</source>
-        <translation>設備類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
-        <source>HCI Version</source>
-        <translation>HCI版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
-        <source>LMP Version</source>
-        <translation>LMP版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
-        <source>Subversion</source>
-        <translation>子版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
-        <source>Device</source>
-        <translation>設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
-        <source>Serial ID</source>
-        <translation>序列號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
-        <source>product</source>
-        <translation>產品</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
-        <source>description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
-        <source>Powered</source>
-        <translation>供電</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
-        <source>Discoverable</source>
-        <translation>可發現</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
-        <source>Pairable</source>
-        <translation>可配對</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
-        <source>Modalias</source>
-        <translation>設置命令別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
-        <source>Discovering</source>
-        <translation>搜索中</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
-        <source>Driver Modules</source>
-        <translation>驅動模塊</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
-        <source>Device File</source>
-        <translation>設備文件</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
-        <source>Device Files</source>
-        <translation>設備文件</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
-        <source>Device Number</source>
-        <translation>設備編號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
-        <source>Application</source>
-        <translation>應用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
-        <source>status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
-        <source>logical name</source>
-        <translation>邏輯地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
-        <source>ansiversion</source>
-        <translation>ANSI版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
-        <source>CPU implementer</source>
-        <translation>CPU程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
-        <source>CPU architecture</source>
-        <translation>CPU架構</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
-        <source>CPU variant</source>
-        <translation>CPU變量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
-        <source>CPU part</source>
-        <translation>CPU部件</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
-        <source>CPU revision</source>
-        <translation>CPU版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
-        <source>One</source>
-        <translation>單</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
-        <source>Two</source>
-        <translation>雙</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
-        <source>Four</source>
-        <translation>四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
-        <source>Six</source>
-        <translation>六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
-        <source>Eight</source>
-        <translation>八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
-        <source>Nine</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
-        <source>Ten</source>
-        <translation>十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
-        <source>Twelve</source>
-        <translation>十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
-        <source>Fourteen</source>
-        <translation>十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
-        <source>Sixteen</source>
-        <translation>十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
-        <source>Eighteen</source>
-        <translation>十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
-        <source>Twenty</source>
-        <translation>二十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
-        <source>Twenty-two</source>
-        <translation>二十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
-        <source>Twenty-four</source>
-        <translation>二十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
-        <source>Twenty-six</source>
-        <translation>二十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
-        <source>Twenty-eight</source>
-        <translation>二十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
-        <source>Thirty</source>
-        <translation>三十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
-        <source>Thirty-two</source>
-        <translation>三十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
-        <source>Thirty-four</source>
-        <translation>三十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
-        <source>Thirty-six</source>
-        <translation>三十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
-        <source>Thirty-eight</source>
-        <translation>三十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
-        <source>Forty</source>
-        <translation>四十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
-        <source>Forty-two</source>
-        <translation>四十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
-        <source>Forty-four</source>
-        <translation>四十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
-        <source>Forty-six</source>
-        <translation>四十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
-        <source>Forty-eight</source>
-        <translation>四十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
-        <source>Fifty</source>
-        <translation>五十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
-        <source>Fifty-two</source>
-        <translation>五十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
-        <source>Fifty-four</source>
-        <translation>五十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
-        <source>Fifty-six</source>
-        <translation>五十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
-        <source>Fifty-eight</source>
-        <translation>五十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
-        <source>Sixty</source>
-        <translation>六十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
-        <source>Sixty-two</source>
-        <translation>六十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
-        <source>Sixty-four</source>
-        <translation>六十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
-        <source>Sixty-six</source>
-        <translation>六十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
-        <source>Sixty-eight</source>
-        <translation>六十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
-        <source>Seventy</source>
-        <translation>七十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
-        <source>Seventy-two</source>
-        <translation>七十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
-        <source>Seventy-four</source>
-        <translation>七十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
-        <source>Seventy-six</source>
-        <translation>七十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
-        <source>Seventy-eight</source>
-        <translation>七十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
-        <source>Eighty</source>
-        <translation>八十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
-        <source>Eighty-two</source>
-        <translation>八十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
-        <source>Eighty-four</source>
-        <translation>八十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
-        <source>Eighty-six</source>
-        <translation>八十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
-        <source>Eighty-eight</source>
-        <translation>八十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
-        <source>Ninety</source>
-        <translation>九十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
-        <source>Ninety-two</source>
-        <translation>九十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
-        <source>Ninety-four</source>
-        <translation>九十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
-        <source>Ninety-six</source>
-        <translation>九十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
-        <source>Ninety-eight</source>
-        <translation>九十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
-        <source>One hundred</source>
-        <translation>100</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
-        <source>One hundred and Two</source>
-        <translation>102</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
-        <source>One hundred and four</source>
-        <translation>104</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
-        <source>One hundred and Six</source>
-        <translation>106</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
-        <source>One hundred and Eight</source>
-        <translation>108</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
-        <source>One hundred and Ten</source>
-        <translation>110</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
-        <source>One hundred and Twelve</source>
-        <translation>112</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
-        <source>One hundred and Fourteen</source>
-        <translation>114</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
-        <source>One hundred and Sixteen</source>
-        <translation>116</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
-        <source>One hundred and Eighteen</source>
-        <translation>118</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
-        <source>One hundred and Twenty</source>
-        <translation>120</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
-        <source>One hundred and Twenty-two</source>
-        <translation>122</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
-        <source>One hundred and Twenty-four</source>
-        <translation>124</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
-        <source>One hundred and Twenty-six</source>
-        <translation>126</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
-        <source>One hundred and Twenty-eight</source>
-        <translation>128</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
-        <source>One hundred and Ninety-two</source>
-        <translation>一百九十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
-        <source>Two hundred and fifty-six</source>
-        <translation>256</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
-        <source>GDDR capacity</source>
-        <translation>GDDR容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
-        <source>GPU vendor</source>
-        <translation>GPU供應商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
-        <source>GPU type</source>
-        <translation>GPU類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
-        <source>EGL version</source>
-        <translation>EGL版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
-        <source>EGL client APIs</source>
-        <translation>EGL接口</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
-        <source>GL version</source>
-        <translation>GL版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
-        <source>GLSL version</source>
-        <translation>GLSL版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
-        <source>Unknown</source>
-        <translation>未知</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
-        <source>Uniq</source>
-        <translation>Uniq</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
-        <source>MSC</source>
-        <translation>MSC</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
-        <source>Hardware Class</source>
-        <translation>硬件類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
-        <source>CPU</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
-        <source>No CPU found</source>
-        <translation>未發現處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
-        <source>Motherboard</source>
-        <translation>主板</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
-        <source>No motherboard found</source>
-        <translation>未發現主板</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
-        <source>Memory</source>
-        <translation>內存</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
-        <source>No memory found</source>
-        <translation>未發現內存</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
-        <source>Storage</source>
-        <translation>存儲設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
-        <source>No disk found</source>
-        <translation>未發現磁盤</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
-        <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
-        <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
-        <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
-        <source>Display Adapter</source>
-        <translation>顯示適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <source>No GPU found</source>
-        <translation>未發現GPU</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
-        <source>Monitor</source>
-        <translation>顯示設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
-        <source>No monitor found</source>
-        <translation>未發現顯示設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
-        <source>Network Adapter</source>
-        <translation>網絡適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <source>No network adapter found</source>
-        <translation>未發現網絡適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>音頻適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>未發現音頻設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>藍牙</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>未發現藍牙設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>其他PCI設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>未發現其他PCI設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>未發現電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
-        <source>Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <source>No keyboard found</source>
-        <translation>未發現鍵盤</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>鼠標</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>未發現鼠標</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>打印機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>未發現打印機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>圖像設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>未發現圖像設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>光驅</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>未發現光驅</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
-        <source>Other Devices</source>
-        <translation>其他設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <source>No other devices found</source>
-        <translation>未發現其他設備</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
-        <source>Array Handle</source>
-        <translation>數組程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
-        <source>Form Factor</source>
-        <translation>尺寸型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
-        <source>Set</source>
-        <translation>設置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
-        <source>Bank Locator</source>
-        <translation>內存通道</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
-        <source>Type Detail</source>
-        <translation>類型詳情</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
-        <source>Part Number</source>
-        <translation>部件號碼</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
-        <source>Rank</source>
-        <translation>位列</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
-        <source>Memory Technology</source>
-        <translation>內存技術</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
-        <source>Memory Operating Mode Capability</source>
-        <translation>內存操作模式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
-        <source>Firmware Version</source>
-        <translation>固件版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
-        <source>Module Manufacturer ID</source>
-        <translation>組件製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
-        <source>Module Product ID</source>
-        <translation>組件產品ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
-        <source>Memory Subsystem Controller Manufacturer ID</source>
-        <translation>內存子系統控制器製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
-        <source>Memory Subsystem Controller Product ID</source>
-        <translation>內存子系統控制器產品ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
-        <source>Non-Volatile Size</source>
-        <translation>不易丢失大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
-        <source>Volatile Size</source>
-        <translation>易丢失大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
-        <source>Cache Size</source>
-        <translation>緩存大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
-        <source>Logical Size</source>
-        <translation>邏輯大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
-        <source>inch</source>
-        <translation>英吋</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
-        <source>Date</source>
-        <translation>日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
-        <source>ioport</source>
-        <translation>I/O端口</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
-        <source>network</source>
-        <translation>網絡</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
-        <source>battery</source>
-        <translation>電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
-        <source>native-path</source>
-        <translation>安裝路徑</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
-        <source>power supply</source>
-        <translation>供電</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
-        <source>updated</source>
-        <translation>更新時間</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
-        <source>has history</source>
-        <translation>歷史記錄</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
-        <source>has statistics</source>
-        <translation>用電統計</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
-        <source>rechargeable</source>
-        <translation>可再充電</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
-        <source>state</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
-        <source>warning-level</source>
-        <translation>警告等級</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
-        <source>energy</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
-        <source>energy-empty</source>
-        <translation>最低容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
-        <source>energy-full</source>
-        <translation>完全充滿容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
-        <source>energy-full-design</source>
-        <translation>設計容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
-        <source>energy-rate</source>
-        <translation>能量密度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
-        <source>voltage</source>
-        <translation>電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
-        <source>percentage</source>
-        <translation>電量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
-        <source>technology</source>
-        <translation>電池技術</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
-        <source>icon-name</source>
-        <translation>圖標</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
-        <source>online</source>
-        <translation>在線</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
-        <source>daemon-version</source>
-        <translation>Daemon版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
-        <source>on-battery</source>
-        <translation>使用電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
-        <source>lid-is-closed</source>
-        <translation>筆記本合蓋</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
-        <source>lid-is-present</source>
-        <translation>打開筆記本蓋子</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
-        <source>critical-action</source>
-        <translation>電量極低時執行</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
-        <source>copies</source>
-        <translation>複印數量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
-        <source>job-cancel-after</source>
-        <translation>此時取消打印任務</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
-        <source>job-hold-until</source>
-        <translation>保留打印任務直至</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
-        <source>job-priority</source>
-        <translation>任務優先級</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
-        <source>marker-change-time</source>
-        <translation>標記修改次數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
-        <source>number-up</source>
-        <translation>編號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
-        <source>orientation-requested</source>
-        <translation>打印方向</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
-        <source>print-color-mode</source>
-        <translation>顏色模式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
-        <source>printer-is-accepting-jobs</source>
-        <translation>當前可打印</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
-        <source>printer-is-shared</source>
-        <translation>打印機已共享</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
-        <source>printer-is-temporary</source>
-        <translation>臨時打印機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
-        <source>printer-make-and-model</source>
-        <translation>製造商和型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
-        <source>printer-state-change-time</source>
-        <translation>打印機狀態修改時間</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
-        <source>printer-state-reasons</source>
-        <translation>打印機狀態訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
-        <source>printer-type</source>
-        <translation>打印機類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
-        <source>printer-uri-supported</source>
-        <translation>支持的URI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
-        <source>sides</source>
-        <translation>打印面數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
-        <source>SSD</source>
-        <translation>固態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
-        <source>HDD</source>
-        <translation>機械</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
-        <source>bus info</source>
-        <translation>總線訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
-        <source>logicalsectorsize</source>
-        <translation>邏輯分區大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
-        <source>sectorsize</source>
-        <translation>扇區大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
-        <source>guid</source>
-        <translation>全局唯一標識符</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
-        <source>Geometry (Logical)</source>
-        <translation>幾何數據（邏輯）</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
-        <source>Device Manager</source>
-        <translation>設備管理器</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="92"/>
-        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
-        <translation>設備管理器是查看、管理硬件設備的工具軟件。</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="148"/>
-        <source>New drivers available! Install or update them now.</source>
-        <translation>您有驅動可進行安裝/更新</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="149"/>
-        <source>View</source>
-        <translation>查看</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
-        <source>Include subfolders</source>
-        <translation>包括子文件夾</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
-        <source>Search for drivers in this path</source>
-        <translation>選擇驅動所在位置</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
-        <source>%1 driver updates available</source>
-        <translation>發現%1個驅動可安裝更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
-        <source>Time checked: %1</source>
-        <translation>檢測時間: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
-        <source>Downloading drivers for %1...</source>
-        <translation>正在下載%1驅動…</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
-        <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation>下載速度：%1 已完成 %2/%3</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
-        <source>Installing drivers for %1...</source>
-        <translation>正在安裝%1驅動…</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
-        <source>%1 drivers installed, %2 drivers failed</source>
-        <translation>驅動安裝成功%1個，失敗%2個</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
-        <source>%1 drivers installed</source>
-        <translation>共成功安裝%1個驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
-        <source>Failed to install drivers</source>
-        <translation>驅動安裝失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
-        <source>Network error. Reconnecting...</source>
-        <translation>網絡異常，重試中</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
-        <source>Download speed: %1</source>
-        <translation>下載速度：%1</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
-        <source>Your drivers are up to date</source>
-        <translation>驅動已是最新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
-        <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
-        <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
-        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
-        <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
-        <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
-        <source>Backing up: %1</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
-        <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
-        <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
-        <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
-        <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
-        <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
-        <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
-        <source>Restoring: %1</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
-        <source>reboot</source>
-        <translation>重啟電腦</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
-        <source>Please %1 for the installed drivers to take effect</source>
-        <translation>驅動已安裝完成，請稍後%1生效</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
-        <source>View backup path</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
-        <source>Backup All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
-        <source>submit feedback</source>
-        <translation>反饋</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
-        <source>Please try again or %1 to us</source>
-        <translation>驅動未安裝成功，請重試或%1給我們</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
-        <source>Install All</source>
-        <translation>一鍵安裝</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
-        <source>Scan Again</source>
-        <translation>重新檢測</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
-        <source>Cancel</source>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
-        <source>Scanning hardware device drivers, please wait...</source>
-        <translation>正在進行硬件驅動掃描，請耐心等待...</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
-        <source>Scanning %1</source>
-        <translation>正在掃描%1</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
-        <source>Scan failed</source>
-        <translation>檢測失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
-        <source>Network unavailable</source>
-        <translation>無網絡</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
-        <source>Please check your network connection</source>
-        <translation>請檢查網絡連接</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <source>Please scan again or %1 to us</source>
-        <translation>請重新檢測或%1給我們</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
-        <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation>當前正在安裝驅動，退出應用後任務將會中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
-        <source>Are you sure you want to exit?</source>
-        <translation>確認是否退出應用？</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation>退 出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
-        <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
-        <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="36"/>
-        <source>Bluetooth adapter</source>
-        <translation>藍牙適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
-        <source>Imaging device</source>
-        <translation>圖像設備</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="38"/>
-        <source>Display adapter</source>
-        <translation>顯卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="40"/>
-        <source>Sound card</source>
-        <translation>聲卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="42"/>
-        <source>Network adapter</source>
-        <translation>網卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="46"/>
-        <source>Wireless network adapter</source>
-        <translation>無線網卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="66"/>
-        <source>Installation successful</source>
-        <translation>安裝成功</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="67"/>
-        <source>Installation failed</source>
-        <translation>安裝失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="68"/>
-        <source>Downloading</source>
-        <translation>下載中</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="69"/>
-        <source>Installing</source>
-        <translation>安裝中</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="70"/>
-        <source>Not installed</source>
-        <translation>驅動未安裝</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="71"/>
-        <source>Out-of-date</source>
-        <translation>驅動可更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="72"/>
-        <source>Waiting</source>
-        <translation>等待中</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="73"/>
-        <source>Not backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="74"/>
-        <source>Backing up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="75"/>
-        <source>Backup failed</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="76"/>
-        <source>Backup successful</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="77"/>
-        <source>Restoring</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
-        <source>Unknown error</source>
-        <translation>未知錯誤</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
-        <source>Network error</source>
-        <translation>網絡異常</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
-        <source>Canceled</source>
-        <translation>已取消</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
-        <source>Failed to get driver files</source>
-        <translation>驅動文件獲取異常</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
-        <source>Update</source>
-        <translation>更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
-        <source>Backup</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
-        <source>Install</source>
-        <translation>安装</translation>
-    </message>
-    <message>
-        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-</context>
-<context>
-    <name>TableWidget</name>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
-        <source>Refresh</source>
-        <translation>刷新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
-        <source>Export</source>
-        <translation>導出</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
-        <source>Update drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
-        <source>Uninstall drivers</source>
-        <translation>卸載驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
-        <source>Allow it to wake the computer</source>
-        <translation>允許喚起電腦</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
-        <source>Enable</source>
-        <translation>啟用</translation>
-    </message>
-</context>
-<context>
-    <name>TextBrowser</name>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
-        <source>Refresh</source>
-        <translation>刷新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
-        <source>Export</source>
-        <translation>導出</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>UrlChooserEdit</name>
-    <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
-        <source>Select a local folder please</source>
-        <translation>請選擇本地文件夾</translation>
-    </message>
-</context>
-<context>
-    <name>WaitingWidget</name>
-    <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
-        <source>Loading...</source>
-        <translation>正在載入...</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="zh_HK" version="2.1">
+    <context>
+        <name>BtnLabel</name>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+            <source>Feedback</source>
+            <translation>反饋</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+            <comment>button</comment>
+        </message>
+    </context>
+    <context>
+        <name>BtnWidget</name>
+        <message>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+            <source>More</source>
+            <translation type="unfinished">更多</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+            <source>Collapse</source>
+            <translation type="unfinished">收起</translation>
+        </message>
+    </context>
+    <context>
+        <name>CmdButtonWidget</name>
+        <message>
+            <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommonTools</name>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="85"/>
+            <source>EC_NOTIFY_NETWORK</source>
+            <translation>EC_NOTIFY_NETWORK</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="86"/>
+            <source>EC_REINSTALL</source>
+            <translation>EC_REINSTALL</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="87"/>
+            <source>EC_6</source>
+            <translation>EC_6</translation>
+        </message>
+    </context>
+    <context>
+        <name>DetailButton</name>
+        <message>
+            <location filename="../src/Page/PageDetail.cpp" line="47"/>
+            <location filename="../src/Page/PageDetail.cpp" line="50"/>
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDetail.cpp" line="48"/>
+            <source>Collapse</source>
+            <translation>收起</translation>
+        </message>
+    </context>
+    <context>
+        <name>DetailViewDelegate</name>
+        <message>
+            <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+            <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceAudio</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+            <source>Device Name</source>
+            <translation>設備名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+            <source>Chip</source>
+            <translation>晶片</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+            <source>SysFS_Path</source>
+            <translation>SysFS_Path</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+            <source>Description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+            <source>Revision</source>
+            <translation>修訂版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+            <source>KernelModeDriver</source>
+            <translation>KernelModeDriver</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+            <source>Memory Address</source>
+            <translation>內存地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceBaseInfo</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceBios</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+            <source>Chipset</source>
+            <translation>晶片組</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceBluetooth</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+            <source>Alias</source>
+            <translation>別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+            <source>Driver Version</source>
+            <translation>驅動版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+            <source>Logical Name</source>
+            <translation>邏輯名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+            <source>MAC Address</source>
+            <translation>物理地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceCdrom</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceComputer</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceCpu</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+            <source>CPU ID</source>
+            <translation>處理器ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+            <source>Core ID</source>
+            <translation>核心ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+            <source>Threads</source>
+            <translation>線程數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+            <source>BogoMIPS</source>
+            <translation>BogoMIPS</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
+            <source>Architecture</source>
+            <translation>架構</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+            <source>CPU Family</source>
+            <translation>家族</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
+            <source>Processor</source>
+            <translation>邏輯處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+            <source>Core(s)</source>
+            <translation>核</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+            <source>Virtualization</source>
+            <translation>虛擬化</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+            <source>Flags</source>
+            <translation>特性</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+            <source>Extensions</source>
+            <translation>擴展指令集</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+            <source>L4 Cache</source>
+            <translation>L4 緩存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+            <source>L3 Cache</source>
+            <translation>L3緩存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+            <source>L2 Cache</source>
+            <translation>L2緩存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+            <source>L1i Cache</source>
+            <translation>L1緩存（指令）</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+            <source>L1d Cache</source>
+            <translation>L1緩存（數據）</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+            <source>Stepping</source>
+            <translation>步進</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+            <source>Speed</source>
+            <translation>頻率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+            <source>Max Speed</source>
+            <translation>最大頻率</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceGpu</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+            <source>Graphics Memory</source>
+            <translation>顯存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+            <source>Memory Address</source>
+            <translation>內存地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+            <source>IO Port</source>
+            <translation>I/O端口</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+            <source>Maximum Resolution</source>
+            <translation>最大解像度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+            <source>Minimum Resolution</source>
+            <translation>最小解像度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+            <source>Current Resolution</source>
+            <translation>當前解像度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+            <source>Description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+            <source>DP</source>
+            <translation>DP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+            <source>eDP</source>
+            <translation>eDP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+            <source>HDMI</source>
+            <translation>HDMI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+            <source>VGA</source>
+            <translation>VGA</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+            <source>DVI</source>
+            <translation>DVI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+            <source>DigitalOutput</source>
+            <translation>DigitalOutput</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+            <source>Display Output</source>
+            <translation>顯示輸出</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceImage</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceInput</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+            <source>Interface</source>
+            <translation>接口</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+            <source>Speed</source>
+            <translation>頻率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+            <source>Maximum Current</source>
+            <translation>最大電流</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceManager</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
+            <source>CPU</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
+            <source>CPU quantity</source>
+            <translation>CPU數量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+            <source>Motherboard</source>
+            <translation>主板</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+            <source>Memory</source>
+            <translation>內存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+            <source>Display Adapter</source>
+            <translation>顯示適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+            <source>Sound Adapter</source>
+            <translation>音頻適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+            <source>Storage</source>
+            <translation>存儲設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+            <source>Other PCI Devices</source>
+            <translation>其他PCI設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+            <source>Battery</source>
+            <translation>電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+            <source>Bluetooth</source>
+            <translation>藍牙</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+            <source>Network Adapter</source>
+            <translation>網絡適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+            <source>Mouse</source>
+            <translation>鼠標</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+            <source>Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+            <source>Monitor</source>
+            <translation>顯示設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
+            <source>CD-ROM</source>
+            <translation>光驅</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
+            <source>Printer</source>
+            <translation>打印機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
+            <source>Camera</source>
+            <translation>圖像設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
+            <source>Other Devices</source>
+            <translation>其他設備</translation>
+            <comment>Other Input Devices</comment>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+            <source>Device</source>
+            <translation>設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
+            <source>OS</source>
+            <translation>操作系統</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceMemory</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
+            <source>Size</source>
+            <translation>大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+            <source>Total Width</source>
+            <translation>總位寬</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+            <source>Locator</source>
+            <translation>插槽</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+            <source>Configured Voltage</source>
+            <translation>配置電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+            <source>Maximum Voltage</source>
+            <translation>最高電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+            <source>Minimum Voltage</source>
+            <translation>最低電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+            <source>Configured Speed</source>
+            <translation>配置頻率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+            <source>Data Width</source>
+            <translation>數據位寬</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceMonitor</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+            <source>Display Input</source>
+            <translation>顯示輸入</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+            <source>Interface Type</source>
+            <translation>接口類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+            <source>Support Resolution</source>
+            <translation>支持解像度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+            <source>Current Resolution</source>
+            <translation>當前解像度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+            <source>Display Ratio</source>
+            <translation>顯示比例</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+            <source>Primary Monitor</source>
+            <translation>主顯示器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+            <source>Size</source>
+            <translation>大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceNetwork</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+            <source>Driver Version</source>
+            <translation>驅動版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+            <source>Maximum Rate</source>
+            <translation>最大速率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+            <source>Negotiation Rate</source>
+            <translation>協商速率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+            <source>Port</source>
+            <translation>端口</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+            <source>Multicast</source>
+            <translation>組播</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+            <source>Link</source>
+            <translation>連接</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+            <source>Latency</source>
+            <translation>延遲</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+            <source>IP</source>
+            <translation>IP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+            <source>Firmware</source>
+            <translation>固件</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+            <source>Duplex</source>
+            <translation>雙工</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+            <source>Broadcast</source>
+            <translation>廣播</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+            <source>Auto Negotiation</source>
+            <translation>自動協商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+            <source>Memory Address</source>
+            <translation>內存地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+            <source>MAC Address</source>
+            <translation>物理地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+            <source>Logical Name</source>
+            <translation>邏輯名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceOtherPCI</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+            <source>Input/Output</source>
+            <translation>輸入/輸出</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+            <source>Memory</source>
+            <translation>內存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+            <source>Latency</source>
+            <translation>延遲</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceOthers</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+            <source>Bus Info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DevicePower</name>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+            <source>Capacity</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+            <source>Voltage</source>
+            <translation>電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+            <source>Slot</source>
+            <translation>插槽</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+            <source>Design Capacity</source>
+            <translation>設計容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+            <source>Design Voltage</source>
+            <translation>設計電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+            <source>SBDS Version</source>
+            <translation>SBDS版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+            <source>SBDS Serial Number</source>
+            <translation>SBDS序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+            <source>SBDS Manufacture Date</source>
+            <translation>SBDS製造日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+            <source>SBDS Chemistry</source>
+            <translation>SBDS材料</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+            <source>Temperature</source>
+            <translation>溫度</translation>
+        </message>
+    </context>
+    <context>
+        <name>DevicePrint</name>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+            <source>Shared</source>
+            <translation>已共享</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+            <source>URI</source>
+            <translation>URI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+            <source>Interface Type</source>
+            <translation>接口類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceStorage</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
+            <source>Media Type</source>
+            <translation>介質類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
+            <source>Size</source>
+            <translation>大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+            <source>Module Alias</source>
+            <translation>模塊別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+            <source>Firmware Version</source>
+            <translation>固件版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+            <source>Description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+            <source>Interface</source>
+            <translation>接口</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+            <source>Rotation Rate</source>
+            <translation>轉速</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>GetDriverNameWidget</name>
+        <message>
+            <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+            <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
+            <source>Select a driver for update</source>
+            <translation>選擇需要更新的驅動程序</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+            <source>No drivers found in this folder</source>
+            <translation>所選文件夾未檢測到驅動文件</translation>
+        </message>
+    </context>
+    <context>
+        <name>GetInfoPool</name>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+            <source>Loading Audio Device Info...</source>
+            <translation>獲取音頻設備訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+            <source>Loading BIOS Info...</source>
+            <translation>獲取BIOS訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+            <source>Loading CD-ROM Info...</source>
+            <translation>獲取光驅訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+            <source>Loading Operating System Info...</source>
+            <translation>獲取操作系統訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+            <source>Loading CPU Info...</source>
+            <translation>獲取處理器訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+            <source>Loading Other Devices Info...</source>
+            <translation>獲取其他設備訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+            <source>Loading Power Info...</source>
+            <translation>獲取電池訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+            <source>Loading Printer Info...</source>
+            <translation>獲取打印機訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+            <source>Loading Mouse Info...</source>
+            <translation>獲取鼠標訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+            <source>Loading Network Adapter Info...</source>
+            <translation>獲取網絡適配器訊息...</translation>
+        </message>
+    </context>
+    <context>
+        <name>LogTreeView</name>
+        <message>
+            <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+            <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+            <location filename="../src/Widget/logtreeview.cpp" line="125"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>LogViewItemDelegate</name>
+        <message>
+            <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>MainWindow</name>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="250"/>
+            <source>Device Info</source>
+            <translation>設備訊息</translation>
+            <comment>export file's name</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="321"/>
+            <source>Display shortcuts</source>
+            <translation>顯示快捷鍵</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="322"/>
+            <source>Close</source>
+            <translation>關閉</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="323"/>
+            <source>Help</source>
+            <translation>幫助</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="324"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="328"/>
+            <source>System</source>
+            <translation>系統</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="335"/>
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="336"/>
+            <source>Refresh</source>
+            <translation>刷新</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="340"/>
+            <source>Device Manager</source>
+            <translation>設備管理器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="409"/>
+            <source>Hardware</source>
+            <translation>硬件訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="409"/>
+            <source>Drivers</source>
+            <translation>驅動管理</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="561"/>
+            <source>Monitor</source>
+            <translation>顯示設備</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="561"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="565"/>
+            <source>Display Adapter</source>
+            <translation>顯示適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="569"/>
+            <source>CPU</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="573"/>
+            <source>Network Adapter</source>
+            <translation>網絡適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="579"/>
+            <source>Battery</source>
+            <translation>電池</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDetail</name>
+        <message>
+            <location filename="../src/Page/PageDetail.cpp" line="319"/>
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverBackupInfo</name>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+            <source>Current Version</source>
+            <translation>當前版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+            <source>Driver Platform Version</source>
+            <translation>驅動平台版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+            <source>Action</source>
+            <translation>操作</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+            <source>Backupable Drivers</source>
+            <translation>可備份驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+            <source>Backed up Drivers</source>
+            <translation>已備份驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverControl</name>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
+            <source>Updating</source>
+            <translation>正在更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+            <source>Next</source>
+            <translation>下一步</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+            <source>Warning</source>
+            <translation>注意</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+            <source>The device will be unavailable after the driver uninstallation</source>
+            <translation>將從系統中卸載此驅動程序，卸載後該設備不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+            <source>Uninstall</source>
+            <translation>卸 載</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+            <source>Uninstalling</source>
+            <translation>正在卸載</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+            <source>Update successful</source>
+            <translation>驅動更新成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+            <source>Uninstallation successful</source>
+            <translation>驅動卸載成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+            <source>Update failed</source>
+            <translation>驅動更新失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+            <source>Uninstallation failed</source>
+            <translation>驅動卸載失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+            <source>Next</source>
+            <translation>下一步</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+            <source>The selected folder does not exist, please select again</source>
+            <translation>所選文件夾不存在，請重新選擇</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+            <source>Update</source>
+            <translation>更 新</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+            <source>Previous</source>
+            <translation>上一步</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+            <source>Broken package</source>
+            <translation>包文件損壞</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+            <source>Unmatched package architecture</source>
+            <translation>包文件與系統架構不匹配</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
+            <source>The selected file does not exist, please select again</source>
+            <translation>所選文件不存在，請重新選擇</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+            <source>It is not a driver</source>
+            <translation>該文件不是驅動文件</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+            <source>Unable to install - no digital signature</source>
+            <translation>無法安裝，安裝包無數字簽名</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+            <source>Unknown error</source>
+            <translation>未知錯誤</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+            <source>The driver module was not found</source>
+            <translation>未發現該驅動模塊</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+            <source>Invalid module format</source>
+            <translation>模塊格式無效</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+            <source>The driver module has dependencies</source>
+            <translation>驅動模塊被依賴</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverInstallInfo</name>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+            <source>Device Name</source>
+            <translation>設備名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+            <source>Version Available</source>
+            <translation>可安裝版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
+            <source>Size</source>
+            <translation>大小</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
+            <source>Action</source>
+            <translation>操作</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+            <source>New Version</source>
+            <translation>可更新版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+            <source>Current Version</source>
+            <translation>當前版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+            <source>Missing drivers (%1)</source>
+            <translation>可安裝驅動 (%1)</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+            <source>Outdated drivers (%1)</source>
+            <translation>可更新驅動 (%1)</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+            <source>Up-to-date drivers (%1)</source>
+            <translation>無需更新驅動 (%1)</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverManager</name>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
+            <source>Driver Install</source>
+            <translation>驅動安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
+            <source>Driver Backup</source>
+            <translation>驅動備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
+            <source>Driver Restore</source>
+            <translation>驅動還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+            <source>Feedback</source>
+            <translation>反饋</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverRestoreInfo</name>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+            <source>You do not have any drivers to restore, please backup first</source>
+            <translation>您沒有驅動可以還原，請先備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+            <source>Go to Backup Driver</source>
+            <translation>前往備份驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+            <source>Current Version</source>
+            <translation>當前版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+            <source>Backup Version</source>
+            <translation>備份版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+            <source>Action</source>
+            <translation>操作</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+            <source>Restorable Drivers</source>
+            <translation>可還原驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageListView</name>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="24"/>
+            <source>Refresh</source>
+            <translation>刷新</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="25"/>
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="27"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="123"/>
+            <source>Driver Install</source>
+            <translation>驅動安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="123"/>
+            <source>Driver Backup</source>
+            <translation>驅動備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="123"/>
+            <source>Driver Restore</source>
+            <translation>驅動還原</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageMultiInfo</name>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+            <source>Failed to enable the device</source>
+            <translation>啟用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+            <source>Failed to disable the device</source>
+            <translation>禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+            <source>Failed to disable it: unable to get the device SN</source>
+            <translation>無法獲取設備序列號，禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+            <source>Update Drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+            <source>Uninstall Drivers</source>
+            <translation>卸載驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageOverview</name>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="42"/>
+            <source>Refresh</source>
+            <translation>刷新</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="43"/>
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="44"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="89"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageSingleInfo</name>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+            <source>Refresh</source>
+            <translation>刷新</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
+            <source>Enable</source>
+            <translation>啟用</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+            <source>Update drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+            <source>Uninstall drivers</source>
+            <translation>卸載驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+            <source>Allow it to wake the computer</source>
+            <translation>允許喚起電腦</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
+            <source>Failed to disable it: unable to get the device SN</source>
+            <translation>無法獲取設備序列號，禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+            <source>Failed to disable the device</source>
+            <translation>禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+            <source>Failed to enable the device</source>
+            <translation>啟用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+            <source>Update Drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+            <source>Uninstall Drivers</source>
+            <translation>卸載驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+            <source>SubVendor</source>
+            <translation>子製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
+            <source>SubDevice</source>
+            <translation>子設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+            <source>Driver Status</source>
+            <translation>驅動狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+            <source>Driver Activation Cmd</source>
+            <translation>驅動啟動命令</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
+            <source>Config Status</source>
+            <translation>配置狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+            <source>latency</source>
+            <translation>延遲</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+            <source>Phys</source>
+            <translation>Phys</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+            <source>Sysfs</source>
+            <translation>Sysfs</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+            <source>Handlers</source>
+            <translation>進程</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
+            <source>PROP</source>
+            <translation>PROP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
+            <source>EV</source>
+            <translation>EV</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+            <source>KEY</source>
+            <translation>KEY</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+            <source>Bus</source>
+            <translation>總線</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+            <source>BIOS Information</source>
+            <translation>BIOS訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
+            <source>Base Board Information</source>
+            <translation>主板訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
+            <source>System Information</source>
+            <translation>系統訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
+            <source>Chassis Information</source>
+            <translation>機箱訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
+            <source>Physical Memory Array</source>
+            <translation>物理內存數組</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+            <source>Release Date</source>
+            <translation>發佈日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+            <source>Address</source>
+            <translation>地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+            <source>Runtime Size</source>
+            <translation>運行內存大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+            <source>ROM Size</source>
+            <translation>ROM大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+            <source>Characteristics</source>
+            <translation>特性</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+            <source>BIOS Revision</source>
+            <translation>BIOS修訂版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+            <source>Firmware Revision</source>
+            <translation>固件修訂版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+            <source>Product Name</source>
+            <translation>產品名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+            <source>Serial Number</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+            <source>Asset Tag</source>
+            <translation>資產編號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
+            <source>Features</source>
+            <translation>特徵</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+            <source>Location In Chassis</source>
+            <translation>機箱內位置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+            <source>Chassis Handle</source>
+            <translation>機箱程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+            <source>Contained Object Handles</source>
+            <translation>包含對象程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+            <source>UUID</source>
+            <translation>UUID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+            <source>Wake-up Type</source>
+            <translation>喚醒類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+            <source>SKU Number</source>
+            <translation>SKU號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+            <source>Family</source>
+            <translation>家族</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+            <source>Lock</source>
+            <translation>鎖</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+            <source>Boot-up State</source>
+            <translation>開機狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+            <source>Power Supply State</source>
+            <translation>供電狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+            <source>Thermal State</source>
+            <translation>散熱狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+            <source>Security Status</source>
+            <translation>安全狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+            <source>OEM Information</source>
+            <translation>OEM訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+            <source>Height</source>
+            <translation>高度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+            <source>Number Of Power Cords</source>
+            <translation>電源線數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+            <source>Contained Elements</source>
+            <translation>包含組件數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+            <source>Location</source>
+            <translation>位置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+            <source>Error Correction Type</source>
+            <translation>糾錯類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+            <source>Maximum Capacity</source>
+            <translation>最大容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+            <source>Error Information Handle</source>
+            <translation>錯誤訊息程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+            <source>Number Of Devices</source>
+            <translation>卡槽數量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+            <source>BIOS ROMSIZE</source>
+            <translation>BIOS ROM大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+            <source>Release date</source>
+            <translation>發佈日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+            <source>Board name</source>
+            <translation>主板名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+            <source>SMBIOS Version</source>
+            <translation>SMBIOS版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+            <source>Language Description Format</source>
+            <translation>語言描述格式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+            <source>Installable Languages</source>
+            <translation>可安裝語言數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+            <source>Currently Installed Language</source>
+            <translation>當前安裝語言</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+            <source>BD Address</source>
+            <translation>藍牙設備地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+            <source>ACL MTU</source>
+            <translation>ACL MTU</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+            <source>SCO MTU</source>
+            <translation>SCO MTU</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+            <source>Packet type</source>
+            <translation>數據包類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+            <source>Link policy</source>
+            <translation>連接策略</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+            <source>Link mode</source>
+            <translation>連接模式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
+            <source>Class</source>
+            <translation>類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+            <source>Service Classes</source>
+            <translation>服務類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+            <source>Device Class</source>
+            <translation>設備類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+            <source>HCI Version</source>
+            <translation>HCI版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+            <source>LMP Version</source>
+            <translation>LMP版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+            <source>Subversion</source>
+            <translation>子版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
+            <source>Device</source>
+            <translation>設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
+            <source>Serial ID</source>
+            <translation>序列號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+            <source>product</source>
+            <translation>產品</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+            <source>description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+            <source>Powered</source>
+            <translation>供電</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+            <source>Discoverable</source>
+            <translation>可發現</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+            <source>Pairable</source>
+            <translation>可配對</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+            <source>Modalias</source>
+            <translation>設置命令別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+            <source>Discovering</source>
+            <translation>搜索中</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
+            <source>Driver Modules</source>
+            <translation>驅動模塊</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
+            <source>Device File</source>
+            <translation>設備文件</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+            <source>Device Files</source>
+            <translation>設備文件</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+            <source>Device Number</source>
+            <translation>設備編號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+            <source>Application</source>
+            <translation>應用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+            <source>status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
+            <source>logical name</source>
+            <translation>邏輯地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
+            <source>ansiversion</source>
+            <translation>ANSI版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+            <source>CPU implementer</source>
+            <translation>CPU程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+            <source>CPU architecture</source>
+            <translation>CPU架構</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+            <source>CPU variant</source>
+            <translation>CPU變量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+            <source>CPU part</source>
+            <translation>CPU部件</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+            <source>CPU revision</source>
+            <translation>CPU版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+            <source>One</source>
+            <translation>單</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+            <source>Two</source>
+            <translation>雙</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+            <source>Four</source>
+            <translation>四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+            <source>Six</source>
+            <translation>六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+            <source>Eight</source>
+            <translation>八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+            <source>Nine</source>
+            <translation>九</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+            <source>Ten</source>
+            <translation>十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+            <source>Twelve</source>
+            <translation>十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+            <source>Fourteen</source>
+            <translation>十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+            <source>Sixteen</source>
+            <translation>十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+            <source>Eighteen</source>
+            <translation>十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+            <source>Twenty</source>
+            <translation>二十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+            <source>Twenty-two</source>
+            <translation>二十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+            <source>Twenty-four</source>
+            <translation>二十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+            <source>Twenty-six</source>
+            <translation>二十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+            <source>Twenty-eight</source>
+            <translation>二十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+            <source>Thirty</source>
+            <translation>三十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+            <source>Thirty-two</source>
+            <translation>三十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+            <source>Thirty-four</source>
+            <translation>三十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+            <source>Thirty-six</source>
+            <translation>三十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+            <source>Thirty-eight</source>
+            <translation>三十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+            <source>Forty</source>
+            <translation>四十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+            <source>Forty-two</source>
+            <translation>四十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+            <source>Forty-four</source>
+            <translation>四十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+            <source>Forty-six</source>
+            <translation>四十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+            <source>Forty-eight</source>
+            <translation>四十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+            <source>Fifty</source>
+            <translation>五十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+            <source>Fifty-two</source>
+            <translation>五十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+            <source>Fifty-four</source>
+            <translation>五十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+            <source>Fifty-six</source>
+            <translation>五十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+            <source>Fifty-eight</source>
+            <translation>五十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+            <source>Sixty</source>
+            <translation>六十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+            <source>Sixty-two</source>
+            <translation>六十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+            <source>Sixty-four</source>
+            <translation>六十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+            <source>Sixty-six</source>
+            <translation>六十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+            <source>Sixty-eight</source>
+            <translation>六十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+            <source>Seventy</source>
+            <translation>七十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+            <source>Seventy-two</source>
+            <translation>七十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+            <source>Seventy-four</source>
+            <translation>七十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+            <source>Seventy-six</source>
+            <translation>七十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+            <source>Seventy-eight</source>
+            <translation>七十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+            <source>Eighty</source>
+            <translation>八十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+            <source>Eighty-two</source>
+            <translation>八十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+            <source>Eighty-four</source>
+            <translation>八十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+            <source>Eighty-six</source>
+            <translation>八十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+            <source>Eighty-eight</source>
+            <translation>八十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+            <source>Ninety</source>
+            <translation>九十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+            <source>Ninety-two</source>
+            <translation>九十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+            <source>Ninety-four</source>
+            <translation>九十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+            <source>Ninety-six</source>
+            <translation>九十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+            <source>Ninety-eight</source>
+            <translation>九十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+            <source>One hundred</source>
+            <translation>100</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+            <source>One hundred and Two</source>
+            <translation>102</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+            <source>One hundred and four</source>
+            <translation>104</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+            <source>One hundred and Six</source>
+            <translation>106</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+            <source>One hundred and Eight</source>
+            <translation>108</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+            <source>One hundred and Ten</source>
+            <translation>110</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+            <source>One hundred and Twelve</source>
+            <translation>112</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+            <source>One hundred and Fourteen</source>
+            <translation>114</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+            <source>One hundred and Sixteen</source>
+            <translation>116</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+            <source>One hundred and Eighteen</source>
+            <translation>118</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+            <source>One hundred and Twenty</source>
+            <translation>120</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+            <source>One hundred and Twenty-two</source>
+            <translation>122</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+            <source>One hundred and Twenty-four</source>
+            <translation>124</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+            <source>One hundred and Twenty-six</source>
+            <translation>126</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+            <source>One hundred and Twenty-eight</source>
+            <translation>128</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+            <source>One hundred and Ninety-two</source>
+            <translation>一百九十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+            <source>Two hundred and fifty-six</source>
+            <translation>256</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+            <source>GDDR capacity</source>
+            <translation>GDDR容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+            <source>GPU vendor</source>
+            <translation>GPU供應商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+            <source>GPU type</source>
+            <translation>GPU類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+            <source>EGL version</source>
+            <translation>EGL版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+            <source>EGL client APIs</source>
+            <translation>EGL接口</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+            <source>GL version</source>
+            <translation>GL版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+            <source>GLSL version</source>
+            <translation>GLSL版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
+            <source>Unknown</source>
+            <translation>未知</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+            <source>Uniq</source>
+            <translation>Uniq</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+            <source>MSC</source>
+            <translation>MSC</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
+            <source>Hardware Class</source>
+            <translation>硬件類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+            <source>CPU</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+            <source>No CPU found</source>
+            <translation>未發現處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+            <source>Motherboard</source>
+            <translation>主板</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+            <source>No motherboard found</source>
+            <translation>未發現主板</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+            <source>Memory</source>
+            <translation>內存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+            <source>No memory found</source>
+            <translation>未發現內存</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+            <source>Storage</source>
+            <translation>存儲設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+            <source>No disk found</source>
+            <translation>未發現磁盤</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+            <source>Driver restore failed!</source>
+            <translation>驅動還原失敗！</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+            <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
+            <source>Please try again or give us feedback</source>
+            <translation>請重試，或反饋給我們</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+            <source>Driver backup failed!</source>
+            <translation>驅動備份失敗！</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+            <source>Display Adapter</source>
+            <translation>顯示適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+            <source>No GPU found</source>
+            <translation>未發現GPU</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+            <source>Monitor</source>
+            <translation>顯示設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+            <source>No monitor found</source>
+            <translation>未發現顯示設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
+            <source>Network Adapter</source>
+            <translation>網絡適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+            <source>No network adapter found</source>
+            <translation>未發現網絡適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+            <source>Sound Adapter</source>
+            <translation>音頻適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+            <source>No audio device found</source>
+            <translation>未發現音頻設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+            <source>Bluetooth</source>
+            <translation>藍牙</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+            <source>No Bluetooth device found</source>
+            <translation>未發現藍牙設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+            <source>Other PCI Devices</source>
+            <translation>其他PCI設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+            <source>No other PCI devices found</source>
+            <translation>未發現其他PCI設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+            <source>Power</source>
+            <translation>電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+            <source>No battery found</source>
+            <translation>未發現電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+            <location filename="../src/Tool/commontools.cpp" line="39"/>
+            <source>Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+            <source>No keyboard found</source>
+            <translation>未發現鍵盤</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+            <location filename="../src/Tool/commontools.cpp" line="41"/>
+            <source>Mouse</source>
+            <translation>鼠標</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+            <source>No mouse found</source>
+            <translation>未發現鼠標</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+            <location filename="../src/Tool/commontools.cpp" line="43"/>
+            <source>Printer</source>
+            <translation>打印機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+            <source>No printer found</source>
+            <translation>未發現打印機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+            <source>Camera</source>
+            <translation>圖像設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+            <source>No camera found</source>
+            <translation>未發現圖像設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+            <source>CD-ROM</source>
+            <translation>光驅</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+            <source>No CD-ROM found</source>
+            <translation>未發現光驅</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
+            <location filename="../src/Tool/commontools.cpp" line="45"/>
+            <location filename="../src/Tool/commontools.cpp" line="47"/>
+            <source>Other Devices</source>
+            <translation>其他設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
+            <source>No other devices found</source>
+            <translation>未發現其他設備</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+            <source>Array Handle</source>
+            <translation>數組程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+            <source>Form Factor</source>
+            <translation>尺寸型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+            <source>Set</source>
+            <translation>設置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+            <source>Bank Locator</source>
+            <translation>內存通道</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+            <source>Type Detail</source>
+            <translation>類型詳情</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+            <source>Part Number</source>
+            <translation>部件號碼</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+            <source>Rank</source>
+            <translation>位列</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+            <source>Memory Technology</source>
+            <translation>內存技術</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+            <source>Memory Operating Mode Capability</source>
+            <translation>內存操作模式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+            <source>Firmware Version</source>
+            <translation>固件版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+            <source>Module Manufacturer ID</source>
+            <translation>組件製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+            <source>Module Product ID</source>
+            <translation>組件產品ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+            <source>Memory Subsystem Controller Manufacturer ID</source>
+            <translation>內存子系統控制器製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+            <source>Memory Subsystem Controller Product ID</source>
+            <translation>內存子系統控制器產品ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+            <source>Non-Volatile Size</source>
+            <translation>不易丢失大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+            <source>Volatile Size</source>
+            <translation>易丢失大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+            <source>Cache Size</source>
+            <translation>緩存大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+            <source>Logical Size</source>
+            <translation>邏輯大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+            <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
+            <source>inch</source>
+            <translation>英吋</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+            <source>Date</source>
+            <translation>日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+            <source>ioport</source>
+            <translation>I/O端口</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+            <source>network</source>
+            <translation>網絡</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+            <source>battery</source>
+            <translation>電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+            <source>native-path</source>
+            <translation>安裝路徑</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+            <source>power supply</source>
+            <translation>供電</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+            <source>updated</source>
+            <translation>更新時間</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+            <source>has history</source>
+            <translation>歷史記錄</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+            <source>has statistics</source>
+            <translation>用電統計</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+            <source>rechargeable</source>
+            <translation>可再充電</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+            <source>state</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+            <source>warning-level</source>
+            <translation>警告等級</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+            <source>energy</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+            <source>energy-empty</source>
+            <translation>最低容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+            <source>energy-full</source>
+            <translation>完全充滿容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+            <source>energy-full-design</source>
+            <translation>設計容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+            <source>energy-rate</source>
+            <translation>能量密度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+            <source>voltage</source>
+            <translation>電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+            <source>percentage</source>
+            <translation>電量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+            <source>technology</source>
+            <translation>電池技術</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+            <source>icon-name</source>
+            <translation>圖標</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+            <source>online</source>
+            <translation>在線</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+            <source>daemon-version</source>
+            <translation>Daemon版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+            <source>on-battery</source>
+            <translation>使用電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+            <source>lid-is-closed</source>
+            <translation>筆記本合蓋</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+            <source>lid-is-present</source>
+            <translation>打開筆記本蓋子</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+            <source>critical-action</source>
+            <translation>電量極低時執行</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+            <source>copies</source>
+            <translation>複印數量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+            <source>job-cancel-after</source>
+            <translation>此時取消打印任務</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+            <source>job-hold-until</source>
+            <translation>保留打印任務直至</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+            <source>job-priority</source>
+            <translation>任務優先級</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+            <source>marker-change-time</source>
+            <translation>標記修改次數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+            <source>number-up</source>
+            <translation>編號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+            <source>orientation-requested</source>
+            <translation>打印方向</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+            <source>print-color-mode</source>
+            <translation>顏色模式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+            <source>printer-is-accepting-jobs</source>
+            <translation>當前可打印</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+            <source>printer-is-shared</source>
+            <translation>打印機已共享</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+            <source>printer-is-temporary</source>
+            <translation>臨時打印機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+            <source>printer-make-and-model</source>
+            <translation>製造商和型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+            <source>printer-state-change-time</source>
+            <translation>打印機狀態修改時間</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+            <source>printer-state-reasons</source>
+            <translation>打印機狀態訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+            <source>printer-type</source>
+            <translation>打印機類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+            <source>printer-uri-supported</source>
+            <translation>支持的URI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+            <source>sides</source>
+            <translation>打印面數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
+            <source>SSD</source>
+            <translation>固態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
+            <source>HDD</source>
+            <translation>機械</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
+            <source>bus info</source>
+            <translation>總線訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+            <source>logicalsectorsize</source>
+            <translation>邏輯分區大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+            <source>sectorsize</source>
+            <translation>扇區大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+            <source>guid</source>
+            <translation>全局唯一標識符</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+            <source>Geometry (Logical)</source>
+            <translation>幾何數據（邏輯）</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="93"/>
+            <location filename="../src/main.cpp" line="95"/>
+            <source>Device Manager</source>
+            <translation>設備管理器</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="96"/>
+            <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+            <translation>設備管理器是查看、管理硬件設備的工具軟件。</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="162"/>
+            <source>New drivers available! Install or update them now.</source>
+            <translation>您有驅動可進行安裝/更新</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="163"/>
+            <source>View</source>
+            <translation>查看</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+            <source>Include subfolders</source>
+            <translation>包括子文件夾</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+            <source>Search for drivers in this path</source>
+            <translation>選擇驅動所在位置</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+            <source>%1 driver updates available</source>
+            <translation>發現%1個驅動可安裝更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
+            <source>Time checked: %1</source>
+            <translation>檢測時間: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+            <source>Downloading drivers for %1...</source>
+            <translation>正在下載%1驅動…</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+            <source>Download speed: %1 Downloaded %2/%3</source>
+            <translation>下載速度：%1 已完成 %2/%3</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+            <source>Installing drivers for %1...</source>
+            <translation>正在安裝%1驅動…</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+            <source>%1 drivers installed, %2 drivers failed</source>
+            <translation>驅動安裝成功%1個，失敗%2個</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+            <source>%1 drivers installed</source>
+            <translation>共成功安裝%1個驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+            <source>Failed to install drivers</source>
+            <translation>驅動安裝失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+            <source>Network error. Reconnecting...</source>
+            <translation>網絡異常，重試中</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+            <source>Download speed: %1</source>
+            <translation>下載速度：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+            <source>Your drivers are up to date</source>
+            <translation>驅動已是最新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+            <source>All drivers have been backed up</source>
+            <translation>驅動已全部備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
+            <source>A total of %1 drivers, of which %2 have been backed up</source>
+            <translation>總計%1個驅動，其中%2個已備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+            <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+            <translation>您有%1個驅動可以備份，建議立即備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+            <source>You have %1 drivers that can be backed up</source>
+            <translation>您有%1個驅動可以備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+            <source>Backing up the %1 driver, a total of %2 drivers</source>
+            <translation>正在備份第%1個驅動，共%2個</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+            <source>Backing up: %1</source>
+            <translation>正在備份：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+            <source>%1 drivers backed up, %2 drivers failed</source>
+            <translation>驅動備份成功%1個，失敗%2個</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+            <source>Failed to backup drivers</source>
+            <translation>備份失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+            <source>%1 drivers backed up</source>
+            <translation>%1個驅動已備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+            <source>You have %1 drivers that can be restored</source>
+            <translation>您有%1個驅動可以還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+            <source>Please select a driver to restore</source>
+            <translation>請選擇驅動還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+            <source>Driver is restoring...</source>
+            <translation>驅動還原中…</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+            <source>Restoring: %1</source>
+            <translation>正在還原：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+            <source>reboot</source>
+            <translation>重啟電腦</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+            <source>Please %1 for the installed drivers to take effect</source>
+            <translation>驅動已安裝完成，請稍後%1生效</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+            <source>View backup path</source>
+            <translation>查看備份路徑</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+            <source>Backup All</source>
+            <translation>一鍵備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
+            <source>submit feedback</source>
+            <translation>反饋</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+            <source>Please try again or %1 to us</source>
+            <translation>驅動未安裝成功，請重試或%1給我們</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+            <source>Install All</source>
+            <translation>一鍵安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
+            <source>Scan Again</source>
+            <translation>重新檢測</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+            <source>Scanning hardware device drivers, please wait...</source>
+            <translation>正在進行硬件驅動掃描，請耐心等待...</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
+            <source>Scanning %1</source>
+            <translation>正在掃描%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+            <source>Scan failed</source>
+            <translation>檢測失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+            <source>Network unavailable</source>
+            <translation>無網絡</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+            <source>Please check your network connection</source>
+            <translation>請檢查網絡連接</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+            <source>Please scan again or %1 to us</source>
+            <translation>請重新檢測或%1給我們</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="689"/>
+            <source>You are installing a driver, which will be interrupted if you exit.</source>
+            <translation>當前正在安裝驅動，退出應用後任務將會中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="690"/>
+            <location filename="../src/Page/MainWindow.cpp" line="703"/>
+            <location filename="../src/Page/MainWindow.cpp" line="716"/>
+            <source>Are you sure you want to exit?</source>
+            <translation>確認是否退出應用？</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="693"/>
+            <location filename="../src/Page/MainWindow.cpp" line="706"/>
+            <location filename="../src/Page/MainWindow.cpp" line="719"/>
+            <source>Exit</source>
+            <translation>退 出</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="694"/>
+            <location filename="../src/Page/MainWindow.cpp" line="707"/>
+            <location filename="../src/Page/MainWindow.cpp" line="720"/>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="702"/>
+            <source>You are backing up drivers, which will be interrupted if you exit.</source>
+            <translation>當前正在備份驅動，退出應用後任務將會中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="715"/>
+            <source>You are restoring drivers, which will be interrupted if you exit.</source>
+            <translation>當前正在還原驅動，退出應用後任務將會中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="36"/>
+            <source>Bluetooth adapter</source>
+            <translation>藍牙適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="37"/>
+            <location filename="../src/Tool/commontools.cpp" line="44"/>
+            <source>Imaging device</source>
+            <translation>圖像設備</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="38"/>
+            <source>Display adapter</source>
+            <translation>顯卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="40"/>
+            <source>Sound card</source>
+            <translation>聲卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="42"/>
+            <source>Network adapter</source>
+            <translation>網卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="46"/>
+            <source>Wireless network adapter</source>
+            <translation>無線網卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="66"/>
+            <source>Installation successful</source>
+            <translation>安裝成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="67"/>
+            <source>Installation failed</source>
+            <translation>安裝失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="68"/>
+            <source>Downloading</source>
+            <translation>下載中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="69"/>
+            <source>Installing</source>
+            <translation>安裝中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="70"/>
+            <source>Not installed</source>
+            <translation>驅動未安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="71"/>
+            <source>Out-of-date</source>
+            <translation>驅動可更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="72"/>
+            <source>Waiting</source>
+            <translation>等待中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="73"/>
+            <source>Not backed up</source>
+            <translation>驅動未備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="74"/>
+            <source>Backing up</source>
+            <translation>正在備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="75"/>
+            <source>Backup failed</source>
+            <translation>備份失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="76"/>
+            <source>Backup successful</source>
+            <translation>備份成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="77"/>
+            <source>Restoring</source>
+            <translation>還原中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="81"/>
+            <source>Unknown error</source>
+            <translation>未知錯誤</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="82"/>
+            <source>Network error</source>
+            <translation>網絡異常</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="83"/>
+            <source>Canceled</source>
+            <translation>已取消</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="84"/>
+            <source>Failed to get driver files</source>
+            <translation>驅動文件獲取異常</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="249"/>
+            <source>Update</source>
+            <translation>更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="254"/>
+            <source>Backup</source>
+            <translation>備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="259"/>
+            <source>Restore</source>
+            <translation>還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="245"/>
+            <source>Install</source>
+            <translation>安装</translation>
+        </message>
+        <message>
+            <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+    </context>
+    <context>
+        <name>TableWidget</name>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+            <location filename="../src/Widget/TableWidget.cpp" line="212"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+            <source>Refresh</source>
+            <translation>刷新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+            <source>Update drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+            <source>Uninstall drivers</source>
+            <translation>卸載驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+            <source>Allow it to wake the computer</source>
+            <translation>允許喚起電腦</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+            <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+            <location filename="../src/Widget/TableWidget.cpp" line="330"/>
+            <source>Enable</source>
+            <translation>啟用</translation>
+        </message>
+    </context>
+    <context>
+        <name>TextBrowser</name>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+            <source>Refresh</source>
+            <translation>刷新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>UrlChooserEdit</name>
+        <message>
+            <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+            <source>Select a local folder please</source>
+            <translation>請選擇本地文件夾</translation>
+        </message>
+    </context>
+    <context>
+        <name>WaitingWidget</name>
+        <message>
+            <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+            <source>Loading...</source>
+            <translation>正在載入...</translation>
+        </message>
+    </context>
 </TS>

--- a/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
+++ b/deepin-devicemanager/translations/deepin-devicemanager_zh_TW.ts
@@ -1,4226 +1,4229 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
-<context>
-    <name>BtnLabel</name>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="43"/>
-        <source>OK</source>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="56"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>確 定</translation>
-    </message>
-</context>
-<context>
-    <name>CmdButtonWidget</name>
-    <message>
-        <location filename="../src/Widget/CmdButtonWidget.cpp" line="22"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-</context>
-<context>
-    <name>CommonTools</name>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="85"/>
-        <source>EC_NOTIFY_NETWORK</source>
-        <translation>EC_NOTIFY_NETWORK</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="86"/>
-        <source>EC_REINSTALL</source>
-        <translation>EC_REINSTALL</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="87"/>
-        <source>EC_6</source>
-        <translation>EC_6</translation>
-    </message>
-</context>
-<context>
-    <name>DetailButton</name>
-    <message>
-        <location filename="../src/Page/PageDetail.cpp" line="44"/>
-        <location filename="../src/Page/PageDetail.cpp" line="47"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDetail.cpp" line="45"/>
-        <source>Collapse</source>
-        <translation>收起</translation>
-    </message>
-</context>
-<context>
-    <name>DetailTreeView</name>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="155"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="376"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="159"/>
-        <location filename="../src/Widget/DetailTreeView.cpp" line="383"/>
-        <source>Collapse</source>
-        <translation>收起</translation>
-    </message>
-</context>
-<context>
-    <name>DetailViewDelegate</name>
-    <message>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceAudio</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="307"/>
-        <source>Device Name</source>
-        <translation>裝置名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="352"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="341"/>
-        <source>Chip</source>
-        <translation>晶片</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="339"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="340"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
-        <source>SysFS_Path</source>
-        <translation>SysFS_Path</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
-        <source>Revision</source>
-        <translation>修訂版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
-        <source>KernelModeDriver</source>
-        <translation>KernelModeDriver</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
-        <source>Memory Address</source>
-        <translation>記憶體地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="362"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceBaseInfo</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceBios</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="243"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
-        <source>Chipset</source>
-        <translation>晶片組</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceBluetooth</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
-        <source>Alias</source>
-        <translation>別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="250"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
-        <source>Driver Version</source>
-        <translation>驅動版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="256"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="257"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="258"/>
-        <source>Logical Name</source>
-        <translation>邏輯名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="259"/>
-        <source>MAC Address</source>
-        <translation>物理地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="271"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="275"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceCdrom</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="129"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="131"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="132"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="133"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="134"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="135"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="136"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="153"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="157"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceComputer</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceComputer.cpp" line="163"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceCpu</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="68"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="69"/>
-        <source>CPU ID</source>
-        <translation>處理器ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="70"/>
-        <source>Core ID</source>
-        <translation>核心ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="71"/>
-        <source>Threads</source>
-        <translation>執行緒數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="74"/>
-        <source>BogoMIPS</source>
-        <translation>BogoMIPS</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
-        <source>Architecture</source>
-        <translation>架構</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
-        <source>CPU Family</source>
-        <translation>家族</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="107"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="120"/>
-        <source>Processor</source>
-        <translation>邏輯處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="118"/>
-        <source>Core(s)</source>
-        <translation>核</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="270"/>
-        <source>Virtualization</source>
-        <translation>虛擬化</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="271"/>
-        <source>Flags</source>
-        <translation>特性</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="272"/>
-        <source>Extensions</source>
-        <translation>擴展指令集</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="273"/>
-        <source>L4 Cache</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="274"/>
-        <source>L3 Cache</source>
-        <translation>L3快取</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="275"/>
-        <source>L2 Cache</source>
-        <translation>L2快取</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="276"/>
-        <source>L1i Cache</source>
-        <translation>L1快取（指令）</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="277"/>
-        <source>L1d Cache</source>
-        <translation>L1快取（數據）</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="278"/>
-        <source>Stepping</source>
-        <translation>步進</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="73"/>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
-        <source>Max Speed</source>
-        <translation>最大頻率</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceGpu</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="62"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="63"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="64"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="65"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
-        <source>Graphics Memory</source>
-        <translation>視訊記憶體</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="327"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="328"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="329"/>
-        <source>Memory Address</source>
-        <translation>記憶體地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="330"/>
-        <source>IO Port</source>
-        <translation>I/O埠</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="331"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="333"/>
-        <source>Maximum Resolution</source>
-        <translation>最大解析度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="334"/>
-        <source>Minimum Resolution</source>
-        <translation>最小解析度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="336"/>
-        <source>Current Resolution</source>
-        <translation>目前解析度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="337"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="338"/>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="340"/>
-        <source>DP</source>
-        <translation>DP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="341"/>
-        <source>eDP</source>
-        <translation>eDP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="342"/>
-        <source>HDMI</source>
-        <translation>HDMI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="343"/>
-        <source>VGA</source>
-        <translation>VGA</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="344"/>
-        <source>DVI</source>
-        <translation>DVI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
-        <source>DigitalOutput</source>
-        <translation>DigitalOutput</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
-        <source>Display Output</source>
-        <translation>顯示輸出</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceImage</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="163"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="164"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="165"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="166"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="167"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="173"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="180"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="192"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceImage.cpp" line="196"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceInput</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="515"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="516"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="517"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="518"/>
-        <source>Interface</source>
-        <translation>介面</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="519"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
-        <source>Maximum Current</source>
-        <translation>最大電流</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="529"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="530"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="531"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="543"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceManager</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="144"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="285"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1485"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1505"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1526"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1537"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1551"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1564"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1579"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1595"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="150"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="263"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1681"/>
-        <source>CPU</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="155"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1684"/>
-        <source>CPU quantity</source>
-        <translation>CPU數量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="166"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="264"/>
-        <source>Motherboard</source>
-        <translation>主機板</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="171"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="265"/>
-        <source>Memory</source>
-        <translation>記憶體</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="176"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="266"/>
-        <source>Display Adapter</source>
-        <translation>顯示適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="181"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
-        <source>Sound Adapter</source>
-        <translation>音訊適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
-        <source>Storage</source>
-        <translation>儲存裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="191"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
-        <source>Other PCI Devices</source>
-        <translation>其他PCI裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="196"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
-        <source>Battery</source>
-        <translation>電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="207"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
-        <source>Bluetooth</source>
-        <translation>藍牙</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="212"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
-        <source>Network Adapter</source>
-        <translation>網路適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
-        <source>Mouse</source>
-        <translation>滑鼠</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="228"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
-        <source>Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="238"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
-        <source>Monitor</source>
-        <translation>顯示裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
-        <source>CD-ROM</source>
-        <translation>光碟機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
-        <source>Printer</source>
-        <translation>印表機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
-        <source>Camera</source>
-        <translation>圖像裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
-        <source>Other Devices</source>
-        <comment>Other Input Devices</comment>
-        <translation>其他裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1491"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1586"/>
-        <source>Device</source>
-        <translation>裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1499"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
-        <source>OS</source>
-        <translation>操作系統</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceMemory</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="165"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="169"/>
-        <source>Size</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="167"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
-        <source>Total Width</source>
-        <translation>總位寬</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
-        <source>Locator</source>
-        <translation>插槽</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="141"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
-        <source>Configured Voltage</source>
-        <translation>配置電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
-        <source>Maximum Voltage</source>
-        <translation>最高電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
-        <source>Minimum Voltage</source>
-        <translation>最低電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="154"/>
-        <source>Configured Speed</source>
-        <translation>配置頻率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="156"/>
-        <source>Data Width</source>
-        <translation>數據位寬</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceMonitor</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="312"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="313"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="314"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="315"/>
-        <source>Display Input</source>
-        <translation>顯示輸入</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="316"/>
-        <source>Interface Type</source>
-        <translation>介面類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="322"/>
-        <source>Support Resolution</source>
-        <translation>支持解析度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="324"/>
-        <source>Current Resolution</source>
-        <translation>目前解析度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
-        <source>Display Ratio</source>
-        <translation>顯示比例</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="327"/>
-        <source>Primary Monitor</source>
-        <translation>主顯示器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="328"/>
-        <source>Size</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="329"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceNetwork</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
-        <source>Driver Version</source>
-        <translation>驅動版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
-        <source>Maximum Rate</source>
-        <translation>最大速率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
-        <source>Negotiation Rate</source>
-        <translation>協商速率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
-        <source>Port</source>
-        <translation>埠</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
-        <source>Multicast</source>
-        <translation>組播</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
-        <source>Link</source>
-        <translation>連結</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
-        <source>Latency</source>
-        <translation>延遲</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
-        <source>IP</source>
-        <translation>IP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
-        <source>Firmware</source>
-        <translation>韌體</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
-        <source>Duplex</source>
-        <translation>雙工</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
-        <source>Broadcast</source>
-        <translation>廣播</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
-        <source>Auto Negotiation</source>
-        <translation>自動協商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
-        <source>Memory Address</source>
-        <translation>記憶體地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
-        <source>MAC Address</source>
-        <translation>物理地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
-        <source>Logical Name</source>
-        <translation>邏輯名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceOtherPCI</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
-        <source>Input/Output</source>
-        <translation>輸入/輸出</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
-        <source>Memory</source>
-        <translation>記憶體</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
-        <source>IRQ</source>
-        <translation>中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
-        <source>Latency</source>
-        <translation>延遲</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceOthers</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
-        <source>Bus Info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
-        <source>Maximum Power</source>
-        <translation>最大功率</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DevicePower</name>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
-        <source>Capacity</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
-        <source>Voltage</source>
-        <translation>電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
-        <source>Slot</source>
-        <translation>插槽</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
-        <source>Design Capacity</source>
-        <translation>設計容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
-        <source>Design Voltage</source>
-        <translation>設計電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
-        <source>SBDS Version</source>
-        <translation>SBDS版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
-        <source>SBDS Serial Number</source>
-        <translation>SBDS序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
-        <source>SBDS Manufacture Date</source>
-        <translation>SBDS製造日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
-        <source>SBDS Chemistry</source>
-        <translation>SBDS材料</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
-        <source>Temperature</source>
-        <translation>溫度</translation>
-    </message>
-</context>
-<context>
-    <name>DevicePrint</name>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
-        <source>Model</source>
-        <translation>型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
-        <source>Shared</source>
-        <translation>已共享</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
-        <source>URI</source>
-        <translation>URI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
-        <source>Interface Type</source>
-        <translation>介面類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceStorage</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="675"/>
-        <source>Vendor</source>
-        <translation>製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
-        <source>Media Type</source>
-        <translation>介質類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="677"/>
-        <source>Size</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="632"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="674"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
-        <source>Capabilities</source>
-        <translation>功能</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="660"/>
-        <source>Module Alias</source>
-        <translation>模組別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="661"/>
-        <source>Physical ID</source>
-        <translation>物理ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="643"/>
-        <source>Firmware Version</source>
-        <translation>韌體版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
-        <source>Speed</source>
-        <translation>速度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
-        <source>Description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="658"/>
-        <source>Interface</source>
-        <translation>介面</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="659"/>
-        <source>Rotation Rate</source>
-        <translation>轉速</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="685"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>GetDriverNameWidget</name>
-    <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="52"/>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="140"/>
-        <source>Select a driver for update</source>
-        <translation>選擇需要更新的驅動程式</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/GetDriverNameWidget.cpp" line="134"/>
-        <source>No drivers found in this folder</source>
-        <translation>所選資料夾未檢測到驅動文件</translation>
-    </message>
-</context>
-<context>
-    <name>GetInfoPool</name>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="75"/>
-        <source>Loading Audio Device Info...</source>
-        <translation>獲取音訊裝置訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="78"/>
-        <source>Loading BIOS Info...</source>
-        <translation>獲取BIOS訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="88"/>
-        <source>Loading CD-ROM Info...</source>
-        <translation>獲取光碟機訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="93"/>
-        <source>Loading Operating System Info...</source>
-        <translation>獲取操作系統訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="96"/>
-        <source>Loading CPU Info...</source>
-        <translation>獲取處理器訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="97"/>
-        <source>Loading Other Devices Info...</source>
-        <translation>獲取其他裝置訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="98"/>
-        <source>Loading Power Info...</source>
-        <translation>獲取電池訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
-        <source>Loading Printer Info...</source>
-        <translation>獲取印表機訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="102"/>
-        <source>Loading Mouse Info...</source>
-        <translation>獲取滑鼠訊息...</translation>
-    </message>
-    <message>
-        <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="103"/>
-        <source>Loading Network Adapter Info...</source>
-        <translation>獲取網路適配器訊息...</translation>
-    </message>
-</context>
-<context>
-    <name>LogTreeView</name>
-    <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="83"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="119"/>
-        <location filename="../src/Widget/logtreeview.cpp" line="121"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/logtreeview.cpp" line="100"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>LogViewItemDelegate</name>
-    <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="108"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/logviewitemdelegate.cpp" line="110"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>MainWindow</name>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="241"/>
-        <source>Device Info</source>
-        <comment>export file's name</comment>
-        <translation>裝置訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="312"/>
-        <source>Display shortcuts</source>
-        <translation>顯示快捷鍵</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="313"/>
-        <source>Close</source>
-        <translation>關閉</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="314"/>
-        <source>Help</source>
-        <translation>說明</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="315"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="319"/>
-        <source>System</source>
-        <translation>系統</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="326"/>
-        <source>Export</source>
-        <translation>匯出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="327"/>
-        <source>Refresh</source>
-        <translation>重新整理</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="331"/>
-        <source>Device Manager</source>
-        <translation>裝置管理器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
-        <source>Hardware</source>
-        <translation>硬體訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="400"/>
-        <source>Drivers</source>
-        <translation>驅動管理</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
-        <source>Monitor</source>
-        <translation>顯示裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="550"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="554"/>
-        <source>Display Adapter</source>
-        <translation>顯示適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="558"/>
-        <source>CPU</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="562"/>
-        <source>Network Adapter</source>
-        <translation>網路適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="568"/>
-        <source>Battery</source>
-        <translation>電池</translation>
-    </message>
-</context>
-<context>
-    <name>PageDetail</name>
-    <message>
-        <location filename="../src/Page/PageDetail.cpp" line="308"/>
-        <source>More</source>
-        <translation>更多</translation>
-    </message>
-</context>
-<context>
-    <name>PageDriverBackupInfo</name>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="92"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
-        <source>Current Version</source>
-        <translation>目前版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="93"/>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="104"/>
-        <source>Driver Platform Version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="94"/>
-        <source>Action</source>
-        <translation>操作</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="179"/>
-        <source>Backupable Drivers</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverBackupInfo.cpp" line="180"/>
-        <source>Backed up Drivers</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageDriverControl</name>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="101"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="234"/>
-        <source>Updating</source>
-        <translation>正在更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="128"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="187"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="107"/>
-        <source>Next</source>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>Warning</source>
-        <translation>注意</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="125"/>
-        <source>The device will be unavailable after the driver uninstallation</source>
-        <translation>將從系統中移除此驅動程式，移除後該裝置不可用</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
-        <source>Uninstall</source>
-        <comment>button</comment>
-        <translation>卸 載</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
-        <source>Uninstalling</source>
-        <translation>正在移除</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
-        <source>Update successful</source>
-        <translation>驅動更新成功</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="159"/>
-        <source>Uninstallation successful</source>
-        <translation>驅動移除成功</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
-        <source>Update failed</source>
-        <translation>驅動更新失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="160"/>
-        <source>Uninstallation failed</source>
-        <translation>驅動移除失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="167"/>
-        <source>OK</source>
-        <comment>button</comment>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="186"/>
-        <source>Next</source>
-        <comment>button</comment>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="207"/>
-        <source>The selected folder does not exist, please select again</source>
-        <translation>所選資料夾不存在，請重新選擇</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="212"/>
-        <source>Update</source>
-        <comment>button</comment>
-        <translation>更 新</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
-        <source>Previous</source>
-        <comment>button</comment>
-        <translation>上一步</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="246"/>
-        <source>Broken package</source>
-        <translation>包文件損壞</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="250"/>
-        <source>Unmatched package architecture</source>
-        <translation>包文件與系統架構不匹配</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="255"/>
-        <location filename="../src/Page/PageDriverControl.cpp" line="338"/>
-        <source>The selected file does not exist, please select again</source>
-        <translation>所選文件不存在，請重新選擇</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="339"/>
-        <source>It is not a driver</source>
-        <translation>該文件不是驅動文件</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="340"/>
-        <source>Unable to install - no digital signature</source>
-        <translation>無法安裝，安裝包無數位簽章</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="334"/>
-        <source>Unknown error</source>
-        <translation>未知錯誤</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="335"/>
-        <source>The driver module was not found</source>
-        <translation>未發現該驅動模組</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="336"/>
-        <source>Invalid module format</source>
-        <translation>模塊格式無效</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverControl.cpp" line="337"/>
-        <source>The driver module has dependencies</source>
-        <translation>驅動模組被依賴</translation>
-    </message>
-</context>
-<context>
-    <name>PageDriverInstallInfo</name>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="102"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
-        <source>Device Name</source>
-        <translation>裝置名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="103"/>
-        <source>Version Available</source>
-        <translation>可安裝版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="104"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="117"/>
-        <source>Size</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="105"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="118"/>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
-        <source>Action</source>
-        <translation>操作</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="116"/>
-        <source>New Version</source>
-        <translation>可更新版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="128"/>
-        <source>Current Version</source>
-        <translation>目前版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="212"/>
-        <source>Missing drivers (%1)</source>
-        <translation>可安裝驅動 (%1)</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="213"/>
-        <source>Outdated drivers (%1)</source>
-        <translation>可更新驅動 (%1)</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverInstallInfo.cpp" line="214"/>
-        <source>Up-to-date drivers (%1)</source>
-        <translation>無需更新驅動 (%1)</translation>
-    </message>
-</context>
-<context>
-    <name>PageDriverManager</name>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="61"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="115"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="485"/>
-        <source>Driver Install</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="99"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="487"/>
-        <source>Driver Backup</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="489"/>
-        <source>Driver Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="628"/>
-        <source>OK</source>
-        <translation>確 定</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="629"/>
-        <source>Feedback</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageDriverRestoreInfo</name>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="93"/>
-        <source>You do not have any drivers to restore, please backup first</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="96"/>
-        <source>Go to Backup Driver</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="122"/>
-        <source>Name</source>
-        <translation>名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="123"/>
-        <source>Current Version</source>
-        <translation>目前版本</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="124"/>
-        <source>Backup Version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="125"/>
-        <source>Action</source>
-        <translation>操作</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="167"/>
-        <source>Restorable Drivers</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageListView</name>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="20"/>
-        <source>Refresh</source>
-        <translation>重新整理</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="21"/>
-        <source>Export</source>
-        <translation>匯出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="23"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
-        <source>Driver Install</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
-        <source>Driver Backup</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageListView.cpp" line="124"/>
-        <source>Driver Restore</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>PageMultiInfo</name>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="162"/>
-        <source>Failed to enable the device</source>
-        <translation>啟用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="165"/>
-        <source>Failed to disable the device</source>
-        <translation>禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="170"/>
-        <source>Failed to disable it: unable to get the device SN</source>
-        <translation>無法獲取裝置序號，禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="192"/>
-        <source>Update Drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageMultiInfo.cpp" line="210"/>
-        <source>Uninstall Drivers</source>
-        <translation>移除驅動</translation>
-    </message>
-</context>
-<context>
-    <name>PageOverview</name>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="39"/>
-        <source>Refresh</source>
-        <translation>重新整理</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="40"/>
-        <source>Export</source>
-        <translation>匯出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="41"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageOverview.cpp" line="84"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-</context>
-<context>
-    <name>PageSingleInfo</name>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
-        <source>Refresh</source>
-        <translation>重新整理</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
-        <source>Export</source>
-        <translation>匯出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="208"/>
-        <source>Enable</source>
-        <translation>啟用</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
-        <source>Update drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
-        <source>Uninstall drivers</source>
-        <translation>移除驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
-        <source>Allow it to wake the computer</source>
-        <translation>允許喚起電腦</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="210"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="292"/>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="309"/>
-        <source>Failed to disable it: unable to get the device SN</source>
-        <translation>無法獲取裝置序號，禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="296"/>
-        <source>Failed to disable the device</source>
-        <translation>禁用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="313"/>
-        <source>Failed to enable the device</source>
-        <translation>啟用失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="328"/>
-        <source>Update Drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageSingleInfo.cpp" line="345"/>
-        <source>Uninstall Drivers</source>
-        <translation>移除驅動</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="308"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="41"/>
-        <source>SubVendor</source>
-        <translation>子製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="309"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="42"/>
-        <source>SubDevice</source>
-        <translation>子裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
-        <source>Driver</source>
-        <translation>驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="310"/>
-        <source>Driver Status</source>
-        <translation>驅動狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="311"/>
-        <source>Driver Activation Cmd</source>
-        <translation>驅動啟動指令</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="312"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="114"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="623"/>
-        <source>Config Status</source>
-        <translation>配置狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="313"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
-        <source>latency</source>
-        <translation>延遲</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="314"/>
-        <source>Phys</source>
-        <translation>Phys</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="315"/>
-        <source>Sysfs</source>
-        <translation>Sysfs</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="316"/>
-        <source>Handlers</source>
-        <translation>處理程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="317"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="501"/>
-        <source>PROP</source>
-        <translation>PROP</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="318"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="502"/>
-        <source>EV</source>
-        <translation>EV</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="319"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="503"/>
-        <source>KEY</source>
-        <translation>KEY</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
-        <source>Version</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceAudio.cpp" line="320"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="146"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="207"/>
-        <source>Bus</source>
-        <translation>匯流排</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="42"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
-        <source>BIOS Information</source>
-        <translation>BIOS訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="64"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
-        <source>Base Board Information</source>
-        <translation>主機板訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="86"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
-        <source>System Information</source>
-        <translation>系統訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="102"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
-        <source>Chassis Information</source>
-        <translation>機箱訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="118"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="230"/>
-        <source>Physical Memory Array</source>
-        <translation>物理記憶體陣列</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="176"/>
-        <source>Release Date</source>
-        <translation>發布日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="177"/>
-        <source>Address</source>
-        <translation>地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="178"/>
-        <source>Runtime Size</source>
-        <translation>運行內存大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="179"/>
-        <source>ROM Size</source>
-        <translation>ROM大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="180"/>
-        <source>Characteristics</source>
-        <translation>特性</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="181"/>
-        <source>BIOS Revision</source>
-        <translation>BIOS修訂版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="182"/>
-        <source>Firmware Revision</source>
-        <translation>韌體修訂版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="184"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="193"/>
-        <source>Product Name</source>
-        <translation>產品名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="185"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
-        <source>Serial Number</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="115"/>
-        <source>Asset Tag</source>
-        <translation>資產編號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="211"/>
-        <source>Features</source>
-        <translation>特徵</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
-        <source>Location In Chassis</source>
-        <translation>機箱內位置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
-        <source>Chassis Handle</source>
-        <translation>機箱程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
-        <source>Contained Object Handles</source>
-        <translation>包含對象程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="232"/>
-        <source>UUID</source>
-        <translation>UUID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
-        <source>Wake-up Type</source>
-        <translation>喚醒類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
-        <source>SKU Number</source>
-        <translation>SKU號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="224"/>
-        <source>Family</source>
-        <translation>家族</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="202"/>
-        <source>Lock</source>
-        <translation>鎖</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
-        <source>Boot-up State</source>
-        <translation>開機狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
-        <source>Power Supply State</source>
-        <translation>供電狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
-        <source>Thermal State</source>
-        <translation>散熱狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
-        <source>Security Status</source>
-        <translation>安全狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="209"/>
-        <source>OEM Information</source>
-        <translation>OEM訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="210"/>
-        <source>Height</source>
-        <translation>高度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
-        <source>Number Of Power Cords</source>
-        <translation>電源線數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
-        <source>Contained Elements</source>
-        <translation>包含組件數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
-        <source>Location</source>
-        <translation>位置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
-        <source>Error Correction Type</source>
-        <translation>糾錯類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
-        <source>Maximum Capacity</source>
-        <translation>最大容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="110"/>
-        <source>Error Information Handle</source>
-        <translation>錯誤訊息程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
-        <source>Number Of Devices</source>
-        <translation>插槽</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
-        <source>BIOS ROMSIZE</source>
-        <translation>BIOS ROM大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
-        <source>Release date</source>
-        <translation>發布日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
-        <source>Board name</source>
-        <translation>主機板名稱</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
-        <source>SMBIOS Version</source>
-        <translation>SMBIOS版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
-        <source>Language Description Format</source>
-        <translation>語言描述格式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="235"/>
-        <source>Installable Languages</source>
-        <translation>可安裝語言數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
-        <source>Currently Installed Language</source>
-        <translation>當前安裝語言</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="208"/>
-        <source>BD Address</source>
-        <translation>藍牙裝置地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="209"/>
-        <source>ACL MTU</source>
-        <translation>ACL MTU</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="210"/>
-        <source>SCO MTU</source>
-        <translation>SCO MTU</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="212"/>
-        <source>Packet type</source>
-        <translation>封包類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="213"/>
-        <source>Link policy</source>
-        <translation>連接策略</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="214"/>
-        <source>Link mode</source>
-        <translation>連接模式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="215"/>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
-        <source>Class</source>
-        <translation>類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="216"/>
-        <source>Service Classes</source>
-        <translation>服務類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="217"/>
-        <source>Device Class</source>
-        <translation>裝置類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
-        <source>HCI Version</source>
-        <translation>HCI版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
-        <source>LMP Version</source>
-        <translation>LMP版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
-        <source>Subversion</source>
-        <translation>子版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="40"/>
-        <source>Device</source>
-        <translation>裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="108"/>
-        <source>Serial ID</source>
-        <translation>序號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
-        <source>product</source>
-        <translation>產品</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
-        <source>description</source>
-        <translation>描述</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
-        <source>Powered</source>
-        <translation>供電</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
-        <source>Discoverable</source>
-        <translation>可發現</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
-        <source>Pairable</source>
-        <translation>可配對</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
-        <source>Modalias</source>
-        <translation>設置命令別名</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
-        <source>Discovering</source>
-        <translation>搜索中</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="109"/>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="43"/>
-        <source>Driver Modules</source>
-        <translation>驅動模組</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="110"/>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="505"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="516"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="615"/>
-        <source>Device File</source>
-        <translation>裝置文件</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="111"/>
-        <source>Device Files</source>
-        <translation>裝置文件</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="112"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="518"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="624"/>
-        <source>Device Number</source>
-        <translation>裝置編號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="115"/>
-        <source>Application</source>
-        <translation>應用</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
-        <source>status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="519"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="618"/>
-        <source>logical name</source>
-        <translation>邏輯地址</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="616"/>
-        <source>ansiversion</source>
-        <translation>ANSI版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="57"/>
-        <source>CPU implementer</source>
-        <translation>CPU程式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="58"/>
-        <source>CPU architecture</source>
-        <translation>CPU架構</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="59"/>
-        <source>CPU variant</source>
-        <translation>CPU變數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="60"/>
-        <source>CPU part</source>
-        <translation>CPU部件</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="61"/>
-        <source>CPU revision</source>
-        <translation>CPU版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="305"/>
-        <source>One</source>
-        <translation>單</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="306"/>
-        <source>Two</source>
-        <translation>雙</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="307"/>
-        <source>Four</source>
-        <translation>四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="308"/>
-        <source>Six</source>
-        <translation>六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="309"/>
-        <source>Eight</source>
-        <translation>八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="310"/>
-        <source>Nine</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="311"/>
-        <source>Ten</source>
-        <translation>十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="312"/>
-        <source>Twelve</source>
-        <translation>十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="313"/>
-        <source>Fourteen</source>
-        <translation>十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="314"/>
-        <source>Sixteen</source>
-        <translation>十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="315"/>
-        <source>Eighteen</source>
-        <translation>十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
-        <source>Twenty</source>
-        <translation>二十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
-        <source>Twenty-two</source>
-        <translation>二十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
-        <source>Twenty-four</source>
-        <translation>二十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
-        <source>Twenty-six</source>
-        <translation>二十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
-        <source>Twenty-eight</source>
-        <translation>二十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
-        <source>Thirty</source>
-        <translation>三十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
-        <source>Thirty-two</source>
-        <translation>三十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
-        <source>Thirty-four</source>
-        <translation>三十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
-        <source>Thirty-six</source>
-        <translation>三十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
-        <source>Thirty-eight</source>
-        <translation>三十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
-        <source>Forty</source>
-        <translation>四十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
-        <source>Forty-two</source>
-        <translation>四十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
-        <source>Forty-four</source>
-        <translation>四十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
-        <source>Forty-six</source>
-        <translation>四十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
-        <source>Forty-eight</source>
-        <translation>四十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
-        <source>Fifty</source>
-        <translation>五十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
-        <source>Fifty-two</source>
-        <translation>五十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
-        <source>Fifty-four</source>
-        <translation>五十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
-        <source>Fifty-six</source>
-        <translation>五十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
-        <source>Fifty-eight</source>
-        <translation>五十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
-        <source>Sixty</source>
-        <translation>六十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
-        <source>Sixty-two</source>
-        <translation>六十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
-        <source>Sixty-four</source>
-        <translation>六十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
-        <source>Sixty-six</source>
-        <translation>六十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
-        <source>Sixty-eight</source>
-        <translation>六十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
-        <source>Seventy</source>
-        <translation>七十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
-        <source>Seventy-two</source>
-        <translation>七十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
-        <source>Seventy-four</source>
-        <translation>七十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
-        <source>Seventy-six</source>
-        <translation>七十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
-        <source>Seventy-eight</source>
-        <translation>七十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
-        <source>Eighty</source>
-        <translation>八十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
-        <source>Eighty-two</source>
-        <translation>八十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
-        <source>Eighty-four</source>
-        <translation>八十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
-        <source>Eighty-six</source>
-        <translation>八十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
-        <source>Eighty-eight</source>
-        <translation>八十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
-        <source>Ninety</source>
-        <translation>九十</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
-        <source>Ninety-two</source>
-        <translation>九十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
-        <source>Ninety-four</source>
-        <translation>九十四</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
-        <source>Ninety-six</source>
-        <translation>九十六</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
-        <source>Ninety-eight</source>
-        <translation>九十八</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
-        <source>One hundred</source>
-        <translation>100</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
-        <source>One hundred and Two</source>
-        <translation>102</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
-        <source>One hundred and four</source>
-        <translation>104</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
-        <source>One hundred and Six</source>
-        <translation>106</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
-        <source>One hundred and Eight</source>
-        <translation>108</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
-        <source>One hundred and Ten</source>
-        <translation>110</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
-        <source>One hundred and Twelve</source>
-        <translation>112</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
-        <source>One hundred and Fourteen</source>
-        <translation>114</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
-        <source>One hundred and Sixteen</source>
-        <translation>116</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
-        <source>One hundred and Eighteen</source>
-        <translation>118</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
-        <source>One hundred and Twenty</source>
-        <translation>120</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
-        <source>One hundred and Twenty-two</source>
-        <translation>122</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
-        <source>One hundred and Twenty-four</source>
-        <translation>124</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
-        <source>One hundred and Twenty-six</source>
-        <translation>126</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
-        <source>One hundred and Twenty-eight</source>
-        <translation>128</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="382"/>
-        <source>One hundred and Ninety-two</source>
-        <translation>一百九十二</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
-        <source>Two hundred and fifty-six</source>
-        <translation>256</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
-        <source>GDDR capacity</source>
-        <translation>GDDR容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
-        <source>GPU vendor</source>
-        <translation>GPU供應商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="50"/>
-        <source>GPU type</source>
-        <translation>GPU類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="51"/>
-        <source>EGL version</source>
-        <translation>EGL版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
-        <source>EGL client APIs</source>
-        <translation>EGL介面</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
-        <source>GL version</source>
-        <translation>GL版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
-        <source>GLSL version</source>
-        <translation>GLSL版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="422"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="440"/>
-        <source>Unknown</source>
-        <translation>未知</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="500"/>
-        <source>Uniq</source>
-        <translation>Uniq</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="504"/>
-        <source>MSC</source>
-        <translation>MSC</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceInput.cpp" line="506"/>
-        <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="614"/>
-        <source>Hardware Class</source>
-        <translation>硬體類別</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
-        <source>CPU</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1359"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1387"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1415"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1451"/>
-        <source>No CPU found</source>
-        <translation>未發現處理器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
-        <source>Motherboard</source>
-        <translation>主機板</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1360"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1388"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1416"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1452"/>
-        <source>No motherboard found</source>
-        <translation>未發現主機板</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
-        <source>Memory</source>
-        <translation>記憶體</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1361"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1389"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1417"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1453"/>
-        <source>No memory found</source>
-        <translation>未發現記憶體</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
-        <source>Storage</source>
-        <translation>儲存裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1362"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1390"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1418"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1454"/>
-        <source>No disk found</source>
-        <translation>未發現磁碟</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="626"/>
-        <source>Driver restore failed!</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/PageDriverManager.cpp" line="622"/>
-        <location filename="../src/Widget/BtnLabel.cpp" line="35"/>
-        <source>Please try again or give us feedback</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/BtnLabel.cpp" line="41"/>
-        <source>Driver backup failed!</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="673"/>
-        <source>Display Adapter</source>
-        <translation>顯示適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
-        <source>No GPU found</source>
-        <translation>未發現GPU</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
-        <source>Monitor</source>
-        <translation>顯示裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
-        <source>No monitor found</source>
-        <translation>未發現顯示裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
-        <source>Network Adapter</source>
-        <translation>網路適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
-        <source>No network adapter found</source>
-        <translation>未發現網路適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="676"/>
-        <source>Sound Adapter</source>
-        <translation>音訊適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
-        <source>No audio device found</source>
-        <translation>未發現音訊裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <location filename="../src/Page/PageDriverManager.cpp" line="679"/>
-        <source>Bluetooth</source>
-        <translation>藍牙</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
-        <source>No Bluetooth device found</source>
-        <translation>未發現藍牙裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>Other PCI Devices</source>
-        <translation>其他PCI裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
-        <source>No other PCI devices found</source>
-        <translation>未發現其他PCI裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>Power</source>
-        <translation>電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
-        <source>No battery found</source>
-        <translation>未發現電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <location filename="../src/Tool/commontools.cpp" line="39"/>
-        <source>Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
-        <source>No keyboard found</source>
-        <translation>未發現鍵盤</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <location filename="../src/Tool/commontools.cpp" line="41"/>
-        <source>Mouse</source>
-        <translation>滑鼠</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
-        <source>No mouse found</source>
-        <translation>未發現滑鼠</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <location filename="../src/Tool/commontools.cpp" line="43"/>
-        <source>Printer</source>
-        <translation>印表機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
-        <source>No printer found</source>
-        <translation>未發現印表機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>Camera</source>
-        <translation>圖像裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
-        <source>No camera found</source>
-        <translation>未發現圖像裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>CD-ROM</source>
-        <translation>光碟機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
-        <source>No CD-ROM found</source>
-        <translation>未發現光碟機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <location filename="../src/Tool/commontools.cpp" line="45"/>
-        <location filename="../src/Tool/commontools.cpp" line="47"/>
-        <source>Other Devices</source>
-        <translation>其他裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
-        <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
-        <source>No other devices found</source>
-        <translation>未發現其他裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="109"/>
-        <source>Array Handle</source>
-        <translation>數組程序</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="111"/>
-        <source>Form Factor</source>
-        <translation>尺寸型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="112"/>
-        <source>Set</source>
-        <translation>設置</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="113"/>
-        <source>Bank Locator</source>
-        <translation>記憶體通道</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="114"/>
-        <source>Type Detail</source>
-        <translation>類型詳情</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="116"/>
-        <source>Part Number</source>
-        <translation>部件號碼</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="117"/>
-        <source>Rank</source>
-        <translation>位列</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="118"/>
-        <source>Memory Technology</source>
-        <translation>記憶體技術</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="119"/>
-        <source>Memory Operating Mode Capability</source>
-        <translation>記憶體操作模式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="120"/>
-        <source>Firmware Version</source>
-        <translation>韌體版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
-        <source>Module Manufacturer ID</source>
-        <translation>元件製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
-        <source>Module Product ID</source>
-        <translation>元件產品ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
-        <source>Memory Subsystem Controller Manufacturer ID</source>
-        <translation>記憶體子系統控制器製造商</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
-        <source>Memory Subsystem Controller Product ID</source>
-        <translation>記憶體子系統控制器產品ID</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
-        <source>Non-Volatile Size</source>
-        <translation>不易遺失大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
-        <source>Volatile Size</source>
-        <translation>易遺失大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
-        <source>Cache Size</source>
-        <translation>快取大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
-        <source>Logical Size</source>
-        <translation>邏輯大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="65"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="81"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="96"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="111"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="440"/>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="470"/>
-        <location filename="../src/Tool/EDIDParser.cpp" line="195"/>
-        <source>inch</source>
-        <translation>英寸</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="306"/>
-        <source>Date</source>
-        <translation>日期</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
-        <source>ioport</source>
-        <translation>IO埠</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
-        <source>network</source>
-        <translation>網路</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
-        <source>battery</source>
-        <translation>電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
-        <source>native-path</source>
-        <translation>安裝路徑</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
-        <source>power supply</source>
-        <translation>供電</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
-        <source>updated</source>
-        <translation>更新時間</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
-        <source>has history</source>
-        <translation>歷史記錄</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
-        <source>has statistics</source>
-        <translation>用電統計</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
-        <source>rechargeable</source>
-        <translation>可再充電</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
-        <source>state</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
-        <source>warning-level</source>
-        <translation>警告等級</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
-        <source>energy</source>
-        <translation>容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
-        <source>energy-empty</source>
-        <translation>最低容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
-        <source>energy-full</source>
-        <translation>完全充滿容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
-        <source>energy-full-design</source>
-        <translation>設計容量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
-        <source>energy-rate</source>
-        <translation>能量密度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
-        <source>voltage</source>
-        <translation>電壓</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
-        <source>percentage</source>
-        <translation>電量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
-        <source>technology</source>
-        <translation>電池技術</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
-        <source>icon-name</source>
-        <translation>圖示</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
-        <source>online</source>
-        <translation>線上</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
-        <source>daemon-version</source>
-        <translation>Daemon版本</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
-        <source>on-battery</source>
-        <translation>使用電池</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
-        <source>lid-is-closed</source>
-        <translation>筆記本合蓋</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
-        <source>lid-is-present</source>
-        <translation>打開筆記本蓋子</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
-        <source>critical-action</source>
-        <translation>電量極低時執行</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
-        <source>copies</source>
-        <translation>影印數量</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
-        <source>job-cancel-after</source>
-        <translation>此時取消列印任務</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
-        <source>job-hold-until</source>
-        <translation>保留列印任務直至</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
-        <source>job-priority</source>
-        <translation>任務優先度</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
-        <source>marker-change-time</source>
-        <translation>標記修改次數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
-        <source>number-up</source>
-        <translation>編號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
-        <source>orientation-requested</source>
-        <translation>列印方向</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
-        <source>print-color-mode</source>
-        <translation>顏色模式</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
-        <source>printer-is-accepting-jobs</source>
-        <translation>當前可列印</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
-        <source>printer-is-shared</source>
-        <translation>印表機已共享</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
-        <source>printer-is-temporary</source>
-        <translation>臨時印表機</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
-        <source>printer-make-and-model</source>
-        <translation>製造商和型號</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
-        <source>printer-state-change-time</source>
-        <translation>印表機狀態修改時間</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
-        <source>printer-state-reasons</source>
-        <translation>印表機狀態訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
-        <source>printer-type</source>
-        <translation>印表機類型</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
-        <source>printer-uri-supported</source>
-        <translation>支持的URI</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
-        <source>sides</source>
-        <translation>列印面數</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="418"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="436"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="664"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="725"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="741"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="745"/>
-        <source>SSD</source>
-        <translation>固態</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="420"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="438"/>
-        <source>HDD</source>
-        <translation>機械</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="515"/>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="617"/>
-        <source>bus info</source>
-        <translation>匯流排訊息</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="619"/>
-        <source>logicalsectorsize</source>
-        <translation>邏輯分區大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="621"/>
-        <source>sectorsize</source>
-        <translation>扇區大小</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="622"/>
-        <source>guid</source>
-        <translation>全局唯一標識符</translation>
-    </message>
-    <message>
-        <location filename="../src/DeviceManager/DeviceStorage.cpp" line="625"/>
-        <source>Geometry (Logical)</source>
-        <translation>幾何資料（邏輯）</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="89"/>
-        <location filename="../src/main.cpp" line="91"/>
-        <source>Device Manager</source>
-        <translation>裝置管理器</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="92"/>
-        <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
-        <translation>裝置管理器是查看、管理硬體裝置的工具軟體。</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="148"/>
-        <source>New drivers available! Install or update them now.</source>
-        <translation>您有驅動可進行安裝/更新</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="149"/>
-        <source>View</source>
-        <translation>查看</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="14"/>
-        <source>Include subfolders</source>
-        <translation>包括子資料夾</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/GetDriverPathWidget.cpp" line="55"/>
-        <source>Search for drivers in this path</source>
-        <translation>選擇驅動所在位置</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="103"/>
-        <source>%1 driver updates available</source>
-        <translation>發現%1個驅動可安裝更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="109"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="377"/>
-        <source>Time checked: %1</source>
-        <translation>檢測時間: %1</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="159"/>
-        <source>Downloading drivers for %1...</source>
-        <translation>正在下載%1驅動…</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="161"/>
-        <source>Download speed: %1 Downloaded %2/%3</source>
-        <translation>下載速度：%1 已完成 %2/%3</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="207"/>
-        <source>Installing drivers for %1...</source>
-        <translation>正在安裝%1驅動…</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="249"/>
-        <source>%1 drivers installed, %2 drivers failed</source>
-        <translation>驅動安裝成功%1個，失敗%2個</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="251"/>
-        <source>%1 drivers installed</source>
-        <translation>共成功安裝%1個驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="291"/>
-        <source>Failed to install drivers</source>
-        <translation>驅動安裝失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="331"/>
-        <source>Network error. Reconnecting...</source>
-        <translation>網路異常，重試中</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="333"/>
-        <source>Download speed: %1</source>
-        <translation>下載速度：%1</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="374"/>
-        <source>Your drivers are up to date</source>
-        <translation>驅動已是最新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="462"/>
-        <source>All drivers have been backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="464"/>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="506"/>
-        <source>A total of %1 drivers, of which %2 have been backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="502"/>
-        <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="505"/>
-        <source>You have %1 drivers that can be backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="550"/>
-        <source>Backing up the %1 driver, a total of %2 drivers</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="551"/>
-        <source>Backing up: %1</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="589"/>
-        <source>%1 drivers backed up, %2 drivers failed</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="591"/>
-        <source>Failed to backup drivers</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="593"/>
-        <source>%1 drivers backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="632"/>
-        <source>You have %1 drivers that can be restored</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="633"/>
-        <source>Please select a driver to restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="663"/>
-        <source>Driver is restoring...</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="664"/>
-        <source>Restoring: %1</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="807"/>
-        <source>reboot</source>
-        <translation>重啟電腦</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="808"/>
-        <source>Please %1 for the installed drivers to take effect</source>
-        <translation>驅動已安裝完成，請稍後%1生效</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="816"/>
-        <source>View backup path</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="829"/>
-        <source>Backup All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="811"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="286"/>
-        <source>submit feedback</source>
-        <translation>回饋</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="812"/>
-        <source>Please try again or %1 to us</source>
-        <translation>驅動未安裝成功，請重試或%1給我們</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="819"/>
-        <source>Install All</source>
-        <translation>一鍵安裝</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="824"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="290"/>
-        <source>Scan Again</source>
-        <translation>重新檢測</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
-        <source>Cancel</source>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="68"/>
-        <source>Scanning hardware device drivers, please wait...</source>
-        <translation>正在進行硬體驅動掃描，請耐心等待...</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="76"/>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="357"/>
-        <source>Scanning %1</source>
-        <translation>正在掃描%1</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="132"/>
-        <source>Scan failed</source>
-        <translation>檢測失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="190"/>
-        <source>Network unavailable</source>
-        <translation>無網路</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="194"/>
-        <source>Please check your network connection</source>
-        <translation>請檢查網路連接</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/DriverScanWidget.cpp" line="287"/>
-        <source>Please scan again or %1 to us</source>
-        <translation>請重新檢測或%1給我們</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="678"/>
-        <source>You are installing a driver, which will be interrupted if you exit.</source>
-        <translation>目前正在安裝驅動，退出應用後任務將會中斷</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="679"/>
-        <location filename="../src/Page/MainWindow.cpp" line="692"/>
-        <location filename="../src/Page/MainWindow.cpp" line="705"/>
-        <source>Are you sure you want to exit?</source>
-        <translation>確認是否退出應用？</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="682"/>
-        <location filename="../src/Page/MainWindow.cpp" line="695"/>
-        <location filename="../src/Page/MainWindow.cpp" line="708"/>
-        <source>Exit</source>
-        <comment>button</comment>
-        <translation>退 出</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="683"/>
-        <location filename="../src/Page/MainWindow.cpp" line="696"/>
-        <location filename="../src/Page/MainWindow.cpp" line="709"/>
-        <source>Cancel</source>
-        <comment>button</comment>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="691"/>
-        <source>You are backing up drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Page/MainWindow.cpp" line="704"/>
-        <source>You are restoring drivers, which will be interrupted if you exit.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="36"/>
-        <source>Bluetooth adapter</source>
-        <translation>藍牙適配器</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="37"/>
-        <location filename="../src/Tool/commontools.cpp" line="44"/>
-        <source>Imaging device</source>
-        <translation>圖像裝置</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="38"/>
-        <source>Display adapter</source>
-        <translation>顯示卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="40"/>
-        <source>Sound card</source>
-        <translation>音效卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="42"/>
-        <source>Network adapter</source>
-        <translation>網卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="46"/>
-        <source>Wireless network adapter</source>
-        <translation>無線網卡</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="66"/>
-        <source>Installation successful</source>
-        <translation>安裝成功</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="67"/>
-        <source>Installation failed</source>
-        <translation>安裝失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="68"/>
-        <source>Downloading</source>
-        <translation>下載中</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="69"/>
-        <source>Installing</source>
-        <translation>安裝中</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="70"/>
-        <source>Not installed</source>
-        <translation>驅動未安裝</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="71"/>
-        <source>Out-of-date</source>
-        <translation>驅動可更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="72"/>
-        <source>Waiting</source>
-        <translation>等待中</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="73"/>
-        <source>Not backed up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="74"/>
-        <source>Backing up</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="75"/>
-        <source>Backup failed</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="76"/>
-        <source>Backup successful</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="77"/>
-        <source>Restoring</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="81"/>
-        <source>Unknown error</source>
-        <translation>未知錯誤</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="82"/>
-        <source>Network error</source>
-        <translation>網路異常</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="83"/>
-        <source>Canceled</source>
-        <translation>已取消</translation>
-    </message>
-    <message>
-        <location filename="../src/Tool/commontools.cpp" line="84"/>
-        <source>Failed to get driver files</source>
-        <translation>驅動文件獲取異常</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="235"/>
-        <source>Update</source>
-        <translation>更新</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="240"/>
-        <source>Backup</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="245"/>
-        <source>Restore</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/Widget/driveritem.cpp" line="231"/>
-        <source>Install</source>
-        <translation>安装</translation>
-    </message>
-    <message>
-        <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
-        <source>Overview</source>
-        <translation>概況</translation>
-    </message>
-</context>
-<context>
-    <name>TableWidget</name>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="35"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="208"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="36"/>
-        <source>Refresh</source>
-        <translation>重新整理</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="37"/>
-        <source>Export</source>
-        <translation>匯出</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="38"/>
-        <source>Update drivers</source>
-        <translation>更新驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="39"/>
-        <source>Uninstall drivers</source>
-        <translation>移除驅動</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="40"/>
-        <source>Allow it to wake the computer</source>
-        <translation>允許喚起電腦</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TableWidget.cpp" line="213"/>
-        <location filename="../src/Widget/TableWidget.cpp" line="320"/>
-        <source>Enable</source>
-        <translation>啟用</translation>
-    </message>
-</context>
-<context>
-    <name>TextBrowser</name>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="29"/>
-        <source>Refresh</source>
-        <translation>重新整理</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="30"/>
-        <source>Export</source>
-        <translation>匯出</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="31"/>
-        <source>Copy</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="240"/>
-        <source>Disable</source>
-        <translation>禁用</translation>
-    </message>
-    <message>
-        <location filename="../src/Widget/TextBrowser.cpp" line="248"/>
-        <source>Unavailable</source>
-        <translation>不可用</translation>
-    </message>
-</context>
-<context>
-    <name>UrlChooserEdit</name>
-    <message>
-        <location filename="../src/Widget/UrlChooserEdit.cpp" line="89"/>
-        <source>Select a local folder please</source>
-        <translation>請選擇本機資料夾</translation>
-    </message>
-</context>
-<context>
-    <name>WaitingWidget</name>
-    <message>
-        <location filename="../src/Page/WaitingWidget.cpp" line="20"/>
-        <source>Loading...</source>
-        <translation>正在載入...</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="zh_TW" version="2.1">
+    <context>
+        <name>BtnLabel</name>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="44"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="45"/>
+            <source>Feedback</source>
+            <translation>反饋</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="57"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+            <comment>button</comment>
+        </message>
+    </context>
+    <context>
+        <name>BtnWidget</name>
+        <message>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="169"/>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="398"/>
+            <source>More</source>
+            <translation type="unfinished">更多</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="173"/>
+            <location filename="../src/Widget/DetailTreeView.cpp" line="405"/>
+            <source>Collapse</source>
+            <translation type="unfinished">收起</translation>
+        </message>
+    </context>
+    <context>
+        <name>CmdButtonWidget</name>
+        <message>
+            <location filename="../src/Widget/CmdButtonWidget.cpp" line="25"/>
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommonTools</name>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="85"/>
+            <source>EC_NOTIFY_NETWORK</source>
+            <translation>EC_NOTIFY_NETWORK</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="86"/>
+            <source>EC_REINSTALL</source>
+            <translation>EC_REINSTALL</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="87"/>
+            <source>EC_6</source>
+            <translation>EC_6</translation>
+        </message>
+    </context>
+    <context>
+        <name>DetailButton</name>
+        <message>
+            <location filename="../src/Page/PageDetail.cpp" line="47"/>
+            <location filename="../src/Page/PageDetail.cpp" line="50"/>
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDetail.cpp" line="48"/>
+            <source>Collapse</source>
+            <translation>收起</translation>
+        </message>
+    </context>
+    <context>
+        <name>DetailViewDelegate</name>
+        <message>
+            <location filename="../src/Widget/DetailViewDelegate.cpp" line="233"/>
+            <location filename="../src/Widget/DetailViewDelegate.cpp" line="244"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetailViewDelegate.cpp" line="236"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceAudio</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="321"/>
+            <source>Device Name</source>
+            <translation>裝置名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="342"/>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="366"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="343"/>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="367"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="355"/>
+            <source>Chip</source>
+            <translation>晶片</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="356"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="353"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="354"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="344"/>
+            <source>SysFS_Path</source>
+            <translation>SysFS_Path</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="345"/>
+            <source>Description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="346"/>
+            <source>Revision</source>
+            <translation>修訂版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="347"/>
+            <source>KernelModeDriver</source>
+            <translation>KernelModeDriver</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="357"/>
+            <source>Memory Address</source>
+            <translation>記憶體地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="358"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="376"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="380"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceBaseInfo</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="625"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="626"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="627"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceBios</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="253"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="254"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="255"/>
+            <source>Chipset</source>
+            <translation>晶片組</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceBluetooth</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="251"/>
+            <source>Alias</source>
+            <translation>別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="252"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="253"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="254"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="255"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="261"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="262"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="263"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="264"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="265"/>
+            <source>Driver Version</source>
+            <translation>驅動版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="266"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="267"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="268"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="269"/>
+            <source>Logical Name</source>
+            <translation>邏輯名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="270"/>
+            <source>MAC Address</source>
+            <translation>物理地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="282"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="286"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceCdrom</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="137"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="138"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="139"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="140"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="141"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="142"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="143"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="144"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="145"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="150"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="151"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="162"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="166"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceComputer</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceComputer.cpp" line="170"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceCpu</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="75"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="299"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="76"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="300"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="77"/>
+            <source>CPU ID</source>
+            <translation>處理器ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="78"/>
+            <source>Core ID</source>
+            <translation>核心ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="79"/>
+            <source>Threads</source>
+            <translation>執行緒數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="82"/>
+            <source>BogoMIPS</source>
+            <translation>BogoMIPS</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="83"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="302"/>
+            <source>Architecture</source>
+            <translation>架構</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="84"/>
+            <source>CPU Family</source>
+            <translation>家族</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="85"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="115"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="130"/>
+            <source>Processor</source>
+            <translation>邏輯處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="128"/>
+            <source>Core(s)</source>
+            <translation>核</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="282"/>
+            <source>Virtualization</source>
+            <translation>虛擬化</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="283"/>
+            <source>Flags</source>
+            <translation>特性</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="284"/>
+            <source>Extensions</source>
+            <translation>擴展指令集</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="285"/>
+            <source>L4 Cache</source>
+            <translation>L4 快取</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="286"/>
+            <source>L3 Cache</source>
+            <translation>L3快取</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="287"/>
+            <source>L2 Cache</source>
+            <translation>L2快取</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="288"/>
+            <source>L1i Cache</source>
+            <translation>L1快取（指令）</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="289"/>
+            <source>L1d Cache</source>
+            <translation>L1快取（數據）</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="290"/>
+            <source>Stepping</source>
+            <translation>步進</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="81"/>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="301"/>
+            <source>Max Speed</source>
+            <translation>最大頻率</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceGpu</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="66"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="67"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="68"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="69"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="70"/>
+            <source>Graphics Memory</source>
+            <translation>視訊記憶體</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="345"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="346"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="347"/>
+            <source>Memory Address</source>
+            <translation>記憶體地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="348"/>
+            <source>IO Port</source>
+            <translation>I/O埠</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="349"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="351"/>
+            <source>Maximum Resolution</source>
+            <translation>最大解析度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="352"/>
+            <source>Minimum Resolution</source>
+            <translation>最小解析度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="354"/>
+            <source>Current Resolution</source>
+            <translation>目前解析度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="355"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="356"/>
+            <source>Description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="358"/>
+            <source>DP</source>
+            <translation>DP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="359"/>
+            <source>eDP</source>
+            <translation>eDP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="360"/>
+            <source>HDMI</source>
+            <translation>HDMI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="361"/>
+            <source>VGA</source>
+            <translation>VGA</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="362"/>
+            <source>DVI</source>
+            <translation>DVI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="363"/>
+            <source>DigitalOutput</source>
+            <translation>DigitalOutput</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="364"/>
+            <source>Display Output</source>
+            <translation>顯示輸出</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="365"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="366"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="378"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceImage</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="174"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="175"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="176"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="177"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="178"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="184"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="185"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="186"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="187"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="188"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="189"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="191"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="203"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceImage.cpp" line="207"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceInput</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="537"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="538"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="539"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="540"/>
+            <source>Interface</source>
+            <translation>介面</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="541"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="547"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="548"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="549"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="550"/>
+            <source>Maximum Current</source>
+            <translation>最大電流</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="551"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="552"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="553"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="565"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="569"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceManager</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="148"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="289"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1489"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1509"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1530"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1541"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1555"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1568"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1583"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1599"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="154"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="267"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1685"/>
+            <source>CPU</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="159"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1688"/>
+            <source>CPU quantity</source>
+            <translation>CPU數量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="170"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="268"/>
+            <source>Motherboard</source>
+            <translation>主機板</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="175"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="269"/>
+            <source>Memory</source>
+            <translation>記憶體</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="180"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="270"/>
+            <source>Display Adapter</source>
+            <translation>顯示適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="185"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="271"/>
+            <source>Sound Adapter</source>
+            <translation>音訊適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="190"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="272"/>
+            <source>Storage</source>
+            <translation>儲存裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="195"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="273"/>
+            <source>Other PCI Devices</source>
+            <translation>其他PCI裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="200"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="274"/>
+            <source>Battery</source>
+            <translation>電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="211"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="275"/>
+            <source>Bluetooth</source>
+            <translation>藍牙</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="216"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="276"/>
+            <source>Network Adapter</source>
+            <translation>網路適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="227"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="277"/>
+            <source>Mouse</source>
+            <translation>滑鼠</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="232"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="278"/>
+            <source>Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="242"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="279"/>
+            <source>Monitor</source>
+            <translation>顯示裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="246"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="280"/>
+            <source>CD-ROM</source>
+            <translation>光碟機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="250"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="281"/>
+            <source>Printer</source>
+            <translation>印表機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="254"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="282"/>
+            <source>Camera</source>
+            <translation>圖像裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="258"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="283"/>
+            <source>Other Devices</source>
+            <translation>其他裝置</translation>
+            <comment>Other Input Devices</comment>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1495"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1559"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1590"/>
+            <source>Device</source>
+            <translation>裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1503"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1563"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1594"/>
+            <source>OS</source>
+            <translation>操作系統</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceMemory</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="146"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="177"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="147"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="178"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="148"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="181"/>
+            <source>Size</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="149"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="179"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="150"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="180"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="151"/>
+            <source>Total Width</source>
+            <translation>總位寬</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="152"/>
+            <source>Locator</source>
+            <translation>插槽</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="153"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="161"/>
+            <source>Configured Voltage</source>
+            <translation>配置電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="162"/>
+            <source>Maximum Voltage</source>
+            <translation>最高電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="163"/>
+            <source>Minimum Voltage</source>
+            <translation>最低電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="164"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="166"/>
+            <source>Configured Speed</source>
+            <translation>配置頻率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="168"/>
+            <source>Data Width</source>
+            <translation>數據位寬</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceMonitor</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="331"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="332"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="333"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="334"/>
+            <source>Display Input</source>
+            <translation>顯示輸入</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="335"/>
+            <source>Interface Type</source>
+            <translation>介面類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="341"/>
+            <source>Support Resolution</source>
+            <translation>支持解析度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="343"/>
+            <source>Current Resolution</source>
+            <translation>目前解析度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="344"/>
+            <source>Display Ratio</source>
+            <translation>顯示比例</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="346"/>
+            <source>Primary Monitor</source>
+            <translation>主顯示器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="347"/>
+            <source>Size</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="348"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceNetwork</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="294"/>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="333"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="295"/>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="334"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="296"/>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="335"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="297"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="298"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="299"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="300"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="301"/>
+            <source>Driver Version</source>
+            <translation>驅動版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="307"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="308"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="309"/>
+            <source>Maximum Rate</source>
+            <translation>最大速率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="310"/>
+            <source>Negotiation Rate</source>
+            <translation>協商速率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="311"/>
+            <source>Port</source>
+            <translation>埠</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="312"/>
+            <source>Multicast</source>
+            <translation>組播</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="313"/>
+            <source>Link</source>
+            <translation>連結</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="314"/>
+            <source>Latency</source>
+            <translation>延遲</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="315"/>
+            <source>IP</source>
+            <translation>IP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="316"/>
+            <source>Firmware</source>
+            <translation>韌體</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="317"/>
+            <source>Duplex</source>
+            <translation>雙工</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="318"/>
+            <source>Broadcast</source>
+            <translation>廣播</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="319"/>
+            <source>Auto Negotiation</source>
+            <translation>自動協商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="322"/>
+            <source>Memory Address</source>
+            <translation>記憶體地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="323"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="324"/>
+            <source>MAC Address</source>
+            <translation>物理地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="325"/>
+            <source>Logical Name</source>
+            <translation>邏輯名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="344"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="348"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceOtherPCI</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="74"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="75"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="76"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="77"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="78"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="84"/>
+            <source>Input/Output</source>
+            <translation>輸入/輸出</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="85"/>
+            <source>Memory</source>
+            <translation>記憶體</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="86"/>
+            <source>IRQ</source>
+            <translation>中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="87"/>
+            <source>Latency</source>
+            <translation>延遲</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="90"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOtherPCI.cpp" line="91"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceOthers</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="184"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="185"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="186"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="187"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="188"/>
+            <source>Bus Info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="189"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="190"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="191"/>
+            <source>Maximum Power</source>
+            <translation>最大功率</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="192"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="198"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="207"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="210"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DevicePower</name>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="178"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="179"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="180"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="181"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="182"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="183"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="184"/>
+            <source>Capacity</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="185"/>
+            <source>Voltage</source>
+            <translation>電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="186"/>
+            <source>Slot</source>
+            <translation>插槽</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="187"/>
+            <source>Design Capacity</source>
+            <translation>設計容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="188"/>
+            <source>Design Voltage</source>
+            <translation>設計電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="189"/>
+            <source>SBDS Version</source>
+            <translation>SBDS版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="190"/>
+            <source>SBDS Serial Number</source>
+            <translation>SBDS序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="191"/>
+            <source>SBDS Manufacture Date</source>
+            <translation>SBDS製造日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="192"/>
+            <source>SBDS Chemistry</source>
+            <translation>SBDS材料</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="193"/>
+            <source>Temperature</source>
+            <translation>溫度</translation>
+        </message>
+    </context>
+    <context>
+        <name>DevicePrint</name>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="150"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="151"/>
+            <source>Model</source>
+            <translation>型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="152"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="153"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="159"/>
+            <source>Shared</source>
+            <translation>已共享</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="160"/>
+            <source>URI</source>
+            <translation>URI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="161"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="162"/>
+            <source>Interface Type</source>
+            <translation>介面類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="173"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeviceStorage</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="645"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="687"/>
+            <source>Vendor</source>
+            <translation>製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="646"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="688"/>
+            <source>Media Type</source>
+            <translation>介質類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="647"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="689"/>
+            <source>Size</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="644"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="686"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="648"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="649"/>
+            <source>Capabilities</source>
+            <translation>功能</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="672"/>
+            <source>Module Alias</source>
+            <translation>模組別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="673"/>
+            <source>Physical ID</source>
+            <translation>物理ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="655"/>
+            <source>Firmware Version</source>
+            <translation>韌體版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="656"/>
+            <source>Speed</source>
+            <translation>速度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="657"/>
+            <source>Description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="669"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="670"/>
+            <source>Interface</source>
+            <translation>介面</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="671"/>
+            <source>Rotation Rate</source>
+            <translation>轉速</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="697"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>GetDriverNameWidget</name>
+        <message>
+            <location filename="../src/Widget/GetDriverNameWidget.cpp" line="58"/>
+            <location filename="../src/Widget/GetDriverNameWidget.cpp" line="143"/>
+            <source>Select a driver for update</source>
+            <translation>選擇需要更新的驅動程式</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/GetDriverNameWidget.cpp" line="137"/>
+            <source>No drivers found in this folder</source>
+            <translation>所選資料夾未檢測到驅動文件</translation>
+        </message>
+    </context>
+    <context>
+        <name>GetInfoPool</name>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="86"/>
+            <source>Loading Audio Device Info...</source>
+            <translation>獲取音訊裝置訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="89"/>
+            <source>Loading BIOS Info...</source>
+            <translation>獲取BIOS訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="99"/>
+            <source>Loading CD-ROM Info...</source>
+            <translation>獲取光碟機訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="104"/>
+            <source>Loading Operating System Info...</source>
+            <translation>獲取操作系統訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="107"/>
+            <source>Loading CPU Info...</source>
+            <translation>獲取處理器訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="108"/>
+            <source>Loading Other Devices Info...</source>
+            <translation>獲取其他裝置訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="109"/>
+            <source>Loading Power Info...</source>
+            <translation>獲取電池訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="110"/>
+            <source>Loading Printer Info...</source>
+            <translation>獲取印表機訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="113"/>
+            <source>Loading Mouse Info...</source>
+            <translation>獲取滑鼠訊息...</translation>
+        </message>
+        <message>
+            <location filename="../src/GenerateDevice/GetInfoPool.cpp" line="114"/>
+            <source>Loading Network Adapter Info...</source>
+            <translation>獲取網路適配器訊息...</translation>
+        </message>
+    </context>
+    <context>
+        <name>LogTreeView</name>
+        <message>
+            <location filename="../src/Widget/logtreeview.cpp" line="87"/>
+            <location filename="../src/Widget/logtreeview.cpp" line="123"/>
+            <location filename="../src/Widget/logtreeview.cpp" line="125"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/logtreeview.cpp" line="104"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>LogViewItemDelegate</name>
+        <message>
+            <location filename="../src/Widget/logviewitemdelegate.cpp" line="112"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/logviewitemdelegate.cpp" line="114"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>MainWindow</name>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="250"/>
+            <source>Device Info</source>
+            <translation>裝置訊息</translation>
+            <comment>export file's name</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="321"/>
+            <source>Display shortcuts</source>
+            <translation>顯示快捷鍵</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="322"/>
+            <source>Close</source>
+            <translation>關閉</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="323"/>
+            <source>Help</source>
+            <translation>說明</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="324"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="328"/>
+            <source>System</source>
+            <translation>系統</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="335"/>
+            <source>Export</source>
+            <translation>匯出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="336"/>
+            <source>Refresh</source>
+            <translation>重新整理</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="340"/>
+            <source>Device Manager</source>
+            <translation>裝置管理器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="409"/>
+            <source>Hardware</source>
+            <translation>硬體訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="409"/>
+            <source>Drivers</source>
+            <translation>驅動管理</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="561"/>
+            <source>Monitor</source>
+            <translation>顯示裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="561"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="565"/>
+            <source>Display Adapter</source>
+            <translation>顯示適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="569"/>
+            <source>CPU</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="573"/>
+            <source>Network Adapter</source>
+            <translation>網路適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="579"/>
+            <source>Battery</source>
+            <translation>電池</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDetail</name>
+        <message>
+            <location filename="../src/Page/PageDetail.cpp" line="319"/>
+            <source>More</source>
+            <translation>更多</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverBackupInfo</name>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="96"/>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+            <source>Current Version</source>
+            <translation>目前版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="97"/>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="108"/>
+            <source>Driver Platform Version</source>
+            <translation>驅動平臺版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="98"/>
+            <source>Action</source>
+            <translation>操作</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="186"/>
+            <source>Backupable Drivers</source>
+            <translation>可備份驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverBackupInfo.cpp" line="187"/>
+            <source>Backed up Drivers</source>
+            <translation>已備份驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverControl</name>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="105"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="240"/>
+            <source>Updating</source>
+            <translation>正在更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="110"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="132"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="193"/>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="111"/>
+            <source>Next</source>
+            <translation>下一步</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+            <source>Warning</source>
+            <translation>注意</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="129"/>
+            <source>The device will be unavailable after the driver uninstallation</source>
+            <translation>將從系統中移除此驅動程式，移除後該裝置不可用</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="133"/>
+            <source>Uninstall</source>
+            <translation>卸 載</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="137"/>
+            <source>Uninstalling</source>
+            <translation>正在移除</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+            <source>Update successful</source>
+            <translation>驅動更新成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="165"/>
+            <source>Uninstallation successful</source>
+            <translation>驅動移除成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+            <source>Update failed</source>
+            <translation>驅動更新失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="166"/>
+            <source>Uninstallation failed</source>
+            <translation>驅動移除失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="173"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="192"/>
+            <source>Next</source>
+            <translation>下一步</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="213"/>
+            <source>The selected folder does not exist, please select again</source>
+            <translation>所選資料夾不存在，請重新選擇</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="218"/>
+            <source>Update</source>
+            <translation>更 新</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="219"/>
+            <source>Previous</source>
+            <translation>上一步</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="254"/>
+            <source>Broken package</source>
+            <translation>包文件損壞</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="259"/>
+            <source>Unmatched package architecture</source>
+            <translation>包文件與系統架構不匹配</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="265"/>
+            <location filename="../src/Page/PageDriverControl.cpp" line="349"/>
+            <source>The selected file does not exist, please select again</source>
+            <translation>所選文件不存在，請重新選擇</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="350"/>
+            <source>It is not a driver</source>
+            <translation>該文件不是驅動文件</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="351"/>
+            <source>Unable to install - no digital signature</source>
+            <translation>無法安裝，安裝包無數位簽章</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="345"/>
+            <source>Unknown error</source>
+            <translation>未知錯誤</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="346"/>
+            <source>The driver module was not found</source>
+            <translation>未發現該驅動模組</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="347"/>
+            <source>Invalid module format</source>
+            <translation>模塊格式無效</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverControl.cpp" line="348"/>
+            <source>The driver module has dependencies</source>
+            <translation>驅動模組被依賴</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverInstallInfo</name>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="106"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="119"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+            <source>Device Name</source>
+            <translation>裝置名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="107"/>
+            <source>Version Available</source>
+            <translation>可安裝版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="108"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="121"/>
+            <source>Size</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="109"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="122"/>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="110"/>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="123"/>
+            <source>Action</source>
+            <translation>操作</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="120"/>
+            <source>New Version</source>
+            <translation>可更新版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="132"/>
+            <source>Current Version</source>
+            <translation>目前版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="219"/>
+            <source>Missing drivers (%1)</source>
+            <translation>可安裝驅動 (%1)</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="220"/>
+            <source>Outdated drivers (%1)</source>
+            <translation>可更新驅動 (%1)</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverInstallInfo.cpp" line="221"/>
+            <source>Up-to-date drivers (%1)</source>
+            <translation>無需更新驅動 (%1)</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverManager</name>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="62"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="116"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="494"/>
+            <source>Driver Install</source>
+            <translation>驅動安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="100"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="101"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="117"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="496"/>
+            <source>Driver Backup</source>
+            <translation>驅動備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="118"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="498"/>
+            <source>Driver Restore</source>
+            <translation>驅動還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="637"/>
+            <source>OK</source>
+            <translation>確 定</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="638"/>
+            <source>Feedback</source>
+            <translation>反饋</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageDriverRestoreInfo</name>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="97"/>
+            <source>You do not have any drivers to restore, please backup first</source>
+            <translation>您沒有驅動可以還原，請先備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="100"/>
+            <source>Go to Backup Driver</source>
+            <translation>前往備份驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="126"/>
+            <source>Name</source>
+            <translation>名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="127"/>
+            <source>Current Version</source>
+            <translation>目前版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="128"/>
+            <source>Backup Version</source>
+            <translation>備份版本</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="129"/>
+            <source>Action</source>
+            <translation>操作</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverRestoreInfo.cpp" line="174"/>
+            <source>Restorable Drivers</source>
+            <translation>可還原驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageListView</name>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="24"/>
+            <source>Refresh</source>
+            <translation>重新整理</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="25"/>
+            <source>Export</source>
+            <translation>匯出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="27"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="123"/>
+            <source>Driver Install</source>
+            <translation>驅動安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="123"/>
+            <source>Driver Backup</source>
+            <translation>驅動備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageListView.cpp" line="123"/>
+            <source>Driver Restore</source>
+            <translation>驅動還原</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageMultiInfo</name>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="168"/>
+            <source>Failed to enable the device</source>
+            <translation>啟用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="171"/>
+            <source>Failed to disable the device</source>
+            <translation>禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="176"/>
+            <source>Failed to disable it: unable to get the device SN</source>
+            <translation>無法獲取裝置序號，禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="200"/>
+            <source>Update Drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageMultiInfo.cpp" line="220"/>
+            <source>Uninstall Drivers</source>
+            <translation>移除驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageOverview</name>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="42"/>
+            <source>Refresh</source>
+            <translation>重新整理</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="43"/>
+            <source>Export</source>
+            <translation>匯出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="44"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageOverview.cpp" line="89"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+    </context>
+    <context>
+        <name>PageSingleInfo</name>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="42"/>
+            <source>Refresh</source>
+            <translation>重新整理</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="43"/>
+            <source>Export</source>
+            <translation>匯出</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="44"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="45"/>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="213"/>
+            <source>Enable</source>
+            <translation>啟用</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="46"/>
+            <source>Update drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="47"/>
+            <source>Uninstall drivers</source>
+            <translation>移除驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="48"/>
+            <source>Allow it to wake the computer</source>
+            <translation>允許喚起電腦</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="215"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="298"/>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="315"/>
+            <source>Failed to disable it: unable to get the device SN</source>
+            <translation>無法獲取裝置序號，禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="302"/>
+            <source>Failed to disable the device</source>
+            <translation>禁用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="319"/>
+            <source>Failed to enable the device</source>
+            <translation>啟用失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="336"/>
+            <source>Update Drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageSingleInfo.cpp" line="355"/>
+            <source>Uninstall Drivers</source>
+            <translation>移除驅動</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="322"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="45"/>
+            <source>SubVendor</source>
+            <translation>子製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="323"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="46"/>
+            <source>SubDevice</source>
+            <translation>子裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="336"/>
+            <source>Driver</source>
+            <translation>驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="324"/>
+            <source>Driver Status</source>
+            <translation>驅動狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="325"/>
+            <source>Driver Activation Cmd</source>
+            <translation>驅動啟動指令</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="326"/>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="123"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="48"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="635"/>
+            <source>Config Status</source>
+            <translation>配置狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="327"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="49"/>
+            <source>latency</source>
+            <translation>延遲</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="328"/>
+            <source>Phys</source>
+            <translation>Phys</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="329"/>
+            <source>Sysfs</source>
+            <translation>Sysfs</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="330"/>
+            <source>Handlers</source>
+            <translation>處理程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="331"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="523"/>
+            <source>PROP</source>
+            <translation>PROP</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="332"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="524"/>
+            <source>EV</source>
+            <translation>EV</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="333"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="525"/>
+            <source>KEY</source>
+            <translation>KEY</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="335"/>
+            <source>Version</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceAudio.cpp" line="334"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="155"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="218"/>
+            <source>Bus</source>
+            <translation>匯流排</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="48"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="236"/>
+            <source>BIOS Information</source>
+            <translation>BIOS訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="72"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="237"/>
+            <source>Base Board Information</source>
+            <translation>主機板訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="94"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="238"/>
+            <source>System Information</source>
+            <translation>系統訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="110"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="239"/>
+            <source>Chassis Information</source>
+            <translation>機箱訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="126"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="240"/>
+            <source>Physical Memory Array</source>
+            <translation>物理記憶體陣列</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="186"/>
+            <source>Release Date</source>
+            <translation>發布日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="187"/>
+            <source>Address</source>
+            <translation>地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="188"/>
+            <source>Runtime Size</source>
+            <translation>運行內存大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="189"/>
+            <source>ROM Size</source>
+            <translation>ROM大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="190"/>
+            <source>Characteristics</source>
+            <translation>特性</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="191"/>
+            <source>BIOS Revision</source>
+            <translation>BIOS修訂版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="192"/>
+            <source>Firmware Revision</source>
+            <translation>韌體修訂版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="194"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="203"/>
+            <source>Product Name</source>
+            <translation>產品名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="195"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="204"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="213"/>
+            <source>Serial Number</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="196"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="214"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="127"/>
+            <source>Asset Tag</source>
+            <translation>資產編號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="197"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="222"/>
+            <source>Features</source>
+            <translation>特徵</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="198"/>
+            <source>Location In Chassis</source>
+            <translation>機箱內位置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="199"/>
+            <source>Chassis Handle</source>
+            <translation>機箱程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="200"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="211"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="201"/>
+            <source>Contained Object Handles</source>
+            <translation>包含對象程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="205"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="243"/>
+            <source>UUID</source>
+            <translation>UUID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="206"/>
+            <source>Wake-up Type</source>
+            <translation>喚醒類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="207"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="223"/>
+            <source>SKU Number</source>
+            <translation>SKU號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="208"/>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="234"/>
+            <source>Family</source>
+            <translation>家族</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="212"/>
+            <source>Lock</source>
+            <translation>鎖</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="215"/>
+            <source>Boot-up State</source>
+            <translation>開機狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="216"/>
+            <source>Power Supply State</source>
+            <translation>供電狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="217"/>
+            <source>Thermal State</source>
+            <translation>散熱狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="218"/>
+            <source>Security Status</source>
+            <translation>安全狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="219"/>
+            <source>OEM Information</source>
+            <translation>OEM訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="220"/>
+            <source>Height</source>
+            <translation>高度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="221"/>
+            <source>Number Of Power Cords</source>
+            <translation>電源線數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="222"/>
+            <source>Contained Elements</source>
+            <translation>包含組件數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="225"/>
+            <source>Location</source>
+            <translation>位置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="226"/>
+            <source>Error Correction Type</source>
+            <translation>糾錯類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="227"/>
+            <source>Maximum Capacity</source>
+            <translation>最大容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="228"/>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="122"/>
+            <source>Error Information Handle</source>
+            <translation>錯誤訊息程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="229"/>
+            <source>Number Of Devices</source>
+            <translation>插槽</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="231"/>
+            <source>BIOS ROMSIZE</source>
+            <translation>BIOS ROM大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="232"/>
+            <source>Release date</source>
+            <translation>發布日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="233"/>
+            <source>Board name</source>
+            <translation>主機板名稱</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="242"/>
+            <source>SMBIOS Version</source>
+            <translation>SMBIOS版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="244"/>
+            <source>Language Description Format</source>
+            <translation>語言描述格式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="245"/>
+            <source>Installable Languages</source>
+            <translation>可安裝語言數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBios.cpp" line="246"/>
+            <source>Currently Installed Language</source>
+            <translation>當前安裝語言</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="219"/>
+            <source>BD Address</source>
+            <translation>藍牙裝置地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="220"/>
+            <source>ACL MTU</source>
+            <translation>ACL MTU</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="221"/>
+            <source>SCO MTU</source>
+            <translation>SCO MTU</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="223"/>
+            <source>Packet type</source>
+            <translation>封包類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="224"/>
+            <source>Link policy</source>
+            <translation>連接策略</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="225"/>
+            <source>Link mode</source>
+            <translation>連接模式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="226"/>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="239"/>
+            <source>Class</source>
+            <translation>類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="227"/>
+            <source>Service Classes</source>
+            <translation>服務類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="228"/>
+            <source>Device Class</source>
+            <translation>裝置類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="229"/>
+            <source>HCI Version</source>
+            <translation>HCI版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="230"/>
+            <source>LMP Version</source>
+            <translation>LMP版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="231"/>
+            <source>Subversion</source>
+            <translation>子版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="233"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="44"/>
+            <source>Device</source>
+            <translation>裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="234"/>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="117"/>
+            <source>Serial ID</source>
+            <translation>序號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="236"/>
+            <source>product</source>
+            <translation>產品</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="237"/>
+            <source>description</source>
+            <translation>描述</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="240"/>
+            <source>Powered</source>
+            <translation>供電</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="241"/>
+            <source>Discoverable</source>
+            <translation>可發現</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="242"/>
+            <source>Pairable</source>
+            <translation>可配對</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="244"/>
+            <source>Modalias</source>
+            <translation>設置命令別名</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceBluetooth.cpp" line="245"/>
+            <source>Discovering</source>
+            <translation>搜索中</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="118"/>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="47"/>
+            <source>Driver Modules</source>
+            <translation>驅動模組</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="119"/>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="527"/>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="177"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="528"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="627"/>
+            <source>Device File</source>
+            <translation>裝置文件</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="120"/>
+            <source>Device Files</source>
+            <translation>裝置文件</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="121"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="530"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="636"/>
+            <source>Device Number</source>
+            <translation>裝置編號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="124"/>
+            <source>Application</source>
+            <translation>應用</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="127"/>
+            <source>status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="128"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="531"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="630"/>
+            <source>logical name</source>
+            <translation>邏輯地址</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCdrom.cpp" line="130"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="628"/>
+            <source>ansiversion</source>
+            <translation>ANSI版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="63"/>
+            <source>CPU implementer</source>
+            <translation>CPU程式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="64"/>
+            <source>CPU architecture</source>
+            <translation>CPU架構</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="65"/>
+            <source>CPU variant</source>
+            <translation>CPU變數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="66"/>
+            <source>CPU part</source>
+            <translation>CPU部件</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="67"/>
+            <source>CPU revision</source>
+            <translation>CPU版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="317"/>
+            <source>One</source>
+            <translation>單</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="318"/>
+            <source>Two</source>
+            <translation>雙</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="319"/>
+            <source>Four</source>
+            <translation>四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="320"/>
+            <source>Six</source>
+            <translation>六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="321"/>
+            <source>Eight</source>
+            <translation>八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="322"/>
+            <source>Nine</source>
+            <translation>九</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="323"/>
+            <source>Ten</source>
+            <translation>十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="324"/>
+            <source>Twelve</source>
+            <translation>十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="325"/>
+            <source>Fourteen</source>
+            <translation>十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="326"/>
+            <source>Sixteen</source>
+            <translation>十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="327"/>
+            <source>Eighteen</source>
+            <translation>十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="329"/>
+            <source>Twenty</source>
+            <translation>二十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="330"/>
+            <source>Twenty-two</source>
+            <translation>二十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="331"/>
+            <source>Twenty-four</source>
+            <translation>二十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="332"/>
+            <source>Twenty-six</source>
+            <translation>二十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="333"/>
+            <source>Twenty-eight</source>
+            <translation>二十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="335"/>
+            <source>Thirty</source>
+            <translation>三十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="336"/>
+            <source>Thirty-two</source>
+            <translation>三十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="337"/>
+            <source>Thirty-four</source>
+            <translation>三十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="338"/>
+            <source>Thirty-six</source>
+            <translation>三十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="339"/>
+            <source>Thirty-eight</source>
+            <translation>三十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="341"/>
+            <source>Forty</source>
+            <translation>四十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="342"/>
+            <source>Forty-two</source>
+            <translation>四十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="343"/>
+            <source>Forty-four</source>
+            <translation>四十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="344"/>
+            <source>Forty-six</source>
+            <translation>四十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="345"/>
+            <source>Forty-eight</source>
+            <translation>四十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="347"/>
+            <source>Fifty</source>
+            <translation>五十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="348"/>
+            <source>Fifty-two</source>
+            <translation>五十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="349"/>
+            <source>Fifty-four</source>
+            <translation>五十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="350"/>
+            <source>Fifty-six</source>
+            <translation>五十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="351"/>
+            <source>Fifty-eight</source>
+            <translation>五十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="353"/>
+            <source>Sixty</source>
+            <translation>六十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="354"/>
+            <source>Sixty-two</source>
+            <translation>六十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="355"/>
+            <source>Sixty-four</source>
+            <translation>六十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="356"/>
+            <source>Sixty-six</source>
+            <translation>六十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="357"/>
+            <source>Sixty-eight</source>
+            <translation>六十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="359"/>
+            <source>Seventy</source>
+            <translation>七十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="360"/>
+            <source>Seventy-two</source>
+            <translation>七十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="361"/>
+            <source>Seventy-four</source>
+            <translation>七十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="362"/>
+            <source>Seventy-six</source>
+            <translation>七十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="363"/>
+            <source>Seventy-eight</source>
+            <translation>七十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="365"/>
+            <source>Eighty</source>
+            <translation>八十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="366"/>
+            <source>Eighty-two</source>
+            <translation>八十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="367"/>
+            <source>Eighty-four</source>
+            <translation>八十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="368"/>
+            <source>Eighty-six</source>
+            <translation>八十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="369"/>
+            <source>Eighty-eight</source>
+            <translation>八十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="371"/>
+            <source>Ninety</source>
+            <translation>九十</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="372"/>
+            <source>Ninety-two</source>
+            <translation>九十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="373"/>
+            <source>Ninety-four</source>
+            <translation>九十四</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="374"/>
+            <source>Ninety-six</source>
+            <translation>九十六</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="375"/>
+            <source>Ninety-eight</source>
+            <translation>九十八</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="377"/>
+            <source>One hundred</source>
+            <translation>100</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="378"/>
+            <source>One hundred and Two</source>
+            <translation>102</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="379"/>
+            <source>One hundred and four</source>
+            <translation>104</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="380"/>
+            <source>One hundred and Six</source>
+            <translation>106</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="381"/>
+            <source>One hundred and Eight</source>
+            <translation>108</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="383"/>
+            <source>One hundred and Ten</source>
+            <translation>110</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="384"/>
+            <source>One hundred and Twelve</source>
+            <translation>112</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="385"/>
+            <source>One hundred and Fourteen</source>
+            <translation>114</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="386"/>
+            <source>One hundred and Sixteen</source>
+            <translation>116</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="387"/>
+            <source>One hundred and Eighteen</source>
+            <translation>118</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="389"/>
+            <source>One hundred and Twenty</source>
+            <translation>120</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="390"/>
+            <source>One hundred and Twenty-two</source>
+            <translation>122</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="391"/>
+            <source>One hundred and Twenty-four</source>
+            <translation>124</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="392"/>
+            <source>One hundred and Twenty-six</source>
+            <translation>126</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="393"/>
+            <source>One hundred and Twenty-eight</source>
+            <translation>128</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="394"/>
+            <source>One hundred and Ninety-two</source>
+            <translation>一百九十二</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceCpu.cpp" line="395"/>
+            <source>Two hundred and fifty-six</source>
+            <translation>256</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="52"/>
+            <source>GDDR capacity</source>
+            <translation>GDDR容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="53"/>
+            <source>GPU vendor</source>
+            <translation>GPU供應商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="54"/>
+            <source>GPU type</source>
+            <translation>GPU類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="55"/>
+            <source>EGL version</source>
+            <translation>EGL版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="56"/>
+            <source>EGL client APIs</source>
+            <translation>EGL介面</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="57"/>
+            <source>GL version</source>
+            <translation>GL版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceGpu.cpp" line="58"/>
+            <source>GLSL version</source>
+            <translation>GLSL版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInfo.cpp" line="94"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="432"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="450"/>
+            <source>Unknown</source>
+            <translation>未知</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="522"/>
+            <source>Uniq</source>
+            <translation>Uniq</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="526"/>
+            <source>MSC</source>
+            <translation>MSC</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceInput.cpp" line="528"/>
+            <location filename="../src/DeviceManager/DeviceOthers.cpp" line="178"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="626"/>
+            <source>Hardware Class</source>
+            <translation>硬體類別</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+            <source>CPU</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1363"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1391"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1419"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1455"/>
+            <source>No CPU found</source>
+            <translation>未發現處理器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+            <source>Motherboard</source>
+            <translation>主機板</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1364"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1392"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1420"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1456"/>
+            <source>No motherboard found</source>
+            <translation>未發現主機板</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+            <source>Memory</source>
+            <translation>記憶體</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1365"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1393"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1421"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1457"/>
+            <source>No memory found</source>
+            <translation>未發現記憶體</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+            <source>Storage</source>
+            <translation>儲存裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1366"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1394"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1422"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1458"/>
+            <source>No disk found</source>
+            <translation>未發現磁碟</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="635"/>
+            <source>Driver restore failed!</source>
+            <translation>驅動還原失敗！</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/PageDriverManager.cpp" line="631"/>
+            <location filename="../src/Widget/BtnLabel.cpp" line="36"/>
+            <source>Please try again or give us feedback</source>
+            <translation>請重試，或反饋給我們</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/BtnLabel.cpp" line="42"/>
+            <source>Driver backup failed!</source>
+            <translation>驅動備份失敗！</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="682"/>
+            <source>Display Adapter</source>
+            <translation>顯示適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1367"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1395"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1423"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1459"/>
+            <source>No GPU found</source>
+            <translation>未發現GPU</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+            <source>Monitor</source>
+            <translation>顯示裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1368"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1396"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1424"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1460"/>
+            <source>No monitor found</source>
+            <translation>未發現顯示裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="691"/>
+            <source>Network Adapter</source>
+            <translation>網路適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1369"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1397"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1425"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1461"/>
+            <source>No network adapter found</source>
+            <translation>未發現網路適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="685"/>
+            <source>Sound Adapter</source>
+            <translation>音訊適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1370"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1398"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1426"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1462"/>
+            <source>No audio device found</source>
+            <translation>未發現音訊裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+            <location filename="../src/Page/PageDriverManager.cpp" line="688"/>
+            <source>Bluetooth</source>
+            <translation>藍牙</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1371"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1399"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1427"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1463"/>
+            <source>No Bluetooth device found</source>
+            <translation>未發現藍牙裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+            <source>Other PCI Devices</source>
+            <translation>其他PCI裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1372"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1400"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1428"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1464"/>
+            <source>No other PCI devices found</source>
+            <translation>未發現其他PCI裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+            <source>Power</source>
+            <translation>電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1373"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1401"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1429"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1465"/>
+            <source>No battery found</source>
+            <translation>未發現電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+            <location filename="../src/Tool/commontools.cpp" line="39"/>
+            <source>Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1374"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1402"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1430"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1466"/>
+            <source>No keyboard found</source>
+            <translation>未發現鍵盤</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+            <location filename="../src/Tool/commontools.cpp" line="41"/>
+            <source>Mouse</source>
+            <translation>滑鼠</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1375"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1403"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1431"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1467"/>
+            <source>No mouse found</source>
+            <translation>未發現滑鼠</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+            <location filename="../src/Tool/commontools.cpp" line="43"/>
+            <source>Printer</source>
+            <translation>印表機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1376"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1404"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1432"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1468"/>
+            <source>No printer found</source>
+            <translation>未發現印表機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+            <source>Camera</source>
+            <translation>圖像裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1377"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1405"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1433"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1469"/>
+            <source>No camera found</source>
+            <translation>未發現圖像裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+            <source>CD-ROM</source>
+            <translation>光碟機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1378"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1406"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1434"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1470"/>
+            <source>No CD-ROM found</source>
+            <translation>未發現光碟機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
+            <location filename="../src/Tool/commontools.cpp" line="45"/>
+            <location filename="../src/Tool/commontools.cpp" line="47"/>
+            <source>Other Devices</source>
+            <translation>其他裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1379"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1407"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1435"/>
+            <location filename="../src/DeviceManager/DeviceManager.cpp" line="1471"/>
+            <source>No other devices found</source>
+            <translation>未發現其他裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="121"/>
+            <source>Array Handle</source>
+            <translation>數組程序</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="123"/>
+            <source>Form Factor</source>
+            <translation>尺寸型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="124"/>
+            <source>Set</source>
+            <translation>設置</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="125"/>
+            <source>Bank Locator</source>
+            <translation>記憶體通道</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="126"/>
+            <source>Type Detail</source>
+            <translation>類型詳情</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="128"/>
+            <source>Part Number</source>
+            <translation>部件號碼</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="129"/>
+            <source>Rank</source>
+            <translation>位列</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="130"/>
+            <source>Memory Technology</source>
+            <translation>記憶體技術</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="131"/>
+            <source>Memory Operating Mode Capability</source>
+            <translation>記憶體操作模式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="132"/>
+            <source>Firmware Version</source>
+            <translation>韌體版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="133"/>
+            <source>Module Manufacturer ID</source>
+            <translation>元件製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="134"/>
+            <source>Module Product ID</source>
+            <translation>元件產品ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="135"/>
+            <source>Memory Subsystem Controller Manufacturer ID</source>
+            <translation>記憶體子系統控制器製造商</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="136"/>
+            <source>Memory Subsystem Controller Product ID</source>
+            <translation>記憶體子系統控制器產品ID</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="137"/>
+            <source>Non-Volatile Size</source>
+            <translation>不易遺失大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="138"/>
+            <source>Volatile Size</source>
+            <translation>易遺失大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="139"/>
+            <source>Cache Size</source>
+            <translation>快取大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMemory.cpp" line="140"/>
+            <source>Logical Size</source>
+            <translation>邏輯大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="68"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="84"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="99"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="114"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="459"/>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="489"/>
+            <location filename="../src/Tool/EDIDParser.cpp" line="213"/>
+            <source>inch</source>
+            <translation>英寸</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceMonitor.cpp" line="325"/>
+            <source>Date</source>
+            <translation>日期</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="287"/>
+            <source>ioport</source>
+            <translation>IO埠</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceNetwork.cpp" line="288"/>
+            <source>network</source>
+            <translation>網路</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="111"/>
+            <source>battery</source>
+            <translation>電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="149"/>
+            <source>native-path</source>
+            <translation>安裝路徑</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="150"/>
+            <source>power supply</source>
+            <translation>供電</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="151"/>
+            <source>updated</source>
+            <translation>更新時間</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="152"/>
+            <source>has history</source>
+            <translation>歷史記錄</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="153"/>
+            <source>has statistics</source>
+            <translation>用電統計</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="154"/>
+            <source>rechargeable</source>
+            <translation>可再充電</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="155"/>
+            <source>state</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="156"/>
+            <source>warning-level</source>
+            <translation>警告等級</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="157"/>
+            <source>energy</source>
+            <translation>容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="158"/>
+            <source>energy-empty</source>
+            <translation>最低容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="159"/>
+            <source>energy-full</source>
+            <translation>完全充滿容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="160"/>
+            <source>energy-full-design</source>
+            <translation>設計容量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="161"/>
+            <source>energy-rate</source>
+            <translation>能量密度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="162"/>
+            <source>voltage</source>
+            <translation>電壓</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="163"/>
+            <source>percentage</source>
+            <translation>電量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="165"/>
+            <source>technology</source>
+            <translation>電池技術</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="166"/>
+            <source>icon-name</source>
+            <translation>圖示</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="167"/>
+            <source>online</source>
+            <translation>線上</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="168"/>
+            <source>daemon-version</source>
+            <translation>Daemon版本</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="169"/>
+            <source>on-battery</source>
+            <translation>使用電池</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="170"/>
+            <source>lid-is-closed</source>
+            <translation>筆記本合蓋</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="171"/>
+            <source>lid-is-present</source>
+            <translation>打開筆記本蓋子</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePower.cpp" line="172"/>
+            <source>critical-action</source>
+            <translation>電量極低時執行</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="128"/>
+            <source>copies</source>
+            <translation>影印數量</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="129"/>
+            <source>job-cancel-after</source>
+            <translation>此時取消列印任務</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="130"/>
+            <source>job-hold-until</source>
+            <translation>保留列印任務直至</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="131"/>
+            <source>job-priority</source>
+            <translation>任務優先度</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="132"/>
+            <source>marker-change-time</source>
+            <translation>標記修改次數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="133"/>
+            <source>number-up</source>
+            <translation>編號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="134"/>
+            <source>orientation-requested</source>
+            <translation>列印方向</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="135"/>
+            <source>print-color-mode</source>
+            <translation>顏色模式</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="136"/>
+            <source>printer-is-accepting-jobs</source>
+            <translation>當前可列印</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="137"/>
+            <source>printer-is-shared</source>
+            <translation>印表機已共享</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="138"/>
+            <source>printer-is-temporary</source>
+            <translation>臨時印表機</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="163"/>
+            <source>printer-make-and-model</source>
+            <translation>製造商和型號</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="140"/>
+            <source>printer-state-change-time</source>
+            <translation>印表機狀態修改時間</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="141"/>
+            <source>printer-state-reasons</source>
+            <translation>印表機狀態訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="142"/>
+            <source>printer-type</source>
+            <translation>印表機類型</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="143"/>
+            <source>printer-uri-supported</source>
+            <translation>支持的URI</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DevicePrint.cpp" line="144"/>
+            <source>sides</source>
+            <translation>列印面數</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="428"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="446"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="676"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="737"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="753"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="757"/>
+            <source>SSD</source>
+            <translation>固態</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="430"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="448"/>
+            <source>HDD</source>
+            <translation>機械</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="527"/>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="629"/>
+            <source>bus info</source>
+            <translation>匯流排訊息</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="631"/>
+            <source>logicalsectorsize</source>
+            <translation>邏輯分區大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="633"/>
+            <source>sectorsize</source>
+            <translation>扇區大小</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="634"/>
+            <source>guid</source>
+            <translation>全局唯一標識符</translation>
+        </message>
+        <message>
+            <location filename="../src/DeviceManager/DeviceStorage.cpp" line="637"/>
+            <source>Geometry (Logical)</source>
+            <translation>幾何資料（邏輯）</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="93"/>
+            <location filename="../src/main.cpp" line="95"/>
+            <source>Device Manager</source>
+            <translation>裝置管理器</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="96"/>
+            <source>Device Manager is a handy tool for viewing hardware information and managing the devices.</source>
+            <translation>裝置管理器是查看、管理硬體裝置的工具軟體。</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="162"/>
+            <source>New drivers available! Install or update them now.</source>
+            <translation>您有驅動可進行安裝/更新</translation>
+        </message>
+        <message>
+            <location filename="../src/main.cpp" line="163"/>
+            <source>View</source>
+            <translation>查看</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/GetDriverPathWidget.cpp" line="18"/>
+            <source>Include subfolders</source>
+            <translation>包括子資料夾</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/GetDriverPathWidget.cpp" line="64"/>
+            <source>Search for drivers in this path</source>
+            <translation>選擇驅動所在位置</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="107"/>
+            <source>%1 driver updates available</source>
+            <translation>發現%1個驅動可安裝更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="113"/>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="392"/>
+            <source>Time checked: %1</source>
+            <translation>檢測時間: %1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="164"/>
+            <source>Downloading drivers for %1...</source>
+            <translation>正在下載%1驅動…</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="166"/>
+            <source>Download speed: %1 Downloaded %2/%3</source>
+            <translation>下載速度：%1 已完成 %2/%3</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="214"/>
+            <source>Installing drivers for %1...</source>
+            <translation>正在安裝%1驅動…</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="258"/>
+            <source>%1 drivers installed, %2 drivers failed</source>
+            <translation>驅動安裝成功%1個，失敗%2個</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="260"/>
+            <source>%1 drivers installed</source>
+            <translation>共成功安裝%1個驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="302"/>
+            <source>Failed to install drivers</source>
+            <translation>驅動安裝失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="344"/>
+            <source>Network error. Reconnecting...</source>
+            <translation>網路異常，重試中</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="346"/>
+            <source>Download speed: %1</source>
+            <translation>下載速度：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="389"/>
+            <source>Your drivers are up to date</source>
+            <translation>驅動已是最新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="485"/>
+            <source>All drivers have been backed up</source>
+            <translation>驅動已全部備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="487"/>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="529"/>
+            <source>A total of %1 drivers, of which %2 have been backed up</source>
+            <translation>總計%1個驅動，其中%2個已備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="525"/>
+            <source>You have %1 drivers that can be backed up, it is recommended to do so immediately</source>
+            <translation>您有%1個驅動可以備份，建議立即備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="528"/>
+            <source>You have %1 drivers that can be backed up</source>
+            <translation>您有%1個驅動可以備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="573"/>
+            <source>Backing up the %1 driver, a total of %2 drivers</source>
+            <translation>正在備份第%1個驅動，共%2個</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="574"/>
+            <source>Backing up: %1</source>
+            <translation>正在備份：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="612"/>
+            <source>%1 drivers backed up, %2 drivers failed</source>
+            <translation>驅動備份成功%1個，失敗%2個</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="614"/>
+            <source>Failed to backup drivers</source>
+            <translation>備份失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="616"/>
+            <source>%1 drivers backed up</source>
+            <translation>%1個驅動已備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="655"/>
+            <source>You have %1 drivers that can be restored</source>
+            <translation>您有%1個驅動可以還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="656"/>
+            <source>Please select a driver to restore</source>
+            <translation>請選擇驅動還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="686"/>
+            <source>Driver is restoring...</source>
+            <translation>驅動還原中…</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="687"/>
+            <source>Restoring: %1</source>
+            <translation>正在還原：%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="830"/>
+            <source>reboot</source>
+            <translation>重啟電腦</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="831"/>
+            <source>Please %1 for the installed drivers to take effect</source>
+            <translation>驅動已安裝完成，請稍後%1生效</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="839"/>
+            <source>View backup path</source>
+            <translation>檢視備份路徑</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="852"/>
+            <source>Backup All</source>
+            <translation>一鍵備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="834"/>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="296"/>
+            <source>submit feedback</source>
+            <translation>回饋</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="835"/>
+            <source>Please try again or %1 to us</source>
+            <translation>驅動未安裝成功，請重試或%1給我們</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="842"/>
+            <source>Install All</source>
+            <translation>一鍵安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="847"/>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="300"/>
+            <source>Scan Again</source>
+            <translation>重新檢測</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DetectedStatusWidget.cpp" line="857"/>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="74"/>
+            <source>Scanning hardware device drivers, please wait...</source>
+            <translation>正在進行硬體驅動掃描，請耐心等待...</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="82"/>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="369"/>
+            <source>Scanning %1</source>
+            <translation>正在掃描%1</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="140"/>
+            <source>Scan failed</source>
+            <translation>檢測失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="200"/>
+            <source>Network unavailable</source>
+            <translation>無網路</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="204"/>
+            <source>Please check your network connection</source>
+            <translation>請檢查網路連接</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/DriverScanWidget.cpp" line="297"/>
+            <source>Please scan again or %1 to us</source>
+            <translation>請重新檢測或%1給我們</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="689"/>
+            <source>You are installing a driver, which will be interrupted if you exit.</source>
+            <translation>目前正在安裝驅動，退出應用後任務將會中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="690"/>
+            <location filename="../src/Page/MainWindow.cpp" line="703"/>
+            <location filename="../src/Page/MainWindow.cpp" line="716"/>
+            <source>Are you sure you want to exit?</source>
+            <translation>確認是否退出應用？</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="693"/>
+            <location filename="../src/Page/MainWindow.cpp" line="706"/>
+            <location filename="../src/Page/MainWindow.cpp" line="719"/>
+            <source>Exit</source>
+            <translation>退 出</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="694"/>
+            <location filename="../src/Page/MainWindow.cpp" line="707"/>
+            <location filename="../src/Page/MainWindow.cpp" line="720"/>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+            <comment>button</comment>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="702"/>
+            <source>You are backing up drivers, which will be interrupted if you exit.</source>
+            <translation>當前正在備份驅動，退出應用後任務將會中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/Page/MainWindow.cpp" line="715"/>
+            <source>You are restoring drivers, which will be interrupted if you exit.</source>
+            <translation>當前正在還原驅動，退出應用後任務將會中斷</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="36"/>
+            <source>Bluetooth adapter</source>
+            <translation>藍牙適配器</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="37"/>
+            <location filename="../src/Tool/commontools.cpp" line="44"/>
+            <source>Imaging device</source>
+            <translation>圖像裝置</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="38"/>
+            <source>Display adapter</source>
+            <translation>顯示卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="40"/>
+            <source>Sound card</source>
+            <translation>音效卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="42"/>
+            <source>Network adapter</source>
+            <translation>網卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="46"/>
+            <source>Wireless network adapter</source>
+            <translation>無線網卡</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="66"/>
+            <source>Installation successful</source>
+            <translation>安裝成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="67"/>
+            <source>Installation failed</source>
+            <translation>安裝失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="68"/>
+            <source>Downloading</source>
+            <translation>下載中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="69"/>
+            <source>Installing</source>
+            <translation>安裝中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="70"/>
+            <source>Not installed</source>
+            <translation>驅動未安裝</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="71"/>
+            <source>Out-of-date</source>
+            <translation>驅動可更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="72"/>
+            <source>Waiting</source>
+            <translation>等待中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="73"/>
+            <source>Not backed up</source>
+            <translation>驅動未備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="74"/>
+            <source>Backing up</source>
+            <translation>正在備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="75"/>
+            <source>Backup failed</source>
+            <translation>備份失敗</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="76"/>
+            <source>Backup successful</source>
+            <translation>備份成功</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="77"/>
+            <source>Restoring</source>
+            <translation>還原中</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="81"/>
+            <source>Unknown error</source>
+            <translation>未知錯誤</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="82"/>
+            <source>Network error</source>
+            <translation>網路異常</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="83"/>
+            <source>Canceled</source>
+            <translation>已取消</translation>
+        </message>
+        <message>
+            <location filename="../src/Tool/commontools.cpp" line="84"/>
+            <source>Failed to get driver files</source>
+            <translation>驅動文件獲取異常</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="249"/>
+            <source>Update</source>
+            <translation>更新</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="254"/>
+            <source>Backup</source>
+            <translation>備份</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="259"/>
+            <source>Restore</source>
+            <translation>還原</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/driveritem.cpp" line="245"/>
+            <source>Install</source>
+            <translation>安装</translation>
+        </message>
+        <message>
+            <location filename="../tests/src/DeviceManager/ut_devicemanager.cpp" line="89"/>
+            <source>Overview</source>
+            <translation>概況</translation>
+        </message>
+    </context>
+    <context>
+        <name>TableWidget</name>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="38"/>
+            <location filename="../src/Widget/TableWidget.cpp" line="212"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="39"/>
+            <source>Refresh</source>
+            <translation>重新整理</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="40"/>
+            <source>Export</source>
+            <translation>匯出</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="41"/>
+            <source>Update drivers</source>
+            <translation>更新驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="42"/>
+            <source>Uninstall drivers</source>
+            <translation>移除驅動</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="43"/>
+            <source>Allow it to wake the computer</source>
+            <translation>允許喚起電腦</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TableWidget.cpp" line="217"/>
+            <location filename="../src/Widget/TableWidget.cpp" line="323"/>
+            <location filename="../src/Widget/TableWidget.cpp" line="330"/>
+            <source>Enable</source>
+            <translation>啟用</translation>
+        </message>
+    </context>
+    <context>
+        <name>TextBrowser</name>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="33"/>
+            <source>Refresh</source>
+            <translation>重新整理</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="34"/>
+            <source>Export</source>
+            <translation>匯出</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="35"/>
+            <source>Copy</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="255"/>
+            <source>Disable</source>
+            <translation>禁用</translation>
+        </message>
+        <message>
+            <location filename="../src/Widget/TextBrowser.cpp" line="263"/>
+            <source>Unavailable</source>
+            <translation>不可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>UrlChooserEdit</name>
+        <message>
+            <location filename="../src/Widget/UrlChooserEdit.cpp" line="94"/>
+            <source>Select a local folder please</source>
+            <translation>請選擇本機資料夾</translation>
+        </message>
+    </context>
+    <context>
+        <name>WaitingWidget</name>
+        <message>
+            <location filename="../src/Page/WaitingWidget.cpp" line="23"/>
+            <source>Loading...</source>
+            <translation>正在載入...</translation>
+        </message>
+    </context>
 </TS>


### PR DESCRIPTION
Modify AI translations

Log: Modify AI translations

## Summary by Sourcery

Refresh and refine the Traditional Chinese (zh_HK) translation file by reorganizing its structure and standardizing UI strings.

Chores:
- Update TS header to include UTF-8 encoding and adjust file version and structure.
- Populate previously unfinished translations across various contexts (e.g., “Feedback”, “More”, “Collapse”).
- Standardize and refine existing Traditional Chinese translations for consistency in button labels, warnings, and driver management texts.